### PR TITLE
Fixed toolbar font size

### DIFF
--- a/packages/hydra-js/hydra.js
+++ b/packages/hydra-js/hydra.js
@@ -1859,7 +1859,7 @@ class Bridge {
           box-sizing: border-box;
         }
         .volto-hydra-dropdown-text {
-          font-size: 15px;
+          font-size: 1rem;
           font-weight: 500;
         }
         .volto-hydra-dropdown-item svg {


### PR DESCRIPTION
This pull request addresses the following issue with the Quanta toolbar:

The toolbar text had a fixed font size that caused issues when users adjusted the text size in their browsers. This has been resolved by replacing the fixed px font size with a relative rem unit to ensure the toolbar text adjusts according to the user's settings.

Changes Made:
Updated the font-size property in the toolbar CSS to use rem units instead of fixed px values.

