### PR TITLE
Moved-content redirects + faithful mock-API/validator for headless

### DIFF
--- a/examples/nuxt-blog-starter/composables/ploneApi.js
+++ b/examples/nuxt-blog-starter/composables/ploneApi.js
@@ -69,7 +69,19 @@ export default async function ploneApi({
     }),
   ).then((entries) => Object.fromEntries(entries.filter(Boolean)));
 
-  return useFetch(api, {
+  // plone.app.redirector 302s moved content (/++api++/old -> /++api++/new).
+  // ofetch auto-follows to valid JSON, so without this the page would render
+  // the new content under the OLD url. Capture the followed-redirect target
+  // and surface it so the page setup can navigateTo() a permanent 301 — the
+  // redirect can't be issued from the ofetch interceptor (it won't propagate
+  // as an SSR redirect).
+  let redirectTarget = null;
+  const toFrontendPath = (u) => u
+    .replace(runtimeConfig.public.backendBaseUrl, '')
+    .replace('/++api++', '')
+    .replace(/\?.*$/, '');
+
+  const result = await useFetch(api, {
     key,
     method: query ? 'POST' : 'GET',
     headers: headers,
@@ -80,6 +92,14 @@ export default async function ploneApi({
     watch: watch,
     default: () => {
       return _default;
+    },
+    onResponse({ response }) {
+      if (response.redirected && response.url) {
+        const target = toFrontendPath(response.url);
+        if (target && !target.startsWith('http') && target !== toFrontendPath(api)) {
+          redirectTarget = target;
+        }
+      }
     },
     onResponseError({ request, response, options }) {
       const error = response._data;
@@ -119,4 +139,13 @@ export default async function ploneApi({
       }
     },
   });
+
+  // Moved content: surface the target so the page setup can navigateTo() it.
+  // Must be issued from the page's setup context for Nuxt to honor the SSR
+  // redirect (not from here, and not from the ofetch interceptor).
+  if (redirectTarget) {
+    result.redirectTo = redirectTarget;
+  }
+
+  return result;
 }

--- a/examples/nuxt-blog-starter/pages/[...slug].vue
+++ b/examples/nuxt-blog-starter/pages/[...slug].vue
@@ -375,14 +375,25 @@ for (var part of route.params.slug) {
     }
 }
 
-// Detect edit mode synchronously at setup time. We need the answer
-// BEFORE the (await ploneApi) below, so we can skip the page fetch.
-// `window.name` is set by the admin before the iframe loads and
-// persists across in-page paging; the `_edit` query string is the
-// SSR-safe fallback but gets dropped by paging URLs.
+// Detect edit mode synchronously at setup time. `window.name` is set
+// by the admin before the iframe loads and persists across in-page
+// paging; the `_edit` query string is the SSR-safe fallback but gets
+// dropped by paging URLs.
 const inEditModeAtSetup =
     route.query._edit === 'true'
     || (typeof window !== 'undefined' && window.name?.startsWith('hydra-edit:'));
+
+// retrieve the data associated with an article
+// based on its slug (pre-loads templates for sync expansion)
+const result = await ploneApi({ path, pages, preloadTemplates });
+
+// Moved content: ploneApi detected the backend's 302 and resolved the
+// new frontend path. Issue a permanent redirect from the page setup
+// (where Nuxt honors SSR redirects) before rendering the old route.
+if (result.redirectTo) {
+  await navigateTo(result.redirectTo, { redirectCode: 301 });
+}
+const { data, error } = result;
 
 // In edit mode the bridge owns the page document — it ships the only
 // copy that carries the `nodeId` attributes selection sync depends on
@@ -395,7 +406,6 @@ const inEditModeAtSetup =
 // strip it down to just the metadata our rules consume; the bridge's
 // onEditChange will replace it with the full nodeId-bearing copy.
 // Site-wide navigation is fetched once by useSiteNav() inside Header.
-const { data, error } = await ploneApi({ path, pages, preloadTemplates });
 if (inEditModeAtSetup && data.value?.page) {
   data.value.page = {
     '@id':   data.value.page['@id'],

--- a/tests-playwright/fixtures/mock-plone-api.cjs
+++ b/tests-playwright/fixtures/mock-plone-api.cjs
@@ -369,6 +369,10 @@ function formatSearchItem(content, baseUrl) {
       ? uidPositionMap[content.UID]
       : null,
     'exclude_from_nav': content.exclude_from_nav === true,
+    // Subject (capital S) is the Plone catalog index name; the @querystring-search
+    // filter reads `item.Subject` for facet.Subject criteria. Populate from the
+    // content's `subjects` field (the lowercase schema field).
+    'Subject': content.subjects || [],
   };
 
   // Match real Plone: always include image_field and image_scales.
@@ -1232,6 +1236,28 @@ app.get('/health', (req, res) => {
 });
 
 /**
+ * Walk every registered content dir and collect unique `subjects` values
+ * across all data.json files. Returns the `{ value: { title } }` shape
+ * Plone's @querystring endpoint uses for the Subject (Keywords) index.
+ */
+function collectSubjectValues() {
+  const subjects = new Set();
+  for (const { dirPath } of Object.values(contentDirMap)) {
+    const dataFile = path.join(dirPath, 'data.json');
+    if (!fs.existsSync(dataFile)) continue;
+    try {
+      const data = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+      for (const s of (data.subjects || [])) {
+        if (typeof s === 'string' && s) subjects.add(s);
+      }
+    } catch { /* ignore malformed data.json */ }
+  }
+  const out = {};
+  for (const s of [...subjects].sort()) out[s] = { title: s };
+  return out;
+}
+
+/**
  * GET /@querystring
  * Get querystring schema (available indexes, operators, sortable indexes)
  * Used by QuerystringWidget to populate criteria and sort dropdowns
@@ -1449,9 +1475,7 @@ app.get('*/@querystring', (req, res) => {
             'operation': 'plone.app.querystring.operation.selection.none',
           },
         },
-        'values': {
-          'main folder': { 'title': 'main folder' },
-        },
+        'values': collectSubjectValues(),
       },
       'Title': {
         'title': 'Title',
@@ -1803,7 +1827,11 @@ app.post('*/@querystring-search', (req, res) => {
   const selectionFields = {
     portal_type: (item) => [item['@type']],
     review_state: (item) => [item.review_state || 'published'],
-    Subject: (item) => item.Subject || [],
+    // Items here come from loadRawContentFromDisk — the raw content schema
+    // field is lowercase `subjects`. The catalog index name `Subject`
+    // (capital S) is only added later by formatSearchItem. Read both so
+    // this works whether the filter runs on raw or brain-formatted items.
+    Subject: (item) => item.subjects || item.Subject || [],
   };
 
   for (const condition of query) {
@@ -1893,6 +1921,9 @@ app.post('*/@querystring-search', (req, res) => {
         const flag = item.exclude_from_nav === true;
         return wantTrue ? flag : !flag;
       });
+      // Note: `review_state` and `Subject` selection.{any,all,none} are
+      // handled generically above via `selectionFields` (which already
+      // maps both indices), so we don't need explicit branches here.
     }
   }
 

--- a/tests-playwright/fixtures/mock-plone-api.cjs
+++ b/tests-playwright/fixtures/mock-plone-api.cjs
@@ -335,8 +335,17 @@ function getPlaceholderImageScales(title, fieldName = 'image') {
  * Includes hasPreviewImage for teaser blocks to show target's preview image
  */
 function formatSearchItem(content, baseUrl) {
-  // Check if content has a preview image (common for Documents, News Items, etc.)
-  const hasPreviewImage = !!(content.preview_image || content['@type'] === 'Image');
+  // Check if content has a preview image (common for Documents, News Items, etc.).
+  // For distribution-style content the preview_image is a blob_path reference;
+  // unless the bytes also exist on disk under the content dir, the mock can't
+  // serve the @@images URL — so don't claim a preview image we can't deliver.
+  const declaresPreview = !!(content.preview_image || content['@type'] === 'Image');
+  let hasPreviewImage = declaresPreview;
+  if (declaresPreview && content.preview_image?.blob_path) {
+    const urlPath = (content['@id'] || '').replace(/^https?:\/\/[^/]+/, '') || '/';
+    const dirInfo = contentDirMap[urlPath];
+    hasPreviewImage = !!(dirInfo && findFirstImageFile(dirInfo.dirPath, 3));
+  }
 
   const item = {
     '@id': content['@id'],
@@ -2218,6 +2227,26 @@ app.get('*/resolveuid/:uid', (req, res) => {
  * Serves actual image files from content directories if they exist,
  * otherwise falls back to placeholder SVGs.
  */
+function findFirstImageFile(rootDir, maxDepth) {
+  const imageExts = new Set(['.svg', '.png', '.jpg', '.jpeg', '.gif', '.webp']);
+  const stack = [{ dir: rootDir, depth: 0 }];
+  while (stack.length) {
+    const { dir, depth } = stack.pop();
+    if (depth > maxDepth) continue;
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isFile() && imageExts.has(path.extname(entry.name).toLowerCase())) {
+        return full;
+      }
+      if (entry.isDirectory()) {
+        stack.push({ dir: full, depth: depth + 1 });
+      }
+    }
+  }
+  return null;
+}
+
 app.get('*/@@images/*', (req, res) => {
   // Extract content path and field name from URL. Serves the same image
   // file regardless of scale — the mock doesn't generate actual scales.
@@ -2242,27 +2271,41 @@ app.get('*/@@images/*', (req, res) => {
   }
   const imageDir = dirInfo ? path.join(dirInfo.dirPath, fieldName) : null;
 
+  const mimeTypes = {
+    '.svg': 'image/svg+xml',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+  };
+  const isImageExt = (ext) => ext in mimeTypes;
+  const serveFile = (imageFile) => {
+    const ext = path.extname(imageFile).toLowerCase();
+    res.set('Content-Type', mimeTypes[ext] || 'application/octet-stream');
+    res.sendFile(imageFile);
+  };
+
   if (imageDir && fs.existsSync(imageDir)) {
     const files = fs.readdirSync(imageDir);
     if (files.length > 0) {
-      const imageFile = path.join(imageDir, files[0]);
-      const ext = path.extname(files[0]).toLowerCase();
-      const mimeTypes = {
-        '.svg': 'image/svg+xml',
-        '.png': 'image/png',
-        '.jpg': 'image/jpeg',
-        '.jpeg': 'image/jpeg',
-        '.gif': 'image/gif',
-        '.webp': 'image/webp',
-      };
-      const contentType = mimeTypes[ext] || 'application/octet-stream';
-      res.set('Content-Type', contentType);
-      res.sendFile(imageFile);
+      serveFile(path.join(imageDir, files[0]));
       return;
     }
   }
 
-  // No image file found — return 404 (don't hide missing images with placeholders)
+  // Fallback for distribution-style content where preview_image is set via
+  // blob_path. The actual bytes live in a nested image content item under
+  // the data dir, e.g. <content>/<screenshot>.png/image/<file>.png.
+  // Walk the dir tree and serve the first image file found (depth-limited).
+  if (dirInfo && fs.existsSync(dirInfo.dirPath)) {
+    const found = findFirstImageFile(dirInfo.dirPath, 3);
+    if (found) {
+      serveFile(found);
+      return;
+    }
+  }
+
   res.status(404).json({
     error: { type: 'NotFound', message: `Image not found: ${req.path}` }
   });

--- a/tests-playwright/fixtures/mock-plone-api.cjs
+++ b/tests-playwright/fixtures/mock-plone-api.cjs
@@ -39,6 +39,31 @@ function parseContentMounts() {
 
 const CONTENT_MOUNTS = parseContentMounts();
 
+/**
+ * Resolve a moved-content redirect, mimicking plone.app.redirector.
+ * Each mount may carry a redirects.json sibling ({ oldPath: newPath },
+ * mount-relative) next to its content dir. Returns the new mount-prefixed
+ * path or null. Read fresh each call (tiny file, only hit on a 404) so dev
+ * edits to redirects.json take effect without a restart.
+ */
+function getRedirectTarget(cleanPath) {
+  for (const { mountPath, dirPath } of CONTENT_MOUNTS) {
+    const redirectsFile = path.join(dirPath, '..', 'redirects.json');
+    if (!fs.existsSync(redirectsFile)) continue;
+    let map;
+    try { map = JSON.parse(fs.readFileSync(redirectsFile, 'utf8')); }
+    catch { continue; }
+    const rel = mountPath === '/'
+      ? cleanPath
+      : (cleanPath.startsWith(mountPath) ? cleanPath.slice(mountPath.length) || '/' : null);
+    if (rel == null) continue;
+    if (map[rel]) {
+      return mountPath === '/' ? map[rel] : mountPath + map[rel];
+    }
+  }
+  return null;
+}
+
 // Validate each mounted content tree at startup. Errors are loud (listed)
 // but non-fatal — tests using the mock API still start. Set
 // SKIP_CONTENT_VALIDATION=true to suppress entirely.
@@ -2471,6 +2496,13 @@ app.get('*', (req, res, next) => {
     }
     res.json(filteredContent);
   } else {
+    // plone.app.redirector: moved content 302s (GET) to the new path, keeping
+    // the ++api++ namespace. The frontend (ploneApi) upgrades this to a 301.
+    const redirectTo = getRedirectTarget(cleanPath);
+    if (redirectTo) {
+      res.redirect(302, `http://localhost:${PORT}/++api++${redirectTo}`);
+      return;
+    }
     res.status(404).json({
       error: {
         type: 'NotFound',

--- a/tests-playwright/fixtures/plone-content-validator.cjs
+++ b/tests-playwright/fixtures/plone-content-validator.cjs
@@ -241,12 +241,24 @@ function checkIntegrity(contentDir) {
   };
 
   // Pass 1: build UID → relpath and path → data
+  // Detect duplicate UIDs as we go — two content items sharing one UID
+  // makes Plone's catalog throw `A different document with value '<UID>'
+  // already exists in the index` during create-site, which silently leaves
+  // half the import incomplete (missing nav items, redirects don't install,
+  // etc.) while the API still responds enough to pass api-wait. Catching
+  // this here turns it into a deploy-blocking validate failure.
   const uidMap = new Map();
   const pathMap = new Map();
   const items = [];
   for (const { rel, data, dir } of walkData(contentDir)) {
     items.push({ rel, data, dir });
-    if (data.UID) uidMap.set(data.UID, rel);
+    if (data.UID) {
+      if (uidMap.has(data.UID)) {
+        errors.push(`  ${rel}: duplicate UID ${data.UID} (also in ${uidMap.get(data.UID)})`);
+      } else {
+        uidMap.set(data.UID, rel);
+      }
+    }
     const atId = data['@id'];
     if (atId) pathMap.set(atId, data);
     pathMap.set('/' + rel.split(path.sep).join('/'), data);

--- a/tests-playwright/fixtures/plone-content-validator.cjs
+++ b/tests-playwright/fixtures/plone-content-validator.cjs
@@ -103,6 +103,33 @@ function validate(contentDir) {
     errors.push("  __metadata__.json has top-level 'content' key — ExportImportMetadata rejects this at site creation. Use 'local_roles' instead.");
   }
 
+  // redirects.json shape: plone.exportimport's set_redirects expects a
+  // flat Dict[str, str] mapping {old_path: new_path}. The REST API's
+  // @aliases response uses an `{items: [{path, redirect-to, ...}]}` array
+  // shape — easy to confuse the two. The importer iterates `data.items()`
+  // and crashes with `'list' object has no attribute 'endswith'` if you
+  // feed it the items-array shape. Catching this here keeps a bad
+  // redirects.json from silently breaking site bootstrap on deploy.
+  const redirectsPath = path.join(parentDir, 'redirects.json');
+  if (fs.existsSync(redirectsPath)) {
+    let redirectsData;
+    try { redirectsData = readJson(redirectsPath); }
+    catch (e) { errors.push(`  redirects.json: invalid JSON (${e.message})`); }
+    if (redirectsData !== undefined) {
+      if (Array.isArray(redirectsData) || typeof redirectsData !== 'object' || redirectsData === null) {
+        errors.push(`  redirects.json: must be a plain {path: target} object, got ${Array.isArray(redirectsData) ? 'array' : typeof redirectsData}`);
+      } else {
+        for (const [key, value] of Object.entries(redirectsData)) {
+          if (typeof value !== 'string') {
+            errors.push(`  redirects.json: value for "${key}" is ${Array.isArray(value) ? 'an array' : typeof value} — use {"/old": "/new"}, not the REST-API {items: [...]} shape`);
+          } else if (!key.startsWith('/') || !value.startsWith('/')) {
+            errors.push(`  redirects.json: paths must be absolute (start with /): ${JSON.stringify(key)} -> ${JSON.stringify(value)}`);
+          }
+        }
+      }
+    }
+  }
+
   // Per-item checks on EVERY data.json in the tree (not just direct children)
   const allUids = new Set();
   for (const { rel, data, dir } of walkData(contentDir)) {

--- a/tests-playwright/fixtures/plone-content-validator.cjs
+++ b/tests-playwright/fixtures/plone-content-validator.cjs
@@ -303,27 +303,43 @@ function checkIntegrity(contentDir) {
     }
   }
 
-  // Pass 2c: Internal link refs in blocks (image.url paths, teaser/button hrefs)
+  // Pass 2c: Internal link refs in blocks. Covers any block's plain `url`
+  // string (image, hero, button, ...) and `href` link-object arrays
+  // (teaser/button/cta), walking nested blocks (sections, grids, columns)
+  // — not just the top level, so a broken CTA inside a section is caught too.
+  const isInternalPath = (u) =>
+    typeof u === 'string' && u.startsWith('/') &&
+    !u.includes('resolveuid') && !u.includes('@@') && !u.includes('/++');
+
+  function* walkBlocks(blocks) {
+    for (const [bid, block] of Object.entries(blocks || {})) {
+      if (!block || typeof block !== 'object') continue;
+      yield [bid, block];
+      if (block.blocks && typeof block.blocks === 'object') {
+        yield* walkBlocks(block.blocks);
+      }
+    }
+  }
+
   for (const { rel, data } of items) {
-    const blocks = data.blocks || {};
-    for (const [bid, block] of Object.entries(blocks)) {
-      if (block && block['@type'] === 'image') {
-        const url = block.url;
-        if (typeof url === 'string' && url.startsWith('/') && !url.includes('resolveuid')) {
-          if (pathMap.has(url)) {
-            stats.linksOk += 1;
-          } else {
-            warnings.push(`  ${rel}: image block ${bid} references missing path: ${url}`);
-            stats.linksBroken += 1;
-          }
+    for (const [bid, block] of walkBlocks(data.blocks)) {
+      // Plain string url on any block (hero CTA, image, button-with-url, ...)
+      if (isInternalPath(block.url)) {
+        if (pathMap.has(block.url)) {
+          stats.linksOk += 1;
+        } else {
+          warnings.push(`  ${rel}: block ${bid} (${block['@type']}) url references missing: ${block.url}`);
+          stats.linksBroken += 1;
         }
       }
-      const href = block && block.href;
-      if (Array.isArray(href)) {
-        for (const h of href) {
-          if (h && typeof h === 'object') {
-            const linkId = h['@id'] || '';
-            if (typeof linkId === 'string' && linkId.startsWith('/') && !pathMap.has(linkId)) {
+      // href link-object arrays (teaser/button/cta)
+      if (Array.isArray(block.href)) {
+        for (const h of block.href) {
+          const linkId = (h && typeof h === 'object') ? (h['@id'] || '') : '';
+          if (isInternalPath(linkId)) {
+            if (pathMap.has(linkId)) {
+              stats.linksOk += 1;
+            } else {
               warnings.push(`  ${rel}: block ${bid} href references missing: ${linkId}`);
               stats.linksBroken += 1;
             }


### PR DESCRIPTION
## Why

Building a real, distribution-based headless site on top of hydra exercised the test harness far harder than the docs fixtures do — and exposed several places where the **mock API diverged from real Plone**, plus a missing redirect pattern in the reference example. Each divergence either hid a real bug or made a real Plone behaviour untestable. This PR closes those gaps so:

1. the mock API behaves like Plone for redirects, tag facets, and preview images;
2. the content validator catches two import-breaking mistakes before deploy;
3. the `nuxt-blog-starter` example demonstrates the canonical moved-content redirect handling so headless adopters get SEO redirects out of the box.

## What changed

### Moved-content redirects (the headline)
Real Plone (`plone.app.redirector`) issues a `302` for moved content, and Volto's API layer upgrades that to a browser `301`. Two pieces were missing:

- **mock-api** (`tests-playwright/fixtures/mock-plone-api.cjs`): on a content `404`, consult a `redirects.json` sibling of the mount's content dir and `302` to `/++api++/<new>` — replicating `plone.app.redirector` so the whole redirect path is testable **without a live Plone**.
- **example** (`examples/nuxt-blog-starter`): `ploneApi` detects the followed `302` (`response.redirected` + `response.url`, stripped of base + `++api++`) and surfaces `redirectTo`; `[...slug].vue` re-issues it as a permanent `301` from page setup. Note the subtlety baked into the comments: `navigateTo` only propagates as an SSR redirect from the **page setup chain** — not from the ofetch interceptor (silently no-ops) and not from inside the composable (throws a 500).

### mock-api fidelity (`tests-playwright/fixtures/mock-plone-api.cjs`)
- **Subject facets**: derive the `Subject` (Keywords) vocabulary from the actual `subjects` across content instead of a hardcoded value, expose `Subject` on catalog brains, and make the `@querystring-search` Subject filter read the raw `subjects` field. Lets facet/filter UIs be tested against real tag data.
- **Preview images**: serve `preview_image` referenced via `blob_path` (distribution content stores the bytes in a nested image item, not a per-field dir) and stop emitting `hasPreviewImage: true` for content the mock can't actually serve — killing both false-negative and false-positive image-integrity failures.

### Validator (`tests-playwright/fixtures/plone-content-validator.cjs`)
- Flag **duplicate UIDs** across the content tree — a duplicate silently aborted `create-site` import mid-way, leaving a partial site.
- Enforce that `redirects.json` is a **flat `{ path: target }` dict** — the shape `plone.exportimport`'s importer actually expects (anything else imports zero redirects, silently).

### hydra-js (`packages/hydra-js/hydra.src.js`)
- Guard `window` access in `log()` so importing the bridge during SSR (e.g. a Nuxt/Next frontend) doesn't throw.

## Test plan
- [ ] Existing Playwright suites stay green
- [ ] mock-api: `GET /++api++/<moved-path>` → `302` to the new path when a `redirects.json` is mounted; unmoved path still `404`
- [ ] mock-api: `@querystring` Subject vocabulary reflects content tags; `facet.Subject` filters results
- [ ] mock-api: a `blob_path` `preview_image` serves bytes; content with no on-disk image reports `hasPreviewImage: false`
- [ ] validator: flags duplicate UIDs and a non-flat `redirects.json`
- [ ] nuxt-blog-starter: moved URL `301`s to the new path, a real page stays `200`

## Note for reviewers
The branch name (`fix/validate-redirects-shape`) predates the scope — it started as the redirects.json shape check and grew into the broader harness-fidelity + redirect work above. Happy to split if preferred; the changes are cohesive (all "make the harness model real Plone, and ship the redirect pattern in the example").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
