### PR TITLE
Fix postMessage origin error in produciton 

### DIFF
--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -211,10 +211,9 @@ const Iframe = (props) => {
   useEffect(() => {
     if (form && Object.keys(form).length > 0 && isValidUrl(src)) {
       // Send the form data to the iframe
-      const origin = new URL(src).origin;
       document
         .getElementById('previewIframe')
-        .contentWindow.postMessage({ type: 'FORM', data: form }, origin);
+        .contentWindow.postMessage({ type: 'FORM', data: form }, '*');
     }
   }, [form, initialUrl, src]);
 


### PR DESCRIPTION
Currently we are getting origin mismatch error in production. To resolve it, using wild card entry ie "*" for now. 