### PR TITLE
plone-content-validator: mock-api startup check + CLI

### DIFF
--- a/bin/plone-content.cjs
+++ b/bin/plone-content.cjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * CLI for the plone-content-validator. Usage:
+ *   plone-content validate [<content-dir>]   — export-shape validation
+ *   plone-content check    [<content-dir>]   — graph integrity check
+ *   plone-content all      [<content-dir>]   — both (exit non-zero on any error)
+ *
+ * <content-dir> defaults to cwd/content.
+ */
+'use strict';
+
+const path = require('path');
+const { validate, checkIntegrity, formatReport } = require(
+  path.join(__dirname, '..', 'tests-playwright', 'fixtures', 'plone-content-validator.cjs'),
+);
+
+function usage() {
+  console.error('Usage: plone-content <validate|check|all> [<content-dir>]');
+  process.exit(2);
+}
+
+const [,, cmd, dirArg] = process.argv;
+if (!cmd || !['validate', 'check', 'all'].includes(cmd)) usage();
+
+const contentDir = path.resolve(dirArg || 'content');
+
+let hasErrors = false;
+if (cmd === 'validate' || cmd === 'all') {
+  const r = validate(contentDir);
+  console.log(formatReport('validate', r));
+  if (r.errors.length) hasErrors = true;
+}
+if (cmd === 'check' || cmd === 'all') {
+  if (cmd === 'all') console.log('');
+  const r = checkIntegrity(contentDir);
+  console.log(formatReport('check', r));
+  if (r.errors.length) hasErrors = true;
+}
+
+process.exit(hasErrors ? 1 : 0);

--- a/tests-playwright/fixtures/mock-plone-api.cjs
+++ b/tests-playwright/fixtures/mock-plone-api.cjs
@@ -39,6 +39,24 @@ function parseContentMounts() {
 
 const CONTENT_MOUNTS = parseContentMounts();
 
+// Validate each mounted content tree at startup. Errors are loud (listed)
+// but non-fatal — tests using the mock API still start. Set
+// SKIP_CONTENT_VALIDATION=true to suppress entirely.
+if (process.env.SKIP_CONTENT_VALIDATION !== 'true') {
+  const { validate, checkIntegrity, formatReport } = require('./plone-content-validator.cjs');
+  for (const { mountPath, dirPath } of CONTENT_MOUNTS) {
+    if (!fs.existsSync(path.join(dirPath, '__metadata__.json'))) continue;
+    const v = validate(dirPath);
+    const c = checkIntegrity(dirPath);
+    const problems = v.errors.length + v.warnings.length + c.errors.length + c.warnings.length;
+    if (problems > 0) {
+      console.log(`[content-check] ${mountPath} -> ${dirPath}`);
+      if (v.errors.length || v.warnings.length) console.log(formatReport('validate', v));
+      if (c.errors.length || c.warnings.length) console.log(formatReport('check', c));
+    }
+  }
+}
+
 // Session-based transient content storage for uploads
 // Uploads are stored per-session so they don't appear for other users
 // Format: { sessionId: { '/path': content, ... } }

--- a/tests-playwright/fixtures/plone-content-validator.cjs
+++ b/tests-playwright/fixtures/plone-content-validator.cjs
@@ -1,0 +1,300 @@
+/**
+ * Validate and integrity-check a plone.exportimport content tree.
+ *
+ * Two entry points:
+ *   validate(contentDir) — export shape: _data_files_/_blob_files_ consistency,
+ *                          parent/UID/id presence, Image blob paths, ordering
+ *   checkIntegrity(contentDir) — graph integrity: resolveuid refs, image refs,
+ *                                teaser/button hrefs, parent containers
+ *
+ * Both return { errors: string[], warnings: string[], stats: object }.
+ * Mirrors the behaviour of pretagov-site/{validate,test}-content.py so the
+ * same errors surface whether invoked at mock-api startup or from a CI
+ * script.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function listDataEntries(contentDir) {
+  const out = [];
+  for (const name of fs.readdirSync(contentDir)) {
+    const dataFile = path.join(contentDir, name, 'data.json');
+    if (fs.statSync(path.join(contentDir, name), { throwIfNoEntry: false })?.isDirectory()
+        && fs.existsSync(dataFile)) {
+      out.push({ name, dataFile });
+    }
+  }
+  return out;
+}
+
+/** Recursively walk every data.json under contentDir, yielding { rel, data }. */
+function* walkData(contentDir) {
+  const stack = [contentDir];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    const dataPath = path.join(dir, 'data.json');
+    if (fs.existsSync(dataPath)) {
+      const rel = path.relative(contentDir, dir) || '.';
+      yield { rel, data: readJson(dataPath), dir };
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) stack.push(path.join(dir, e.name));
+    }
+  }
+}
+
+/**
+ * Export-shape validation. Mirrors validate-content.py.
+ */
+function validate(contentDir) {
+  const errors = [];
+  const warnings = [];
+  const stats = { dataFiles: 0, blobFiles: 0 };
+
+  const metaPath = path.join(contentDir, '__metadata__.json');
+  if (!fs.existsSync(metaPath)) {
+    errors.push(`${metaPath} not found`);
+    return { errors, warnings, stats };
+  }
+  const meta = readJson(metaPath);
+  const listed = new Set(meta._data_files_ || []);
+  const listedBlobs = new Set(meta._blob_files_ || []);
+  stats.dataFiles = listed.size;
+  stats.blobFiles = listedBlobs.size;
+
+  // Required sibling files one level above the content dir
+  const parentDir = path.dirname(contentDir);
+  for (const req of ['discussions.json', 'portlets.json', 'principals.json', 'redirects.json']) {
+    if (!fs.existsSync(path.join(parentDir, req))) {
+      errors.push(`  Missing ${req} in ${parentDir}/`);
+    }
+  }
+
+  // Per-item checks on direct children of contentDir
+  for (const { name, dataFile } of listDataEntries(contentDir)) {
+    const entry = `${name}/data.json`;
+    if (!listed.has(entry)) {
+      errors.push(`  ${entry} on disk but not in __metadata__.json _data_files_`);
+    }
+    const d = readJson(dataFile);
+    const contentType = d['@type'] || '?';
+
+    if (name !== 'plone_site_root' && !d.UID) {
+      errors.push(`  ${entry} missing UID`);
+    }
+    if (name !== 'plone_site_root' && !d.parent) {
+      errors.push(`  ${entry} missing parent`);
+    }
+    if (!d.id) {
+      errors.push(`  ${entry} has empty id`);
+    }
+
+    if (contentType === 'Image') {
+      const img = d.image || {};
+      const blobPath = img.blob_path || '';
+      const download = img.download || '';
+      if (download && download.startsWith('http')) {
+        errors.push(`  ${entry} image has remote URL instead of blob_path: ${download.slice(0, 80)}`);
+      } else if (blobPath) {
+        const fullBlob = path.join(contentDir, blobPath);
+        if (!fs.existsSync(fullBlob)) {
+          errors.push(`  ${entry} blob_path file missing: ${blobPath}`);
+        }
+        if (!listedBlobs.has(blobPath)) {
+          warnings.push(`  ${entry} blob_path not in _blob_files_: ${blobPath}`);
+        }
+      } else if (!blobPath && !download) {
+        warnings.push(`  ${entry} Image has no image data`);
+      }
+    }
+  }
+
+  // Every non-root listing should have its parent container also listed
+  for (const entry of listed) {
+    const parts = entry.split('/');
+    if (parts.length > 2 && parts[0] !== 'plone_site_root') {
+      const parentEntry = parts.slice(0, -2).join('/') + '/data.json';
+      if (!listed.has(parentEntry)) {
+        errors.push(`  ${entry} parent container missing: ${parentEntry}`);
+      }
+    }
+  }
+
+  // Ordering: parents must appear before their children in _data_files_
+  const listedList = meta._data_files_ || [];
+  const seenParents = new Set();
+  for (const entry of listedList) {
+    const parts = entry.split('/');
+    if (parts.length > 2 && parts[0] !== 'plone_site_root') {
+      const parentEntry = parts.slice(0, -2).join('/') + '/data.json';
+      if (listed.has(parentEntry) && !seenParents.has(parentEntry)) {
+        errors.push(`  ${entry} appears before its parent ${parentEntry} in _data_files_`);
+      }
+    }
+    seenParents.add(entry);
+  }
+
+  // Listed entries must exist on disk
+  for (const entry of listed) {
+    if (!fs.existsSync(path.join(contentDir, entry))) {
+      errors.push(`  ${entry} in _data_files_ but missing from disk`);
+    }
+  }
+  for (const entry of listedBlobs) {
+    if (!fs.existsSync(path.join(contentDir, entry))) {
+      errors.push(`  ${entry} in _blob_files_ but missing from disk`);
+    }
+  }
+
+  return { errors, warnings, stats };
+}
+
+/**
+ * Graph integrity. Mirrors test-content.py.
+ */
+function checkIntegrity(contentDir) {
+  const errors = [];
+  const warnings = [];
+  const stats = {
+    items: 0,
+    imagesOk: 0, imagesBroken: 0,
+    resolveuidOk: 0, resolveuidBroken: 0,
+    linksOk: 0, linksBroken: 0,
+  };
+
+  // Pass 1: build UID → relpath and path → data
+  const uidMap = new Map();
+  const pathMap = new Map();
+  const items = [];
+  for (const { rel, data, dir } of walkData(contentDir)) {
+    items.push({ rel, data, dir });
+    if (data.UID) uidMap.set(data.UID, rel);
+    const atId = data['@id'];
+    if (atId) pathMap.set(atId, data);
+    pathMap.set('/' + rel.split(path.sep).join('/'), data);
+  }
+  stats.items = uidMap.size;
+
+  // Pass 2a: resolveuid references
+  const resolveuidRe = /(?:\.\.\/)*resolveuid\/([a-f0-9]{10,})/g;
+  for (const { rel, dir } of items) {
+    const text = fs.readFileSync(path.join(dir, 'data.json'), 'utf8');
+    let m;
+    while ((m = resolveuidRe.exec(text)) !== null) {
+      const uid = m[1];
+      if (uidMap.has(uid)) {
+        stats.resolveuidOk += 1;
+      } else {
+        stats.resolveuidBroken += 1;
+        errors.push(`  ${rel}: broken resolveuid/${uid}`);
+      }
+    }
+  }
+
+  // Pass 2b: Image content items have blob files
+  for (const { rel, data } of items) {
+    if (data['@type'] !== 'Image') continue;
+    const img = data.image || {};
+    const blobPath = img.blob_path || '';
+    const download = img.download || '';
+    if (download && download.startsWith('http')) {
+      errors.push(`  ${rel}: image has remote URL (not blob_path): ${download.slice(0, 60)}`);
+      stats.imagesBroken += 1;
+    } else if (blobPath) {
+      if (fs.existsSync(path.join(contentDir, blobPath))) {
+        stats.imagesOk += 1;
+      } else {
+        errors.push(`  ${rel}: blob file missing: ${blobPath}`);
+        stats.imagesBroken += 1;
+      }
+    } else {
+      errors.push(`  ${rel}: Image has no image data`);
+      stats.imagesBroken += 1;
+    }
+  }
+
+  // Pass 2c: Internal link refs in blocks (image.url paths, teaser/button hrefs)
+  for (const { rel, data } of items) {
+    const blocks = data.blocks || {};
+    for (const [bid, block] of Object.entries(blocks)) {
+      if (block && block['@type'] === 'image') {
+        const url = block.url;
+        if (typeof url === 'string' && url.startsWith('/') && !url.includes('resolveuid')) {
+          if (pathMap.has(url)) {
+            stats.linksOk += 1;
+          } else {
+            warnings.push(`  ${rel}: image block ${bid} references missing path: ${url}`);
+            stats.linksBroken += 1;
+          }
+        }
+      }
+      const href = block && block.href;
+      if (Array.isArray(href)) {
+        for (const h of href) {
+          if (h && typeof h === 'object') {
+            const linkId = h['@id'] || '';
+            if (typeof linkId === 'string' && linkId.startsWith('/') && !pathMap.has(linkId)) {
+              warnings.push(`  ${rel}: block ${bid} href references missing: ${linkId}`);
+              stats.linksBroken += 1;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Parent containers (metadata cross-check for completeness)
+  const metaPath = path.join(contentDir, '__metadata__.json');
+  if (fs.existsSync(metaPath)) {
+    const meta = readJson(metaPath);
+    const listed = new Set(meta._data_files_ || []);
+    for (const entry of listed) {
+      const parts = entry.split('/');
+      if (parts.length > 2 && parts[0] !== 'plone_site_root') {
+        const parentEntry = parts.slice(0, -2).join('/') + '/data.json';
+        if (!listed.has(parentEntry)) {
+          errors.push(`  ${entry}: parent container missing (${parentEntry})`);
+        }
+      }
+    }
+  }
+
+  return { errors, warnings, stats };
+}
+
+function formatReport(title, result) {
+  const lines = [];
+  if (title === 'validate') {
+    lines.push(`Content export OK: ${result.stats.dataFiles} data files, ${result.stats.blobFiles} blob files`);
+  } else {
+    lines.push(`Content: ${result.stats.items} items`);
+    lines.push(`Images:  ${result.stats.imagesOk} ok, ${result.stats.imagesBroken} broken`);
+    lines.push(`UIDs:    ${result.stats.resolveuidOk} resolved, ${result.stats.resolveuidBroken} broken`);
+    lines.push(`Links:   ${result.stats.linksOk} ok, ${result.stats.linksBroken} broken`);
+  }
+  if (result.errors.length) {
+    lines.push('');
+    lines.push(`ERRORS (${result.errors.length}):`);
+    for (const e of result.errors) lines.push(e);
+  }
+  if (result.warnings.length) {
+    lines.push('');
+    lines.push(`Warnings (${result.warnings.length}):`);
+    for (const w of result.warnings) lines.push(w);
+  }
+  return lines.join('\n');
+}
+
+module.exports = { validate, checkIntegrity, formatReport };

--- a/tests-playwright/fixtures/plone-content-validator.test.cjs
+++ b/tests-playwright/fixtures/plone-content-validator.test.cjs
@@ -1,0 +1,194 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { validate, checkIntegrity } = require('./plone-content-validator.cjs');
+
+/**
+ * Build a minimal plone.exportimport content tree under a temp dir.
+ * Returns the content dir path. Caller is responsible for cleanup.
+ */
+function buildFixture(overrides = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'plone-content-test-'));
+  const contentDir = path.join(root, 'content');
+  fs.mkdirSync(contentDir);
+  // Required sibling files for validate()
+  for (const sib of ['discussions.json', 'portlets.json', 'principals.json', 'redirects.json']) {
+    fs.writeFileSync(path.join(root, sib), '{}');
+  }
+
+  const dataFiles = overrides.dataFiles || ['plone_site_root/data.json', 'page-a/data.json'];
+  const blobFiles = overrides.blobFiles || [];
+  fs.writeFileSync(
+    path.join(contentDir, '__metadata__.json'),
+    JSON.stringify({ _data_files_: dataFiles, _blob_files_: blobFiles }, null, 2),
+  );
+
+  const rootItem = {
+    '@id': '/',
+    '@type': 'Plone Site',
+    id: 'plone_site_root',
+    UID: 'rootuid1234567',
+    ...overrides.rootItem,
+  };
+  fs.mkdirSync(path.join(contentDir, 'plone_site_root'));
+  fs.writeFileSync(path.join(contentDir, 'plone_site_root', 'data.json'), JSON.stringify(rootItem));
+
+  const pageA = overrides.pageA || {
+    '@id': '/page-a',
+    '@type': 'Document',
+    id: 'page-a',
+    UID: 'pageauid1234567',
+    parent: { '@id': '/' },
+  };
+  fs.mkdirSync(path.join(contentDir, 'page-a'));
+  fs.writeFileSync(path.join(contentDir, 'page-a', 'data.json'), JSON.stringify(pageA));
+
+  return { root, contentDir };
+}
+
+function cleanup(root) {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+describe('plone-content-validator validate()', () => {
+  it('returns no errors on a clean fixture', () => {
+    const { root, contentDir } = buildFixture();
+    const r = validate(contentDir);
+    cleanup(root);
+    assert.deepEqual(r.errors, []);
+    assert.equal(r.stats.dataFiles, 2);
+  });
+
+  it('reports missing parent container', () => {
+    const { root, contentDir } = buildFixture({
+      dataFiles: ['plone_site_root/data.json', 'section/child/data.json'],
+    });
+    fs.mkdirSync(path.join(contentDir, 'section'), { recursive: true });
+    fs.mkdirSync(path.join(contentDir, 'section', 'child'), { recursive: true });
+    fs.writeFileSync(
+      path.join(contentDir, 'section', 'child', 'data.json'),
+      JSON.stringify({ '@id': '/section/child', '@type': 'Document', id: 'child', UID: 'x'.repeat(15), parent: {} }),
+    );
+    const r = validate(contentDir);
+    cleanup(root);
+    assert.ok(r.errors.some((e) => e.includes('parent container missing')), r.errors.join('\n'));
+  });
+
+  it('reports Image with remote URL instead of blob_path', () => {
+    const { root, contentDir } = buildFixture({
+      dataFiles: ['plone_site_root/data.json', 'my-image/data.json'],
+      pageA: {
+        '@id': '/my-image',
+        '@type': 'Image',
+        id: 'my-image',
+        UID: 'img1234567890',
+        parent: { '@id': '/' },
+        image: { download: 'https://example.com/remote.jpg' },
+      },
+    });
+    // buildFixture wrote page-a, but we also need my-image at the path
+    fs.mkdirSync(path.join(contentDir, 'my-image'), { recursive: true });
+    fs.writeFileSync(
+      path.join(contentDir, 'my-image', 'data.json'),
+      JSON.stringify({
+        '@id': '/my-image', '@type': 'Image', id: 'my-image',
+        UID: 'img1234567890', parent: {}, image: { download: 'https://example.com/remote.jpg' },
+      }),
+    );
+    // Remove page-a so the only Image we check is my-image
+    fs.rmSync(path.join(contentDir, 'page-a'), { recursive: true });
+    fs.writeFileSync(
+      path.join(contentDir, '__metadata__.json'),
+      JSON.stringify({ _data_files_: ['plone_site_root/data.json', 'my-image/data.json'], _blob_files_: [] }, null, 2),
+    );
+    const r = validate(contentDir);
+    cleanup(root);
+    assert.ok(r.errors.some((e) => e.includes('remote URL')), r.errors.join('\n'));
+  });
+
+  it('reports child before parent in _data_files_ ordering', () => {
+    const { root, contentDir } = buildFixture({
+      dataFiles: [
+        'plone_site_root/data.json',
+        'section/child/data.json',  // child first
+        'section/data.json',        // parent second (wrong order)
+      ],
+    });
+    for (const rel of ['section', 'section/child']) {
+      fs.mkdirSync(path.join(contentDir, rel), { recursive: true });
+      fs.writeFileSync(
+        path.join(contentDir, rel, 'data.json'),
+        JSON.stringify({ '@id': '/' + rel, '@type': 'Document', id: rel.split('/').pop(), UID: rel + '1234567', parent: {} }),
+      );
+    }
+    const r = validate(contentDir);
+    cleanup(root);
+    assert.ok(
+      r.errors.some((e) => e.includes('appears before its parent')),
+      r.errors.join('\n'),
+    );
+  });
+});
+
+describe('plone-content-validator checkIntegrity()', () => {
+  it('flags broken resolveuid refs', () => {
+    const { root, contentDir } = buildFixture({
+      pageA: {
+        '@id': '/page-a',
+        '@type': 'Document',
+        id: 'page-a',
+        UID: 'pageauid1234567',
+        parent: { '@id': '/' },
+        // Reference a UID that doesn't exist in the tree
+        body: 'See <a href="resolveuid/deadbeefdeadbeef">this</a>',
+      },
+    });
+    const r = checkIntegrity(contentDir);
+    cleanup(root);
+    assert.ok(r.errors.some((e) => e.includes('broken resolveuid')), r.errors.join('\n'));
+    assert.equal(r.stats.resolveuidBroken, 1);
+  });
+
+  it('flags broken internal hrefs in block teasers', () => {
+    const { root, contentDir } = buildFixture({
+      pageA: {
+        '@id': '/page-a',
+        '@type': 'Document',
+        id: 'page-a',
+        UID: 'pageauid1234567',
+        parent: { '@id': '/' },
+        blocks: {
+          'teaser-1': {
+            '@type': 'teaser',
+            href: [{ '@id': '/does-not-exist' }],
+          },
+        },
+      },
+    });
+    const r = checkIntegrity(contentDir);
+    cleanup(root);
+    assert.ok(r.warnings.some((w) => w.includes('/does-not-exist')), r.warnings.join('\n'));
+  });
+
+  it('resolves valid resolveuid refs', () => {
+    // UID must be hex ≥ 10 chars to match the /resolveuid/[a-f0-9]{10,}/ regex
+    const uid = 'abcdef1234567890';
+    const { root, contentDir } = buildFixture({
+      pageA: {
+        '@id': '/page-a',
+        '@type': 'Document',
+        id: 'page-a',
+        UID: uid,
+        parent: { '@id': '/' },
+        body: `Self-ref: <a href="resolveuid/${uid}">here</a>`,
+      },
+    });
+    const r = checkIntegrity(contentDir);
+    cleanup(root);
+    assert.equal(r.stats.resolveuidBroken, 0);
+    assert.equal(r.stats.resolveuidOk, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `plone-content-validator` — a single JS module with `validate(dir)` and `checkIntegrity(dir)` functions that check a `plone.exportimport` content tree for export-shape issues and graph integrity issues (broken `resolveuid` refs, missing image blobs, broken internal hrefs, etc.).
- Mock API (`mock-plone-api.cjs`) runs both on every `CONTENT_MOUNT` at startup. Errors / warnings are logged; no runtime impact. Suppress with `SKIP_CONTENT_VALIDATION=true`.
- `bin/plone-content.cjs` — thin CLI shell for deploy/CI scripts (`plone-content validate|check|all <dir>`).
- Ported 1:1 from two Python scripts (`validate-content.py`, `test-content.py`) previously carried by downstream consumers (e.g. pretagov-site), so the same issues surface whether the validator is invoked from mock-api, CLI, or CI. Downstream consumers can then drop the Python scripts.

## Test plan
- [x] `node --test tests-playwright/fixtures/plone-content-validator.test.cjs` — 7 unit tests, each builds a minimal fixture (clean / broken in one specific way) and asserts the validator reports the right thing.
- [x] Run CLI against a real distribution (pretagov-site): found real issues that the existing Python scripts also surface.
- [x] Mock-api hot-reloads cleanly with the validator loaded; no tests regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)