### PR TITLE
Give testing package a name

### DIFF
--- a/tests-playwright/package.json
+++ b/tests-playwright/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@volto-hydra/testing",
-  "type": "module"
+  "type": "module",
+  "exports": {
+    "helpers/*": "./helpers"
+  }
 }

--- a/tests-playwright/package.json
+++ b/tests-playwright/package.json
@@ -2,6 +2,6 @@
   "name": "@volto-hydra/testing",
   "type": "module",
   "exports": {
-    "helpers/*": "./helpers"
+    "./helpers/*": "./helpers/*"
   }
 }

--- a/tests-playwright/package.json
+++ b/tests-playwright/package.json
@@ -1,3 +1,4 @@
 {
+  "name": "@volto-hydra/testing",
   "type": "module"
 }


### PR DESCRIPTION
This allows it to be used correctly as a package rather than having to rely on file paths. E.g. you can have a dependency of `"@volto-hydra/testing": "github:collective/volto-hydra#path:/tests-playwright"`. Makes it easier to get started using the `AdminUIHelper`