### PR TITLE
fix routing if its done with changing the hash

### DIFF
--- a/packages/hydra-js/hydra.js
+++ b/packages/hydra-js/hydra.js
@@ -36,14 +36,21 @@ class Bridge {
         const newUrl = new URL(e.destination.url);
         if (
           this.currentUrl === null ||
+          newUrl.hash !== this.currentUrl.hash ||
           (this.currentUrl.pathname !== newUrl.pathname &&
             this.currentUrl.origin === newUrl.origin)
         ) {
-          this.currentUrl = newUrl;
           window.parent.postMessage(
-            { type: 'URL_CHANGE', url: e.destination.url },
+            {
+              type: 'URL_CHANGE',
+              url: newUrl.href,
+              isRoutingWithHash:
+                newUrl.hash !== this.currentUrl?.hash &&
+                newUrl.hash.startsWith('#!'),
+            },
             this.adminOrigin,
           );
+          this.currentUrl = newUrl;
         } else if (
           this.currentUrl !== null &&
           this.currentUrl.origin !== newUrl.origin

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -135,18 +135,26 @@ const Iframe = (props) => {
     onChangeFormData(newFormData);
   };
   //---------------------------
-
+  /**
+   * Handle the navigation to a new URL
+   * @param {URL} givenUrlObject
+   * @param {Boolean} isRoutingWithHash
+   */
   const handleNavigateToUrl = useCallback(
-    (givenUrl = null) => {
-      if (!isValidUrl(givenUrl)) {
+    (givenUrlObject, isRoutingWithHash) => {
+      if (!isValidUrl(givenUrlObject.href)) {
         return;
       }
       // Update adminUI URL with the new URL
-      const formattedUrl = new URL(givenUrl);
-      const newOrigin = formattedUrl.origin;
+      const newOrigin = givenUrlObject.origin;
       Cookies.set('iframe_url', newOrigin, { expires: 7 });
-
-      history.push(`${formattedUrl.pathname}`);
+      const hash = givenUrlObject.hash;
+      if (isRoutingWithHash) {
+        const pathname = hash.replace('#!', '');
+        history.push(`${pathname}`);
+      } else {
+        history.push(`${givenUrlObject.pathname}`);
+      }
     },
     [history],
   );
@@ -176,7 +184,10 @@ const Iframe = (props) => {
       const { type } = event.data;
       switch (type) {
         case 'URL_CHANGE': // URL change from the iframe
-          handleNavigateToUrl(event.data.url);
+          handleNavigateToUrl(
+            new URL(event.data.url),
+            event.data.isRoutingWithHash,
+          );
           break;
 
         case 'OPEN_SETTINGS':


### PR DESCRIPTION
Bug : if navigation is done through changing the hash of the url then adminUI does not detect this. (eg. Vue example)
Fix : now hydrajs keeps track if the path is getting changed by pathname or hash and sends the signal to adminUI to change the path accordingly