### PR TITLE
fix: preserve NBSP in slate round-trip (failing test)

### DIFF
--- a/tests-playwright/bridge/block-sanity.spec.ts
+++ b/tests-playwright/bridge/block-sanity.spec.ts
@@ -24,6 +24,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 interface DiscoveredBlock {
   blockType: string;
+  variation?: string;
   blockId: string;
   pagePath: string;
   blockData: Record<string, unknown>;
@@ -53,7 +54,10 @@ const test = base.extend<{ helper: AdminUIHelper }>({
 
 test.describe('Block sanity (auto-discovered)', () => {
   for (const block of discoveredBlocks) {
-    test(`${block.blockType} block renders and has edit annotations`, async ({ page, helper }, testInfo) => {
+    const label = block.variation && block.variation !== 'default'
+      ? `${block.blockType} (${block.variation})`
+      : block.blockType;
+    test(`${label} block renders and has edit annotations`, async ({ page, helper }, testInfo) => {
       const frontendUrl = process.env.FRONTEND_URL || getFrontendUrl(testInfo.project.name);
       const frontend = frontendUrl ? `&frontend=${encodeURIComponent(frontendUrl)}` : '';
 

--- a/tests-playwright/global-setup.ts
+++ b/tests-playwright/global-setup.ts
@@ -15,8 +15,11 @@ async function globalSetup() {
   // causes early return but discovery still needs to run for bridge tests)
   const discoverApi = process.env.DISCOVER_BLOCKS_API;
   if (discoverApi) {
-    const maxPages = parseInt(process.env.DISCOVER_MAX_PAGES || '50', 10);
-    console.log(`[SETUP] Discovering blocks from ${discoverApi} (max ${maxPages} pages)...`);
+    const maxPages = process.env.DISCOVER_MAX_PAGES
+      ? parseInt(process.env.DISCOVER_MAX_PAGES, 10)
+      : Infinity;
+    const maxLabel = Number.isFinite(maxPages) ? `max ${maxPages} pages` : 'all pages';
+    console.log(`[SETUP] Discovering blocks from ${discoverApi} (${maxLabel})...`);
     const blocks = await discoverBlocks(discoverApi, maxPages);
     const outPath = path.resolve(__dirname, '../.discovered-blocks.json');
     fs.writeFileSync(outPath, JSON.stringify(blocks, null, 2));

--- a/tests-playwright/global-setup.ts
+++ b/tests-playwright/global-setup.ts
@@ -34,10 +34,13 @@ async function globalSetup() {
 
   // In production mode (USE_PREBUILT), check SSR server directly
   // In dev mode, check webpack-dev-server health endpoint
+  // Consumers running Volto on non-default ports (e.g. parallel test stacks)
+  // can override with VOLTO_HEALTH_URL.
   const usePrebuilt = process.env.USE_PREBUILT === 'true';
-  const healthUrl = usePrebuilt
+  const defaultHealthUrl = usePrebuilt
     ? 'http://localhost:3001'
     : 'http://localhost:3002/health';
+  const healthUrl = process.env.VOLTO_HEALTH_URL || defaultHealthUrl;
   const serverType = usePrebuilt ? 'production server' : 'webpack compilation';
 
   console.log(`[SETUP] Checking Volto ${serverType} status...`);

--- a/tests-playwright/helpers/BlockVerificationHelper.ts
+++ b/tests-playwright/helpers/BlockVerificationHelper.ts
@@ -219,6 +219,116 @@ export async function checkEditAnnotations(
   }
 }
 
+/**
+ * Detect slate-shaped field values in block data: non-empty arrays of
+ * objects where the first item has a `children` array (slate node shape).
+ */
+function findSlateFields(
+  blockData: Record<string, unknown>,
+): string[] {
+  const fields: string[] = [];
+  for (const [key, value] of Object.entries(blockData)) {
+    if (key.startsWith('@') || key === 'blocks' || key === 'blocks_layout') continue;
+    if (!Array.isArray(value) || value.length === 0) continue;
+    const first = value[0] as Record<string, unknown> | undefined;
+    if (first && typeof first === 'object' && Array.isArray(first.children)) {
+      fields.push(key);
+    }
+  }
+  return fields;
+}
+
+/**
+ * Compare two slate trees for structural equality (types + text), ignoring
+ * nodeId metadata and inline mark ordering. Used to verify that the DOM
+ * round-trips back to the same Slate value via readSlateValueFromDOM.
+ */
+function slateEqualIgnoringIds(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((item, i) => slateEqualIgnoringIds(item, b[i]));
+  }
+  if (a && b && typeof a === 'object' && typeof b === 'object') {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const SKIP = new Set(['nodeId', 'data-node-id']);
+    const keys = new Set([...Object.keys(ao), ...Object.keys(bo)].filter(k => !SKIP.has(k)));
+    for (const k of keys) {
+      if (!slateEqualIgnoringIds(ao[k], bo[k])) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Schema-driven (with shape-based fallback) slate annotation check.
+ *
+ * For every slate field — either declared as `widget: 'slate'` in the block
+ * schema or detected by value shape (array of `{children: [...]}`) — round-trip
+ * the rendered DOM back to a Slate value using Bridge.readSlateValueFromDOM
+ * and compare against blockData[field]. A mismatch means the renderer
+ * isn't emitting the data-node-id attributes the bridge needs to anchor
+ * text nodes, so cursor sync will fail during editing.
+ *
+ * This is strictly stronger than counting [data-node-id] descendants —
+ * it fails when any slate node is missing an id, not just when all are.
+ */
+export async function checkSlateAnnotations(
+  block: Locator,
+  blockData: Record<string, unknown> | undefined,
+  blockSchema?: { properties?: Record<string, any> },
+): Promise<void> {
+  if (!blockData) return;
+
+  let slateFields: string[];
+  if (blockSchema?.properties) {
+    slateFields = Object.entries(blockSchema.properties)
+      .filter(([, prop]) => (prop as Record<string, unknown>)?.widget === 'slate')
+      .map(([field]) => field)
+      .filter((field) => {
+        const v = blockData[field];
+        return Array.isArray(v) && v.length > 0;
+      });
+  } else {
+    slateFields = findSlateFields(blockData);
+  }
+
+  for (const field of slateFields) {
+    const container = block.locator(`[data-edit-text="${field}"]`).first();
+    await expect(
+      container,
+      `Slate field "${field}" should have a [data-edit-text="${field}"] container`,
+    ).toBeAttached();
+
+    // Round-trip via the bridge's own DOM→Slate reader. Returns [] (or partial)
+    // if the renderer didn't emit data-node-id on slate elements.
+    // The bridge is set up asynchronously by initBridge() in the frontend's
+    // onMounted, so wait for __hydraBridge to appear before calling it.
+    const existing = blockData[field];
+    const domValue = await container.evaluate(async (el, existingValue) => {
+      for (let i = 0; i < 50; i++) {
+        if ((window as any).__hydraBridge?.readSlateValueFromDOM) break;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      const bridge = (window as any).__hydraBridge;
+      if (!bridge?.readSlateValueFromDOM) return { error: 'bridge not available on window.__hydraBridge after 5s' };
+      try {
+        return { value: bridge.readSlateValueFromDOM(el, existingValue) };
+      } catch (e: any) {
+        return { error: `readSlateValueFromDOM threw: ${e?.message || String(e)}` };
+      }
+    }, existing);
+
+    expect(domValue, `Slate field "${field}" DOM round-trip`).not.toHaveProperty('error');
+    expect(
+      slateEqualIgnoringIds((domValue as any).value, existing),
+      `Slate field "${field}" DOM does not round-trip to the same Slate value — renderer is likely missing data-node-id on some nodes. Got: ${JSON.stringify((domValue as any).value)} Expected (ignoring ids): ${JSON.stringify(existing)}`,
+    ).toBe(true);
+  }
+}
+
 export interface VerifyBlockRenderingOptions {
   expectedText?: string | null;
   isListing?: boolean;
@@ -271,6 +381,11 @@ export async function verifyBlockRendering(
   // Verify edit annotations
   await checkEditAnnotations(block, blockData);
 
+  // Schema-driven slate check (no-op if schema or data not supplied)
+  const blockType = blockData?.['@type'] as string | undefined;
+  const blockSchema = blockType ? blocksConfig?.[blockType]?.blockSchema : undefined;
+  await checkSlateAnnotations(block, blockData, blockSchema);
+
   // Verify sub-blocks (before clicking, which may toggle interactive
   // containers like accordions closed).
   if (checkSubBlocks && blockData) {
@@ -282,6 +397,9 @@ export async function verifyBlockRendering(
       if (await loc.isVisible()) {
         anyVisible = true;
         await checkEditAnnotations(loc, data);
+        const subType = data?.['@type'] as string | undefined;
+        const subSchema = subType ? blocksConfig?.[subType]?.blockSchema : undefined;
+        await checkSlateAnnotations(loc, data, subSchema);
       }
     }
     if (subBlocks.length > 0) {

--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -160,8 +160,83 @@ function richnessScore(blockData) {
  * @param {Object} [blocksConfig={}] - Block schemas for object_list discovery
  * @returns {Promise<DiscoveredBlock[]>} One entry per unique (blockType, variation)
  */
-async function discoverBlocks(apiUrl, maxPages = 50, blocksConfig = {}) {
+/**
+ * Walk a slate subtree and collect structural issues:
+ *  - Element nodes (have `children`) must have a string `type`.
+ *  - Text leaves (have `text`) must not also have `children` or `type`.
+ *  - Leaf-only nodes at root level (text without element wrapper) are invalid.
+ */
+function validateSlateNode(node, pathStr, issues) {
+  if (!node || typeof node !== 'object' || Array.isArray(node)) {
+    issues.push(`${pathStr}: non-object slate node (${typeof node})`);
+    return;
+  }
+  const hasChildren = Array.isArray(node.children);
+  const hasText = Object.prototype.hasOwnProperty.call(node, 'text');
+  const hasType = typeof node.type === 'string' && node.type.length > 0;
+
+  if (hasChildren) {
+    if (!hasType) issues.push(`${pathStr}: element has children but no \`type\``);
+    for (let i = 0; i < node.children.length; i++) {
+      validateSlateNode(node.children[i], `${pathStr}.children[${i}]`, issues);
+    }
+  } else if (hasText) {
+    if (hasType) issues.push(`${pathStr}: text leaf must not have \`type\``);
+    // Newlines inside a text leaf mean under-structured content — multi-
+    // paragraph or bulleted content stuffed into one text node instead of
+    // proper slate elements. Breaks inline editing boundaries.
+    if (typeof node.text === 'string' && node.text.includes('\n')) {
+      const preview = node.text.replace(/\n/g, '\\n').slice(0, 80);
+      issues.push(`${pathStr}: text leaf contains newline(s) — split into separate slate elements ("${preview}${node.text.length > 80 ? '…' : ''}")`);
+    }
+  } else {
+    issues.push(`${pathStr}: node has neither \`children\` nor \`text\``);
+  }
+}
+
+/**
+ * Walk a block's data for slate-shaped fields (arrays whose first item looks
+ * like a slate node) and record all structural issues:
+ *  - Multi-root values force renderers to add a nodeId-less wrapper.
+ *  - Missing `type` on root element.
+ *  - Invalid node shapes anywhere in the tree.
+ *
+ * Schema-independent; runs against raw API data.
+ */
+function collectSlateIssues(blockData, pagePath, blockId, out) {
+  if (!blockData || typeof blockData !== 'object') return;
+  for (const [key, value] of Object.entries(blockData)) {
+    if (key.startsWith('@') || key === 'blocks' || key === 'blocks_layout') continue;
+    if (!Array.isArray(value) || value.length === 0) continue;
+    const first = value[0];
+    const looksSlate =
+      first && typeof first === 'object' &&
+      (Array.isArray(first.children) || Object.prototype.hasOwnProperty.call(first, 'text'));
+    if (!looksSlate) continue;
+
+    const issues = [];
+    if (value.length > 1) {
+      issues.push(`multiple top-level nodes (${value.length}); split into separate blocks`);
+    }
+    for (let i = 0; i < value.length; i++) {
+      validateSlateNode(value[i], `value[${i}]`, issues);
+    }
+    // A slate field's roots must be elements, not text leaves.
+    for (let i = 0; i < value.length; i++) {
+      const n = value[i];
+      if (n && typeof n === 'object' && Object.prototype.hasOwnProperty.call(n, 'text') && !Array.isArray(n.children)) {
+        issues.push(`value[${i}]: text leaf at root (must be wrapped in an element)`);
+      }
+    }
+    if (issues.length) {
+      out.push({ pagePath, blockId, field: key, issues });
+    }
+  }
+}
+
+async function discoverBlocks(apiUrl, maxPages = Infinity, blocksConfig = {}) {
   const seen = new Map();
+  const slateIssues = [];
   const objectListFields = buildObjectListFieldsMap(blocksConfig);
 
   if (objectListFields.size > 0) {
@@ -213,6 +288,8 @@ async function discoverBlocks(apiUrl, maxPages = 50, blocksConfig = {}) {
       const blocks = extractBlocks(content.blocks, content.blocks_layout.items, objectListFields);
 
       for (const { blockId, blockType, blockData } of blocks) {
+        collectSlateIssues(blockData, pagePath, blockId, slateIssues);
+
         // Skip metadata block types that don't render visually
         if (blockType === 'title' || blockType === 'description') continue;
 
@@ -247,6 +324,20 @@ async function discoverBlocks(apiUrl, maxPages = 50, blocksConfig = {}) {
 
   const result = Array.from(seen.values()).map(({ _score, ...rest }) => rest);
   console.log(`[DISCOVER] Discovered ${result.length} unique (blockType, variation) pairs from ${fetched} pages`);
+
+  if (slateIssues.length) {
+    const lines = slateIssues.flatMap((e) => [
+      `  ${e.pagePath} [${e.blockId}] field "${e.field}":`,
+      ...e.issues.map((msg) => `    - ${msg}`),
+    ]);
+    throw new Error(
+      `Discovery found ${slateIssues.length} slate field(s) with structural issues. ` +
+        `Each slate field must be a single element root with a string \`type\`; ` +
+        `text leaves must live inside an element.\n` +
+        lines.join('\n'),
+    );
+  }
+
   return result;
 }
 

--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -1,5 +1,5 @@
 /**
- * Crawls a Plone REST API to discover one example of each block @type.
+ * Crawls a Plone REST API to discover one example of each (block @type, variation) pair.
  *
  * Used by globalSetup to write .discovered-blocks.json, which the
  * block-sanity spec reads at module load time to parametrize tests.
@@ -7,7 +7,7 @@
  * Works against any Plone API (mock or real) — no filesystem access needed.
  * When blocksConfig (schemas) is provided, also discovers object_list sub-blocks.
  *
- * @typedef {{ blockType: string, blockId: string, pagePath: string, blockData: Object, isListing: boolean }} DiscoveredBlock
+ * @typedef {{ blockType: string, variation: string, blockId: string, pagePath: string, blockData: Object, isListing: boolean }} DiscoveredBlock
  */
 
 /**
@@ -96,12 +96,69 @@ function extractBlocks(blocks, layout, objectListFields) {
 }
 
 /**
- * Discover one example of each block type from a Plone API.
+ * Pick a variation key from block data. Covers the common select-widget
+ * field names hydra blocks use: `variation`, `template`, `variant`. Falls
+ * back to `'default'` so blocks without variations still get one entry.
+ */
+function variationOf(blockData) {
+  return (
+    blockData?.variation ||
+    blockData?.template ||
+    blockData?.variant ||
+    'default'
+  );
+}
+
+/**
+ * Score an example block by content richness, so when multiple pages
+ * contain the same (blockType, variation) we keep the most interesting
+ * example for testing. Heuristic:
+ *  - +1 per non-empty field
+ *  - +number of unique slate node types across slate values (heading, list,
+ *    link, bold, etc. — exercises more renderer paths)
+ *
+ * Handles circular-ish data defensively: a shallow walk is enough for slate.
+ */
+function collectSlateNodeTypes(node, types) {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) collectSlateNodeTypes(item, types);
+    return;
+  }
+  if (typeof node.type === 'string') types.add(node.type);
+  // Slate leaves carry inline marks as boolean keys
+  for (const key of ['bold', 'italic', 'underline', 'strikethrough', 'code']) {
+    if (node[key]) types.add(`leaf:${key}`);
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) collectSlateNodeTypes(child, types);
+  }
+}
+
+function richnessScore(blockData) {
+  let score = 0;
+  const slateTypes = new Set();
+  for (const [key, value] of Object.entries(blockData || {})) {
+    if (key.startsWith('@') || key === 'blocks' || key === 'blocks_layout') continue;
+    if (value == null) continue;
+    if (typeof value === 'string' && value === '') continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    score += 1;
+    // Arrays of slate nodes or single slate-like trees
+    if (Array.isArray(value) && value.length && typeof value[0] === 'object' && value[0] && 'children' in value[0]) {
+      collectSlateNodeTypes(value, slateTypes);
+    }
+  }
+  return score + slateTypes.size;
+}
+
+/**
+ * Discover one example of each (block type, variation) pair from a Plone API.
  *
  * @param {string} apiUrl - Base URL of the Plone API (e.g. "http://localhost:8888")
  * @param {number} [maxPages=50] - Maximum number of pages to fetch
  * @param {Object} [blocksConfig={}] - Block schemas for object_list discovery
- * @returns {Promise<DiscoveredBlock[]>} One entry per unique block @type
+ * @returns {Promise<DiscoveredBlock[]>} One entry per unique (blockType, variation)
  */
 async function discoverBlocks(apiUrl, maxPages = 50, blocksConfig = {}) {
   const seen = new Map();
@@ -156,20 +213,31 @@ async function discoverBlocks(apiUrl, maxPages = 50, blocksConfig = {}) {
       const blocks = extractBlocks(content.blocks, content.blocks_layout.items, objectListFields);
 
       for (const { blockId, blockType, blockData } of blocks) {
-        if (seen.has(blockType)) continue;
-
         // Skip metadata block types that don't render visually
         if (blockType === 'title' || blockType === 'description') continue;
 
-        seen.set(blockType, {
+        const variation = variationOf(blockData);
+        const key = `${blockType}:${variation}`;
+        const score = richnessScore(blockData);
+        const existing = seen.get(key);
+        if (existing && existing._score >= score) continue;
+
+        const label = variation === 'default' ? blockType : `${blockType} (${variation})`;
+        if (existing) {
+          console.log(`[DISCOVER] Replaced ${label} with richer example from ${pagePath} (score ${existing._score} → ${score})`);
+        } else {
+          console.log(`[DISCOVER] Found ${label} block "${blockId}" on ${pagePath} (score ${score})`);
+        }
+
+        seen.set(key, {
           blockType,
+          variation,
           blockId,
           pagePath,
           blockData,
           isListing: blockType === 'listing',
+          _score: score,
         });
-
-        console.log(`[DISCOVER] Found ${blockType} block "${blockId}" on ${pagePath}`);
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -177,8 +245,8 @@ async function discoverBlocks(apiUrl, maxPages = 50, blocksConfig = {}) {
     }
   }
 
-  const result = Array.from(seen.values());
-  console.log(`[DISCOVER] Discovered ${result.length} unique block types from ${fetched} pages`);
+  const result = Array.from(seen.values()).map(({ _score, ...rest }) => rest);
+  console.log(`[DISCOVER] Discovered ${result.length} unique (blockType, variation) pairs from ${fetched} pages`);
   return result;
 }
 

--- a/tests-playwright/unit/readSlateValueFromDOM.spec.ts
+++ b/tests-playwright/unit/readSlateValueFromDOM.spec.ts
@@ -748,4 +748,27 @@ test.describe('Bridge.readSlateValueFromDOM()', () => {
       ]}],
     });
   });
+
+  // Regression: NBSP (U+00A0) is user-enterable (Opt+Space on macOS) and
+  // semantically meaningful. domNodeToSlate must preserve it verbatim instead
+  // of collapsing it to a regular space. The bridge's internal
+  // stripZeroWidthSpaces DOES normalise NBSP→space for cursor/text-equality
+  // math; the read-back-for-save path must use a separate helper that only
+  // strips ZWS/BOM and keeps NBSP.
+  test('NBSP in user content is preserved verbatim (not collapsed to space)', async () => {
+    const body = helper.getIframe().locator('body');
+    await testDomToSlate(body, {
+      id: 'nbsp1',
+      existing: [{ type: 'p', nodeId: '0', children: [
+        { text: 'How we use your\u00A0personal data' },
+      ]}],
+      dom:
+        '<p data-edit-text="value" data-node-id="0">' +
+          'How we use your\u00A0personal data' +
+        '</p>',
+      expected: [{ type: 'p', nodeId: '0', children: [
+        { text: 'How we use your\u00A0personal data' },
+      ]}],
+    });
+  });
 });


### PR DESCRIPTION
Failing test documenting that readSlateValueFromDOM collapses NBSP to regular space. See #208 for fix options.