### PR TITLE
restrict all block types  except text & image on add

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,19 @@ export default function Blog({ params }) {
   ```js
   // In Layout.js or App.js
   import { initBridge } from './hydra.js';
-  initBridge("https://hydra.pretagov.com");
+  const bridge = initBridge("https://hydra.pretagov.com");
   ```
 - This will enable the 2 way link between hydra and your frontend.
 - Log into https://hydra.pretagov.com/ (or your test hydra), go to ```User Preferences``` and paste in your local running frontend to test.
    - You can also add this url to the env ```RAZZLE_DEFAULT_IFRAME_URL``` on your hydra instance to have this frontend selectable by the user. 
+
+**Note:** You can also pass an options object while initializing the bridge. Currently you can pass a List of allowed blocks (by default image & text blocks are allowed if not specified).
+E.g. :
+  ```js
+  // In Layout.js or App.js
+  import { initBridge } from './hydra.js';
+  const bridge = initBridge("https://hydra.pretagov.com", {allowedBlocks: ['slate', 'image', 'video']});
+  ```
 
 #### Asynchronously Load the Bridge
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@plone/client": "1.0.0-alpha.16",
     "@plone/registry": "workspace:*",
     "@plone/volto": "workspace:*",
+    "events": "^3.3.0",
     "js-cookie": "^3.0.5",
     "volto-hydra": "workspace:*"
   },

--- a/packages/hydra-js/hydra.js
+++ b/packages/hydra-js/hydra.js
@@ -1,6 +1,11 @@
 /** Bridge class creating two-way link between the Hydra and the frontend **/
 class Bridge {
-  constructor(adminOrigin) {
+  /**
+   *
+   * @param {URL} adminOrigin - The origin of the adminUI
+   * @param {Object} options - Options for the bridge initialization -- allowedBlocks: Array of allowed block types e.g. ['title', 'text', 'image', ...]
+   */
+  constructor(adminOrigin, options = {}) {
     this.adminOrigin = adminOrigin;
     this.token = null;
     this.navigationHandler = null; // Handler for navigation events
@@ -13,10 +18,10 @@ class Bridge {
     this.quantaToolbar = null;
     this.currentPathname =
       typeof window !== 'undefined' ? window.location.pathname : null;
-    this.init();
+    this.init(options);
   }
 
-  init() {
+  init(options = {}) {
     if (typeof window === 'undefined') {
       return;
     }
@@ -48,6 +53,15 @@ class Bridge {
       if (access_token) {
         this.token = access_token;
         this._setTokenCookie(access_token);
+      }
+
+      if (options) {
+        if (options.allowedBlocks) {
+          window.parent.postMessage(
+            { type: 'ALLOWED_BLOCKS', allowedBlocks: options.allowedBlocks },
+            this.adminOrigin,
+          );
+        }
       }
 
       if (isEditMode) {
@@ -403,12 +417,13 @@ let bridgeInstance = null;
 /**
  * Initialize the bridge
  *
- * @param {*} adminOrigin
+ * @param {URL} adminOrigin
+ * @param {Object} options
  * @returns new Bridge()
  */
-export function initBridge(adminOrigin) {
+export function initBridge(adminOrigin, options = {}) {
   if (!bridgeInstance) {
-    bridgeInstance = new Bridge(adminOrigin);
+    bridgeInstance = new Bridge(adminOrigin, options);
   }
   return bridgeInstance;
 }

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -63,7 +63,7 @@ const Iframe = (props) => {
       {
         name: 'offset',
         options: {
-          offset: [0, -350],
+          offset: [550, -300],
         },
       },
       {

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -19,6 +19,10 @@ import { usePopper } from 'react-popper';
 import { useSelector, useDispatch } from 'react-redux';
 import { getURlsFromEnv } from '../../utils/getSavedURLs';
 import { setSidebarTab } from '@plone/volto/actions';
+import {
+  getAllowedBlocksList,
+  setAllowedBlocksList,
+} from '../../utils/allowedBlockList';
 
 /**
  * Format the URL for the Iframe with location, token and edit mode
@@ -186,6 +190,15 @@ const Iframe = (props) => {
 
         case 'DELETE_BLOCK':
           onDeleteBlock(event.data.uid, true);
+          break;
+
+        case 'ALLOWED_BLOCKS':
+          if (
+            JSON.stringify(getAllowedBlocksList()) !==
+            JSON.stringify(event.data.allowedBlocks)
+          ) {
+            setAllowedBlocksList(event.data.allowedBlocks);
+          }
           break;
 
         default:

--- a/packages/volto-hydra/src/index.js
+++ b/packages/volto-hydra/src/index.js
@@ -17,8 +17,12 @@ const applyConfig = (config) => {
     schema.fieldsets[0].fields.push('value');
     return schema;
   };
-  // Set the sidebarTab to 1
-  config.blocks.blocksConfig.slate.sidebarTab = 1;
+  // Set the sidebarTab to 1 & set most used to true
+  config.blocks.blocksConfig.slate = {
+    ...config.blocks.blocksConfig.slate,
+    sidebarTab: 1,
+    mostUsed: true,
+  };
 
   // Add image from sidebar
   config.blocks.blocksConfig.image.schemaEnhancer = ({
@@ -33,6 +37,13 @@ const applyConfig = (config) => {
     schema.fieldsets[0].fields.push('url');
     return schema;
   };
+
+  // Remove Blocks except for slate and image
+  for (const key in config.blocks.blocksConfig) {
+    if (key !== 'slate' && key !== 'image') {
+      config.blocks.blocksConfig[key].restricted = true;
+    }
+  }
 
   return config;
 };

--- a/packages/volto-hydra/src/index.js
+++ b/packages/volto-hydra/src/index.js
@@ -1,4 +1,8 @@
 import frontendPreviewUrl from './reducers';
+import {
+  getAllowedBlocksList,
+  subscribeToAllowedBlocksListChanges,
+} from './utils/allowedBlockList';
 
 const applyConfig = (config) => {
   // Add the frontendPreviwUrl reducer
@@ -38,12 +42,22 @@ const applyConfig = (config) => {
     return schema;
   };
 
-  // Remove Blocks except for slate and image
-  for (const key in config.blocks.blocksConfig) {
-    if (key !== 'slate' && key !== 'image') {
-      config.blocks.blocksConfig[key].restricted = true;
+  const updateAllowedBlocks = () => {
+    const allowedBlocksList = getAllowedBlocksList();
+    const defaultAllowedBlocks = ['slate', 'image'];
+
+    for (const key in config.blocks.blocksConfig) {
+      config.blocks.blocksConfig[key].restricted =
+        allowedBlocksList && allowedBlocksList.length > 0
+          ? !allowedBlocksList.includes(key)
+          : !defaultAllowedBlocks.includes(key);
     }
-  }
+  };
+  // Subscribe to changes in the allowed blocks list
+  subscribeToAllowedBlocksListChanges(updateAllowedBlocks);
+
+  // Initial call to set the blocks based on the initial state
+  updateAllowedBlocks();
 
   return config;
 };

--- a/packages/volto-hydra/src/utils/allowedBlockList.js
+++ b/packages/volto-hydra/src/utils/allowedBlockList.js
@@ -1,0 +1,27 @@
+import EventEmitter from 'events';
+
+let allowedBlocksList = [];
+const eventEmitter = new EventEmitter();
+/**
+ * Get the allowed blocks list
+ * @returns {Array} Allowed blocks list.
+ */
+export const getAllowedBlocksList = () => allowedBlocksList;
+
+/**
+ * Set the allowed blocks list & emit an event to notify subscribers
+ * @param {Array} newAllowedBlocks New allowed blocks list.
+ */
+export const setAllowedBlocksList = (newAllowedBlocks) => {
+  allowedBlocksList = newAllowedBlocks;
+  eventEmitter.emit('allowedBlocksListChanged', newAllowedBlocks);
+};
+
+// Subscribe to changes in the allowed blocks list
+export const subscribeToAllowedBlocksListChanges = (callback) => {
+  eventEmitter.on('allowedBlocksListChanged', callback);
+};
+
+export const unsubscribeFromAllowedBlocksListChanges = (callback) => {
+  eventEmitter.off('allowedBlocksListChanged', callback);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@plone/volto':
         specifier: workspace:*
         version: link:core/packages/volto
+      events:
+        specifier: ^3.3.0
+        version: 3.3.0
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5


### PR DESCRIPTION
Fixes #70 

Since, we only support image & text blocks, so restricting every other block type.