### PR TITLE
Inline link formatting

### DIFF
--- a/examples/hydra-nextjs/src/components/BlocksList/BlocksList.js
+++ b/examples/hydra-nextjs/src/components/BlocksList/BlocksList.js
@@ -8,9 +8,16 @@ const BlocksList = ({ data }) => {
       {data.blocks_layout.items.map((id) => {
         if (data.blocks[id]['@type'] === 'slate') {
           const slateValue = data.blocks[id].value;
+
           return (
             <li key={id} className="blog-list-item" data-block-uid={`${id}`}>
-              <SlateBlock value={slateValue} />
+              <SlateBlock
+                value={
+                  slateValue || [
+                    { nodeId: 1, type: 'p', children: [{ text: '&nbsp;' }] },
+                  ]
+                }
+              />
             </li>
           );
         } else if (data.blocks[id]['@type'] === 'image') {
@@ -52,10 +59,14 @@ const BlocksList = ({ data }) => {
                 {teaserHeadTitle && (
                   <h3 className="teaser-head-title">{teaserHeadTitle}</h3>
                 )}
-                {teaserTitle && <h2 className="teaser-title">{teaserTitle}</h2>}
+                {teaserTitle && (
+                  <h2 className="teaser-title" data-editable-field="title">
+                    {teaserTitle}
+                  </h2>
+                )}
                 {teaserDescription && (
                   <p
-                    data-editable-field="teaser"
+                    data-editable-field="description"
                     className="teaser-description"
                   >
                     {teaserDescription}

--- a/examples/hydra-vue-f7/src/components/richtext.vue
+++ b/examples/hydra-vue-f7/src/components/richtext.vue
@@ -1,22 +1,33 @@
 <template>
-    <f7-link v-if="node.type =='link'" :href="node.data.url" external :data-node-id="node['nodeId']">{{ node.text }}<RichText v-for="child in subs" :key="child" :node="child"/></f7-link>
-    <template v-else-if="!node.type">{{ node.text }}</template>
-    <component v-else :is="node.type" :data-node-id="node['nodeId']">{{ node.text }}<RichText v-for="child in subs" :key="child" :node="child"/></component>
+  <template v-if="node.type === 'link'">
+    <f7-link :href="node.data.url" external :data-node-id="node.nodeId">
+      {{ node.text }}
+      <RichText v-for="child in subs" :key="child.nodeId" :node="child" />
+    </f7-link>
+  </template>
+  <span v-else-if="!node.type" :data-node-id="node.nodeId">
+    {{ node.text }}
+  </span>
+  <component v-else :is="node.type" :data-node-id="node.nodeId">
+    {{ node.text }}
+    <RichText v-for="child in subs" :key="child.nodeId" :node="child" />
+  </component>
 </template>
+
 <script>
 export default {
   name: 'RichText',
   props: {
     node: {
       type: Object,
-      required: true
-    }
+      required: true,
+    },
   },
   computed: {
     subs() {
-      const { children } = this.node
-      return children && children || []
-    }
-  }
-}
+      const { children } = this.node;
+      return (children && children) || [];
+    },
+  },
+};
 </script>

--- a/packages/hydra-js/hydra.js
+++ b/packages/hydra-js/hydra.js
@@ -23,8 +23,6 @@ class Bridge {
     this.blockTextMutationObserver = null;
     this.attributeMutationObserver = null;
     this.selectedBlockUid = null;
-    this.handleBlockFocusIn = null;
-    this.handleBlockFocusOut = null;
     this.isInlineEditing = false;
     this.handleMouseUp = null;
     this.blockObserver = null;
@@ -141,12 +139,72 @@ class Bridge {
       ) {
         if (event.data.type === 'FORM_DATA') {
           if (event.data.data) {
+            this.isInlineEditing = false;
             this.formData = JSON.parse(JSON.stringify(event.data.data));
+            console.log(
+              'data recieved from adminUI',
+              this.formData.blocks[this.selectedBlockUid],
+            );
+
+            // Call the callback first to trigger the re-render
             callback(event.data.data);
+
+            // After the re-render, add the toolbar (if needed)
+            setTimeout(() => {
+              if (this.selectedBlockUid) {
+                // Check if a block is selected
+                const blockElement = document.querySelector(
+                  `[data-block-uid="${this.selectedBlockUid}"]`,
+                );
+                if (
+                  blockElement &&
+                  !blockElement.contains(this.quantaToolbar)
+                ) {
+                  console.log(
+                    'is toolbar inside block already',
+                    blockElement.contains(this.quantaToolbar),
+                  );
+                  // Add border to the currently selected block
+                  blockElement.classList.add('volto-hydra--outline');
+                  let show = { formatBtns: false };
+                  if (
+                    this.formData &&
+                    this.formData.blocks[this.selectedBlockUid] &&
+                    this.formData.blocks[this.selectedBlockUid]['@type'] ===
+                      'slate'
+                  ) {
+                    show.formatBtns = true;
+                  }
+                  if (this.currentlySelectedBlock) {
+                    this.deselectBlock(
+                      this.currentlySelectedBlock,
+                      blockElement,
+                    );
+                  }
+                  this.createQuantaToolbar(this.selectedBlockUid, show);
+                  this.observeBlockTextChanges(blockElement);
+                  const editableField = blockElement.getAttribute(
+                    'data-editable-field',
+                  );
+                  if (editableField === 'value') {
+                    this.makeBlockContentEditable(blockElement);
+                  } else if (editableField !== null) {
+                    blockElement.setAttribute('contenteditable', 'true');
+                  }
+                  const editableChildren = blockElement.querySelectorAll(
+                    '[data-editable-field]',
+                  );
+                  editableChildren.forEach((child) => {
+                    child.setAttribute('contenteditable', 'true');
+                  });
+                }
+              }
+            }, 0); // Use setTimeout to ensure execution after the current call stack
           } else {
             throw new Error('No form data has been sent from the adminUI');
           }
         } else if (event.data.type === 'TOGGLE_MARK_DONE') {
+          console.log('toggle mark data rec');
           this.formData = JSON.parse(JSON.stringify(event.data.data));
           callback(event.data.data);
         }
@@ -172,6 +230,7 @@ class Bridge {
    */
   enableBlockClickListener() {
     this.blockClickHandler = (event) => {
+      event.stopPropagation();
       const blockElement = event.target.closest('[data-block-uid]');
       if (blockElement) {
         this.selectBlock(blockElement);
@@ -187,7 +246,9 @@ class Bridge {
     if (this.quantaToolbar) {
       return;
     }
-
+    const blockElement = document.querySelector(
+      `[data-block-uid="${blockUid}"]`,
+    );
     // Create the quantaToolbar
     this.quantaToolbar = document.createElement('div');
     this.quantaToolbar.className = 'volto-hydra-quantaToolbar';
@@ -207,7 +268,7 @@ class Bridge {
         this.adminOrigin,
       );
     };
-    this.currentlySelectedBlock.appendChild(this.addButton);
+    blockElement.appendChild(this.addButton);
 
     // Create the drag button
     const dragButton = document.createElement('button');
@@ -220,12 +281,12 @@ class Bridge {
       e.preventDefault();
       document.querySelector('body').classList.add('grabbing');
       // Create a copy of the block
-      const draggedBlock = this.currentlySelectedBlock.cloneNode(true);
+      const draggedBlock = blockElement.cloneNode(true);
       draggedBlock.classList.add('dragging');
       document.body.appendChild(draggedBlock);
 
       // Position the copy under the cursor
-      const rect = this.currentlySelectedBlock.getBoundingClientRect();
+      const rect = blockElement.getBoundingClientRect();
       draggedBlock.style.width = `${rect.width}px`;
       draggedBlock.style.height = `${rect.height}px`;
       draggedBlock.style.left = `${e.clientX}px`;
@@ -329,8 +390,7 @@ class Bridge {
         clearTimeout(startYTimeout);
         draggedBlock.remove();
         if (closestBlockUid) {
-          const draggedBlockId =
-            this.currentlySelectedBlock.getAttribute('data-block-uid');
+          const draggedBlockId = blockElement.getAttribute('data-block-uid');
 
           const blocks_layout = this.formData.blocks_layout.items;
           const draggedBlockIndex = blocks_layout.indexOf(draggedBlockId);
@@ -490,10 +550,7 @@ class Bridge {
           handleSelectionChange();
         }
       };
-      this.currentlySelectedBlock.addEventListener(
-        'mouseup',
-        this.handleMouseUp,
-      );
+      blockElement.addEventListener('mouseup', this.handleMouseUp);
     }
 
     // Create the three-dot menu button
@@ -549,7 +606,7 @@ class Bridge {
     this.quantaToolbar.appendChild(dropdownMenu);
 
     // Append the quantaToolbar to the currently selected block
-    this.currentlySelectedBlock.appendChild(this.quantaToolbar);
+    blockElement.appendChild(this.quantaToolbar);
   }
 
   /**
@@ -558,6 +615,7 @@ class Bridge {
    */
   selectBlock(blockElement) {
     if (!blockElement) return;
+    this.isInlineEditing = true;
     // Remove border and button from the previously selected block
     if (this.currentlySelectedBlock) {
       this.deselectBlock(this.currentlySelectedBlock, blockElement);
@@ -566,23 +624,6 @@ class Bridge {
       this.currentlySelectedBlock === null ||
       this.currentlySelectedBlock !== blockElement
     ) {
-      this.isInlineEditing = true;
-      this.handleBlockFocusOut = (e) => {
-        // console.log("focus out");
-        window.parent.postMessage(
-          { type: 'INLINE_EDIT_EXIT' },
-          this.adminOrigin,
-        );
-        this.isInlineEditing = false;
-      };
-      this.handleBlockFocusIn = (e) => {
-        this.isInlineEditing = true;
-      };
-      // Add focus in event listener
-      blockElement.addEventListener('focusout', this.handleBlockFocusOut);
-
-      blockElement.addEventListener('focusin', this.handleBlockFocusIn);
-
       // Helper function to handle each element
       const handleElement = (element) => {
         const editableField = element.getAttribute('data-editable-field');
@@ -603,6 +644,8 @@ class Bridge {
 
       const blockUid = blockElement.getAttribute('data-block-uid');
       this.selectedBlockUid = blockUid;
+      // Set the currently selected block
+      this.currentlySelectedBlock = blockElement;
 
       let show = { formatBtns: false };
       // if the block is a slate block, add nodeIds to the block's data
@@ -619,23 +662,24 @@ class Bridge {
           window.location.origin,
         );
         window.parent.postMessage(
-          { type: 'INLINE_EDIT_DATA', data: this.formData },
+          {
+            type: 'INLINE_EDIT_DATA',
+            data: this.formData,
+            from: 'selectBlock',
+          },
           this.adminOrigin,
         );
-        window.parent.postMessage(
-          { type: 'INLINE_EDIT_EXIT' },
-          this.adminOrigin,
-        );
+      } else {
+        // Add border to the currently selected block
+        this.currentlySelectedBlock.classList.add('volto-hydra--outline');
+        this.createQuantaToolbar(this.selectedBlockUid, show);
+        console.log('added toolbar on non slate');
       }
       handleElementAndChildren(blockElement);
-      // Set the currently selected block
-      this.currentlySelectedBlock = blockElement;
-      // Add border to the currently selected block
-      this.currentlySelectedBlock.classList.add('volto-hydra--outline');
 
-      if (this.formData) {
-        this.createQuantaToolbar(blockUid, show);
-      }
+      // if (this.formData) {
+      //   this.createQuantaToolbar(blockUid, show);
+      // }
 
       if (!this.clickOnBtn) {
         window.parent.postMessage(
@@ -664,6 +708,23 @@ class Bridge {
         event.data.type === 'SELECT_BLOCK'
       ) {
         const { uid } = event.data;
+        this.selectedBlockUid = uid;
+        this.formData = JSON.parse(JSON.stringify(event.data.data));
+        if (
+          this.selectedBlockUid &&
+          this.formData.blocks[this.selectedBlockUid]['@type'] === 'slate' &&
+          typeof this.formData.blocks[this.selectedBlockUid].nodeId ===
+            'undefined'
+        ) {
+          this.formData.blocks[this.selectedBlockUid] = this.addNodeIds(
+            this.formData.blocks[this.selectedBlockUid],
+          );
+          window.postMessage(
+            { type: 'FORM_DATA', data: this.formData },
+            window.location.origin,
+          );
+        }
+        this.isInlineEditing = true;
         this.observeForBlock(uid);
       }
     };
@@ -700,8 +761,10 @@ class Bridge {
             `[data-block-uid="${uid}"]`,
           );
 
-          if (blockElement) {
+          if (blockElement && this.isInlineEditing) {
             this.selectBlock(blockElement);
+            console.log('oberveeeeeeeee');
+
             !this.elementIsVisibleInViewport(blockElement, true) &&
               blockElement.scrollIntoView({ behavior: 'smooth' });
             observer.disconnect();
@@ -767,10 +830,13 @@ class Bridge {
    */
   deselectBlock(prevBlockElement, currBlockElement) {
     const currBlockUid = currBlockElement?.getAttribute('data-block-uid');
+    const prevBlockUid = prevBlockElement?.getAttribute('data-block-uid');
+    console.log('delesecet', prevBlockElement);
+
     if (
-      this.selectedBlockUid !== null &&
+      prevBlockUid !== null &&
       currBlockUid &&
-      this.selectedBlockUid !== currBlockUid
+      prevBlockUid !== currBlockUid
     ) {
       this.currentlySelectedBlock.classList.remove('volto-hydra--outline');
       if (this.blockObserver) {
@@ -797,14 +863,6 @@ class Bridge {
 
       // Clean up JSON structure
       // if (this.formData.blocks[this.selectedBlockUid]["@type"] === "slate") this.resetJsonNodeIds(this.formData.blocks[this.selectedBlockUid]);
-
-      // Remove focus out event listener
-      prevBlockElement.removeEventListener(
-        'focusout',
-        this.handleBlockFocusOut,
-      );
-      // Remove focus in event listener
-      prevBlockElement.removeEventListener('focusin', this.handleBlockFocusIn);
     }
     document.removeEventListener('mouseup', this.handleMouseUp);
     // Disconnect the mutation observer

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -103,15 +103,16 @@ const Iframe = (props) => {
     const origin = iframeSrc && new URL(iframeSrc).origin;
     console.log('selectedBlock', selectedBlock);
 
-    document.getElementById('previewIframe').contentWindow.postMessage(
-      {
-        type: 'SELECT_BLOCK',
-        uid: selectedBlock,
-        method: 'select',
-        data: form,
-      },
-      origin,
-    );
+    !isInlineEditingRef.current &&
+      document.getElementById('previewIframe').contentWindow.postMessage(
+        {
+          type: 'SELECT_BLOCK',
+          uid: selectedBlock,
+          method: 'select',
+          data: form,
+        },
+        origin,
+      );
   }, [selectedBlock]);
   //-------------------------
 
@@ -136,7 +137,7 @@ const Iframe = (props) => {
     if (value?.['@type'] === 'slate') {
       value = {
         ...value,
-        value: [{ type: 'p', children: [{ text: '' }] }],
+        value: [{ type: 'p', children: [{ text: '', nodeId: 2 }], nodeId: 1 }],
       };
     }
     const [newId, newFormData] = insertBlock(
@@ -171,10 +172,9 @@ const Iframe = (props) => {
     const onDeleteBlock = (id, selectPrev) => {
       const previous = previousBlockId(properties, id);
       const newFormData = deleteBlock(properties, id);
+      isInlineEditingRef.current = false;
       onChangeFormData(newFormData);
-
       onSelectBlock(selectPrev ? previous : null);
-      onSelectBlock(previous);
       setAddNewBlockOpened(false);
       dispatch(setSidebarTab(1));
     };
@@ -331,23 +331,24 @@ const Iframe = (props) => {
   const sidebarFocusEventListenerRef = useRef(null);
 
   useEffect(() => {
-    const handleFocus = (event) => {
+    const handleMouseHover = (e) => {
+      e.stopPropagation();
       isInlineEditingRef.current = false;
       // console.log(
       //   'Sidebar or its child element focused!',
       //   isInlineEditingRef.current,
       // );
     };
-    sidebarFocusEventListenerRef.current = handleFocus;
+    sidebarFocusEventListenerRef.current = handleMouseHover;
     const sidebarElement = document.getElementById('sidebar');
-    sidebarElement.addEventListener('focus', handleFocus, true);
+    sidebarElement.addEventListener('mouseover', handleMouseHover, true);
 
     // Cleanup on component unmount
     return () => {
       // ... (your other cleanup code)
       if (sidebarElement && sidebarFocusEventListenerRef.current) {
         sidebarElement.removeEventListener(
-          'focus',
+          'mouseover',
           sidebarFocusEventListenerRef.current,
           true,
         );

--- a/packages/volto-hydra/src/utils/toggleMark.js
+++ b/packages/volto-hydra/src/utils/toggleMark.js
@@ -2,7 +2,7 @@ import { jsx } from 'slate-hyperscript';
 import addNodeIds from './addNodeIds';
 
 const deserialize = (el, markAttributes = {}) => {
-  if (el.nodeType === Node.TEXT_NODE) {
+  if (el.nodeType === Node.TEXT_NODE && !!el.textContent.trim()) {
     return jsx('text', markAttributes, el.textContent);
   } else if (el.nodeType !== Node.ELEMENT_NODE) {
     return null;

--- a/packages/volto-hydra/src/utils/toggleMark.js
+++ b/packages/volto-hydra/src/utils/toggleMark.js
@@ -10,22 +10,8 @@ const deserialize = (el, markAttributes = {}) => {
 
   const nodeAttributes = { ...markAttributes };
 
-  // define attributes for text nodes
-  // (Lets try handling this after the recursive call because slate is throwing an error when we pass this json)
-  // switch (el.nodeName) {
-  //   case 'STRONG':
-  //     nodeAttributes.type = 'strong';
-  //     break;
-  //   default:
-  //     break;
-  // }
-
   const children = Array.from(el.childNodes)
     .map((node) => {
-      // Add data-slate-node attribute if missing
-      if (node.nodeType === Node.ELEMENT_NODE && !node.dataset.slateNode) {
-        node.dataset.slateNode = 'element'; // Or 'text' if it's a text node
-      }
       return deserialize(node, nodeAttributes);
     })
     .flat();

--- a/packages/volto-hydra/src/utils/toggleMark.js
+++ b/packages/volto-hydra/src/utils/toggleMark.js
@@ -53,7 +53,7 @@ const deserialize = (el, markAttributes = {}) => {
     case 'A':
       return jsx(
         'element',
-        { type: 'link', url: el.getAttribute('href') },
+        { type: 'link', data: { url: el.getAttribute('href') } },
         children,
       );
     case 'STRONG': // Handle <strong> elements explicitly


### PR DESCRIPTION
Fixes #35 

This PR should :

- [x] convert selected text node (only) into link with typed in url (no object browser support needed) and synchronize admniUi
- [x] convert multiple selected nodes (selection might contain non-text nodes like `<b>, <em>` etc.) into link
- [ ] clicking on folder icon on the left side on input field should open up sidebar to choose the link
- [x] UI should match quanta (as much as possible) 


### Toolbar fix
This PR also includes some fixes for the below edge cases:
The toolbar is added before the frontend re-renders, causing it to disappear. The solution is to add the toolbar after the re-render using a timeout, but this introduces a slight visual delay

what is happening is that 

- after clicking on a block 'selectBlock' is called and then this do all the other stuff, then it adds nodeIds in the json data (if text block with richtext enable) and then
- it sends this to both adminUI (parent) and also itself (window) and as you can see in the code we got onEditChange which takes a callback as an args and calls this callback with updated data when the message of type 'FORM_DATA' is triggered and so
- f7 frontend is then gets the updated data but before that data will re-render the blocks, our 'selectBlock' calls the 'creatQuantaToolbar' method and adds the toolbar but then html is re-rendered by this framework and it removes this toolbar added by hydrajs

so what we can do is that we add toolbar only when the data is sent to the frontend and we are sure that the html is re-rendered and then after this we add the toolbar so now it will not get removed, i did this by setting a 0 timeout so adding toolbar goes to another cycle but this adds up a visual delay of toolbar appearing