### PR TITLE
Allow all origins for CORS in backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ci-test: ## Run unit tests in CI
 .PHONY: backend-docker-start
 backend-docker-start:	## Starts a Docker-based backend for development
 	@echo "$(GREEN)==> Start Docker-based Plone Backend$(RESET)"
-	docker run -it --rm --name=backend -p 8080:8080 -e SITE=Plone $(DOCKER_IMAGE)
+	docker run -it --rm --name=backend -p 8080:8080 -e SITE=Plone -e CORS_ALLOW_ORIGIN='*' $(DOCKER_IMAGE)
 
 ## Storybook
 .PHONY: storybook-start


### PR DESCRIPTION
CORS is adding friction to developing locally, without actually adding any benefit as the `backend-docker-start` command shouldn't be used outside of a dev environment.

This PR adjusts the Makefile to allow all origins out-the-box.