### PR TITLE
package: declare @playwright/test as peer at both layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,12 @@
     "@plone/volto": "18.31.0",
     "volto-hydra": "workspace:*"
   },
+  "peerDependencies": {
+    "@playwright/test": "^1.58.2"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": { "optional": false }
+  },
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-export-default-from": "7.18.10",
@@ -62,7 +68,6 @@
     "@fiverr/afterbuild-webpack-plugin": "^1.0.0",
     "@loadable/babel-plugin": "5.13.2",
     "@loadable/webpack-plugin": "5.15.2",
-    "@playwright/test": "^1.58.2",
     "@storybook/react": "^8.0.4",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@types/node": "^22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
 
   .:
     dependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@plone/volto':
         specifier: 18.31.0
         version: 18.31.0(@babel/runtime@7.28.4)(@popperjs/core@2.11.8)(@types/react@19.2.7)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4)(slate-dom@0.119.0(slate@0.118.1))
@@ -49,9 +52,6 @@ importers:
       '@loadable/webpack-plugin':
         specifier: 5.15.2
         version: 5.15.2(webpack@5.90.1(esbuild@0.25.12))
-      '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
       '@storybook/react':
         specifier: ^8.0.4
         version: 8.6.15(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.15(prettier@3.2.5))(typescript@5.9.3)
@@ -3096,6 +3096,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3704,6 +3705,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -4431,6 +4433,7 @@ packages:
 
   decorate-component-with-props@1.2.1:
     resolution: {integrity: sha512-X2hZBnVHZAZQHG+g3Ce97SBtog1Vglzg7sPNbUY5XKmmgd3NVAiOHviw9hd7GOJIDrQ1slfwsmkbKQxESWFy7Q==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
@@ -9015,6 +9018,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}

--- a/tests-playwright/package.json
+++ b/tests-playwright/package.json
@@ -3,5 +3,11 @@
   "type": "module",
   "exports": {
     "./helpers/*": "./helpers/*"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.58.2"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": { "optional": false }
   }
 }


### PR DESCRIPTION
## Summary

Move `@playwright/test` from `devDependencies` to `peerDependencies` at both layers that depend on it:

- `hydra/package.json` — outer `volto-hydra-dev` workspace
- `tests-playwright/package.json` — inner `@volto-hydra/testing` package (named in #212)

## Why

When the same `@playwright/test` is installed in two separate workspaces (consumer + hydra), pnpm produces two physical copies. The consumer's playwright config loads one; hydra's `globalSetup` or the `@volto-hydra/testing` helper imports the other via Node's module-walk. Playwright detects this and throws:

```
Error: Requiring @playwright/test second time, ...
```

This affects two consumption modes:

1. **Git submodule** (e.g. a downstream project that vendors all of hydra and runs its own playwright suite over hydra's `tests-playwright/` helpers + globalSetup). Fixed by the change in `hydra/package.json`.
2. **`@volto-hydra/testing` as an npm-style dep** (the new pattern enabled by #212 — `"github:collective/volto-hydra#path:/tests-playwright"`). Fixed by the change in `tests-playwright/package.json`.

## Behaviour after this change

- **Hydra standalone (own CI / dev):** unchanged. pnpm 7+ defaults to `auto-install-peers=true`, so `pnpm install` inside hydra still pulls in `@playwright/test`. `pnpm test:e2e` works exactly as before.

- **Hydra or `@volto-hydra/testing` as a consumer dep:** the consumer sets `auto-install-peers=false` in its root `.npmrc`. The peer is then satisfied by the consumer's own `@playwright/test`; hydra has no separate copy; Node's resolver from inside hydra walks up to the consumer's installed copy. Single physical Playwright instance → no duplicate-import error.

## Test plan

- [x] `pnpm install` inside hydra still installs `@playwright/test` (verified: `hydra/node_modules/@playwright/test` symlink present)
- [x] With `auto-install-peers=false` in the consumer, `pnpm install --dir hydra` does NOT add `hydra/node_modules/@playwright/test` (verified locally in a downstream project)
- [ ] Existing hydra `pnpm test:e2e` runs to completion on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
