### PR TITLE
Add js-cookie as a dependency to the addon

### DIFF
--- a/packages/volto-hydra/package.json
+++ b/packages/volto-hydra/package.json
@@ -27,7 +27,8 @@
     "release-alpha": "release-it --preRelease=alpha"
   },
   "dependencies": {
-    "@plone/components": "1.7.0"
+    "@plone/components": "1.7.0",
+    "js-cookie": "^3.0.5"
   },
   "peerDependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
The `js-cookie` dependency was set in the project for this, but developers often won't use the project and will instead import `volto-hydra` directly, causing a missing dependency. This fixes that issue so we can directly add `volto-hydra` to any project using mrs developer (and later npm ) and get started straight away.