### PR TITLE
Added the ability to use the image block URL field from the sidebar

### DIFF
--- a/packages/volto-hydra/src/index.js
+++ b/packages/volto-hydra/src/index.js
@@ -1,7 +1,40 @@
 import selectedBlock from './reducers';
 
 const applyConfig = (config) => {
+  // Add the selectedBlock reducer
   config.addonReducers.selectedBlock = selectedBlock;
+
+  // Add the slate block in the sidebar
+  config.blocks.blocksConfig.slate.schemaEnhancer = ({
+    formData,
+    schema,
+    intl,
+  }) => {
+    schema.properties.value = {
+      title: 'Body',
+      widget: 'slate',
+    };
+    schema.fieldsets[0].fields.push('value');
+    return schema;
+  };
+
+  // Set the sidebarTab to 1
+  config.blocks.blocksConfig.slate.sidebarTab = 1;
+
+  // Add image from sidebar
+  config.blocks.blocksConfig.image.schemaEnhancer = ({
+    formData,
+    schema,
+    intl,
+  }) => {
+    schema.properties.url = {
+      title: 'Image Src',
+      widget: 'image',
+    };
+    schema.fieldsets[0].fields.push('url');
+    return schema;
+  };
+
   return config;
 };
 


### PR DESCRIPTION
Blocked by #75

Fixes #22 
Fixes #19 

@JeffersonBledsoe I added `widget: image` as you said but it is giving me a input field only (pasting there a url works) not like the you shown in discord. Do i need to use `widget:object_browser` for that? but using that breaks the site. 