### PR TITLE
docs: explain the optional core/ Volto checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ RAZZLE_API_PATH="http://localhost:8080/Plone" RAZZLE_DEFAULT_IFRAME_URL=http://l
 
 Log in at <http://localhost:3001>.
 
+### Optional: clone Volto source for IDE navigation
+
+`@plone/volto` is installed from npm, but its source is unzipped deep in `node_modules/.pnpm/@plone+volto@…/`, which is awkward to navigate in an editor. If you want to read or grep the Volto source at the version this repo pins, clone the matching tag into `core/` next to the workspace:
+
+```bash
+# Match the version pinned in package.json
+git clone --branch 18.31.0 --depth 1 https://github.com/plone/volto.git core
+```
+
+`core/` is `.gitignore`d and not part of the pnpm workspace — the build always uses the npm `@plone/volto`. The local checkout is purely a developer convenience for code reading; remove or skip it if you don't need it.
+
 ### Run only your frontend, against the deployed CMS
 
 If you don't want to run Plone + Hydra locally and just want to develop your frontend against the deployed admin:


### PR DESCRIPTION
## Why

`core/` is `.gitignore`d but its purpose isn't documented anywhere — nothing in this repo tells a new contributor that they could optionally clone `plone/volto` into `core/` for IDE source navigation. Today, anyone running `pnpm install` for the first time has no idea this option exists, and people poking around find a stray `core/.git` from somebody else's local clone with no context.

## What changed

`README.md`: one new subsection under "Run locally for development" — "Optional: clone Volto source for IDE navigation" — explaining:

- Why you'd want it (npm Volto source lives at an awkward `.pnpm` path)
- How to clone it at the matching version
- That `core/` is `.gitignore`d and not in the pnpm workspace — purely a developer convenience

No code or build changes; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
