### PR TITLE
hydra: stop mutating host-page CSS (position, min-height, hover border)

### DIFF
--- a/packages/hydra-js/hydra.src.js
+++ b/packages/hydra-js/hydra.src.js
@@ -4527,29 +4527,6 @@ export class Bridge {
     }
   }
 
-  /**
-   * Handles timeout when a Slate transform takes too long to respond.
-   * Shows error state and permanently disables editing to prevent data corruption.
-   *
-   * @param {string} blockId - Block UID that timed out
-   */
-  handleTransformTimeout(blockId) {
-    const block = this.queryBlockElement(blockId);
-    const editableField = block ? this.getOwnFirstEditableField(block) : null;
-
-    if (editableField) {
-      // Show error state - permanently disable editing
-      editableField.setAttribute('contenteditable', 'false');
-      editableField.style.cursor = 'not-allowed';
-      editableField.style.opacity = '0.5';
-      editableField.title =
-        'Transform timeout - refresh page to continue editing';
-    }
-
-    console.error('[HYDRA] Transform timeout for block:', blockId);
-    this.pendingTransform = null;
-  }
-
   ////////////////////////////////////////////////////////////////////////////////
   // Whitespace & Zero-Width Space (ZWS) Strategy
   //
@@ -5889,13 +5866,12 @@ export class Bridge {
       log(`activateEditableField: focused field`);
     }
 
-    // Hide placeholder on focus — remove data-empty so CSS ::before hides
-    fieldElement.removeAttribute('data-empty');
-    // Re-add on blur if still empty
-    if (!fieldElement._placeholderBlurHandler) {
-      fieldElement._placeholderBlurHandler = () => this.updateEmptyState(fieldElement);
-      fieldElement.addEventListener('blur', fieldElement._placeholderBlurHandler);
-    }
+    // Make sure data-empty reflects current text content. data-empty no
+    // longer flips based on focus — the placeholder ::before is held
+    // invisible by :focus::before { visibility: hidden } and its
+    // layout space keeps the field's height stable across focus,
+    // empty-typing, and content states without any host-CSS rule.
+    this.updateEmptyState(fieldElement);
 
     // If field was already editable AND already focused, browser already handled
     // cursor positioning on click - don't redo it (causes race with typing)
@@ -10952,9 +10928,14 @@ export class Bridge {
    * Checks three sources in priority order:
    * 1. Instance-level: block.fieldPlaceholders[fieldName] (from template authoring)
    * 2. Schema-level: resolvedBlockSchema.properties[fieldName].placeholder
+   * 3. Universal fallback: 'Click to edit' — ensures every empty
+   *    editable field has something rendered via ::before, which in turn
+   *    gives the host element natural height. Without the fallback, plain
+   *    div wrappers (slate blocks) collapse to 0px when empty and we have
+   *    to force host CSS to keep them clickable.
    * @param {string} blockUid - The block UID
    * @param {string} fieldName - The field name
-   * @returns {string|undefined} Placeholder text or undefined
+   * @returns {string} Placeholder text (never undefined — universal fallback)
    */
   getFieldPlaceholder(blockUid, fieldName) {
     const resolved = this.resolveFieldPath(fieldName, blockUid);
@@ -10973,7 +10954,9 @@ export class Bridge {
     }
     // 2. Schema-level placeholder
     const fieldDef = this.getBlockSchema(resolved.blockId)?.properties?.[resolved.fieldName];
-    return fieldDef?.placeholder || undefined;
+    if (fieldDef?.placeholder) return fieldDef.placeholder;
+    // 3. Universal fallback
+    return 'Click to edit';
   }
 
   /**
@@ -10988,7 +10971,13 @@ export class Bridge {
     // it would flash between keystrokes as the user types/deletes.
     const doc = field.ownerDocument;
     const isFocused = doc && (doc.activeElement === field || field.contains(doc.activeElement));
-    field.toggleAttribute('data-empty', isEmpty && !isFocused);
+    // data-empty depends purely on whether the field has content. We
+    // do NOT toggle it based on focus — keeping it set even during
+    // focus means the placeholder ::before stays in the layout (held
+    // invisible by :focus::before { visibility: hidden }). That keeps
+    // the field's height stable across unfocused / focused / typing
+    // without any host-CSS min-height override.
+    field.toggleAttribute('data-empty', isEmpty);
   }
 
   /**
@@ -11737,72 +11726,51 @@ export class Bridge {
         [contenteditable] {
           outline: 0px solid transparent;
         }
-        /* Placeholder text for empty editable fields — keeps them visible/clickable */
+        /* Placeholder text for empty editable fields. The ::before is in
+           normal flow (no position: absolute) so the placeholder text
+           contributes its natural line-height to the parent. That holds
+           the field open at exactly one line of text — same height
+           whether the placeholder is visible (unfocused), invisible
+           (focused), or replaced by typed content (single line). No
+           min-height override needed. */
         [data-edit-text][data-placeholder][data-empty]::before {
           content: attr(data-placeholder);
           color: #aaa;
           font-style: italic;
           pointer-events: none;
-          position: absolute;
         }
-        /* Hide placeholder when field is focused (user is editing) */
+        /* Hide the placeholder TEXT while the user is focused, but keep
+           the ::before in layout (visibility:hidden, NOT display:none) so
+           the parent's height stays the same. The bridge no longer needs
+           to mutate host CSS to keep the focused-empty field clickable —
+           the invisible ::before is doing the job. */
         [data-edit-text][data-placeholder][data-empty]:focus::before {
-          display: none;
+          visibility: hidden;
         }
-        /* Empty editable fields — reserve height so the field stays clickable
-           and the placeholder text (rendered via the absolutely-positioned
-           ::before above) doesn't overlap adjacent content. The pseudo-element
-           is out of the normal flow so the parent must explicitly reserve
-           space; without min-height, an empty field with a placeholder
-           collapses to 0px even though the placeholder appears to render. */
-        [data-edit-text][data-empty] {
-          position: relative;
-          min-height: 1.5em;
-        }
-        /* Linkable field hover styles - indicate clickable link areas */
+        /* Linkable field hover styles - indicate clickable link areas.
+           Uses CSS outline (renders outside the box, ignores layout) so the
+           host element position is NOT mutated. */
         /* Exclude fields inside readonly blocks (listing items, non-overwrite teasers) */
         [data-edit-link]:not([data-block-readonly] [data-edit-link]):not([data-block-readonly][data-edit-link]) {
           cursor: pointer;
-          position: relative;
         }
-        [data-edit-link]:not([data-block-readonly] [data-edit-link]):not([data-block-readonly][data-edit-link]):hover::after {
-          content: "";
-          position: absolute;
-          inset: -2px;
-          border: 2px dashed rgba(0, 126, 177, 0.5);
+        [data-edit-link]:not([data-block-readonly] [data-edit-link]):not([data-block-readonly][data-edit-link]):hover {
+          outline: 2px dashed rgba(0, 126, 177, 0.5);
+          outline-offset: 2px;
           border-radius: 4px;
-          pointer-events: none;
         }
-        /* Media field hover styles - indicate clickable image areas */
+        /* Media field hover styles - indicate clickable image areas.
+           Same outline approach — host CSS untouched. */
         /* Exclude fields inside readonly blocks */
         [data-edit-media]:not([data-block-readonly] [data-edit-media]):not([data-block-readonly][data-edit-media]) {
           cursor: pointer;
-          position: relative;
         }
-        [data-edit-media]:not([data-block-readonly] [data-edit-media]):not([data-block-readonly][data-edit-media]):hover::after {
-          content: "";
-          position: absolute;
-          inset: -2px;
-          border: 2px dashed rgba(120, 192, 215, 0.5);
+        [data-edit-media]:not([data-block-readonly] [data-edit-media]):not([data-block-readonly][data-edit-media]):hover {
+          outline: 2px dashed rgba(120, 192, 215, 0.5);
+          outline-offset: 2px;
           border-radius: 4px;
-          pointer-events: none;
         }
         /* Readonly block styles are applied dynamically via applyReadonlyVisuals() */
-        .volto-hydra--outline {
-          position: relative !important;
-        }
-        .volto-hydra--outline:before {
-          content: "";
-          position: absolute;
-          top: -1px;
-          left: -1px;
-          right: -1px;
-          bottom: -1px;
-          border: 2px solid rgba(120,192,215,.75);
-          border-radius: 6px;
-          pointer-events: none;
-          z-index: 5;
-        }
         .volto-hydra-add-button {
           position: absolute;
           background: none;
@@ -11892,12 +11860,6 @@ export class Bridge {
           opacity: 0.5;
           pointer-events: none;
           z-index: 1000;
-        }
-        .highlighted-block {
-          border-top: 5px solid blue; 
-        }
-        .highlighted-block-bottom {
-          border-bottom: 5px solid blue;
         }
         .link-input-container {
           position: absolute;

--- a/packages/hydra-js/hydra.src.js
+++ b/packages/hydra-js/hydra.src.js
@@ -11747,6 +11747,21 @@ export class Bridge {
         [data-edit-text][data-placeholder][data-empty]:focus::before {
           visibility: hidden;
         }
+        /* If the frontend renders its own empty-paragraph placeholder
+           inside the editable field (e.g. Slate's <p><br></p> convention
+           which contributes one line of layout via the <br> and any ZWS
+           the bridge has inserted for cursor preservation), don't ALSO
+           render the bridge's ::before placeholder — it would stack on
+           top of the empty paragraph and the field would be 2 lines tall
+           when empty but 1 line tall after the first keystroke. We only
+           suppress ::before when the editable has a NON-EMPTY child
+           element (one that itself has children/text). A truly bare
+           <p></p> doesn't provide layout, so ::before still fires for it
+           (covers the fixture-empty case where the frontend renders no
+           empty-paragraph marker). */
+        [data-edit-text][data-placeholder][data-empty]:has(*:not(:empty))::before {
+          content: none;
+        }
         /* Linkable field hover styles - indicate clickable link areas.
            Uses CSS outline (renders outside the box, ignores layout) so the
            host element position is NOT mutated. */

--- a/tests-playwright/integration/host-css-preservation.spec.ts
+++ b/tests-playwright/integration/host-css-preservation.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests that Hydra does NOT silently mutate host-page CSS.
+ *
+ * Regression coverage for the "Hydra is messing with css like position when
+ * it should never do that" bug. The bridge was setting `position: relative`
+ * on every `[data-edit-media]` and `[data-edit-link]` host element through
+ * its injected stylesheet, just to anchor a `:hover::after` dashed border.
+ * That mutation applied to EVERY matching element on every page load and
+ * could silently break any frontend layout that relies on a different
+ * position value.
+ *
+ * Note: `ensureElementsHaveMinSize` (which DOES write inline min-width /
+ * min-height) is intentionally left in place — it only fires for truly
+ * zero-sized elements (e.g., an empty `<img>` with no src) where the
+ * frontend has already failed to give the user a clickable target. The
+ * second test below asserts that a non-zero-sized image (the hero image)
+ * is NOT touched, which is the contract: Hydra rescues zero-size cases,
+ * Hydra does not edit working layouts.
+ */
+import { test, expect } from '../fixtures';
+import { AdminUIHelper } from '../helpers/AdminUIHelper';
+
+const HERO_MEDIA = '[data-block-uid="block-4-hero"] [data-edit-media="image"]';
+const HERO_LINK = '[data-block-uid="block-4-hero"] [data-edit-link="buttonLink"]';
+
+test.describe('Hydra must not mutate host-page CSS', () => {
+  test('host [data-edit-media] keeps the frontend computed `position` (no forced relative)', async ({
+    page,
+  }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/test-page');
+
+    const iframe = helper.getIframe();
+    const heroImage = iframe.locator(HERO_MEDIA);
+    await expect(heroImage).toBeVisible();
+
+    // The test frontend renders the hero image with NO position style — so
+    // its computed position must be the browser default (`static`). If Hydra
+    // is forcing position:relative through its injected stylesheet, this
+    // assertion fails — which is what we want it to do until the bridge is
+    // fixed to use `outline` (or some other non-mutating affordance).
+    const computedPosition = await heroImage.evaluate(
+      (el) => window.getComputedStyle(el).position,
+    );
+    expect(computedPosition).toBe('static');
+  });
+
+  test('working-size host [data-edit-media] is NOT touched by ensureElementsHaveMinSize', async ({
+    page,
+  }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/test-page');
+
+    const iframe = helper.getIframe();
+    const heroImage = iframe.locator(HERO_MEDIA);
+    await expect(heroImage).toBeVisible();
+
+    // The hero image renders at non-zero size (it has a src). The contract:
+    // Hydra's ensureElementsHaveMinSize rescues ONLY truly zero-sized
+    // elements; it must leave working ones alone. So the hero image must
+    // have nothing in its inline style.minWidth / style.minHeight.
+    //
+    // The empty-image rescue path is exercised separately by the existing
+    // container-blocks test ("an empty image block gets a minimum size...").
+    const inlineMinWidth = await heroImage.evaluate(
+      (el) => (el as HTMLElement).style.minWidth,
+    );
+    const inlineMinHeight = await heroImage.evaluate(
+      (el) => (el as HTMLElement).style.minHeight,
+    );
+    expect(inlineMinWidth).toBe('');
+    expect(inlineMinHeight).toBe('');
+  });
+
+  test('host [data-edit-link] keeps the frontend computed `position` (no forced relative)', async ({
+    page,
+  }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/test-page');
+
+    const iframe = helper.getIframe();
+    const heroLink = iframe.locator(HERO_LINK);
+    await expect(heroLink.first()).toBeVisible();
+
+    const computedPosition = await heroLink.first().evaluate(
+      (el) => window.getComputedStyle(el).position,
+    );
+    expect(computedPosition).toBe('static');
+  });
+
+  test('host empty [data-edit-text] keeps the frontend computed `position` (no forced relative)', async ({
+    page,
+  }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/test-page');
+
+    const iframe = helper.getIframe();
+
+    // The hero buttonText field has no schema-defined placeholder, so it
+    // exercises the universal-fallback path. Clear it so it's data-empty.
+    const buttonField = iframe.locator(
+      '[data-block-uid="block-4-hero"] [data-edit-text="buttonText"]',
+    );
+    await expect(buttonField).toBeVisible();
+    await buttonField.click();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.press('Backspace');
+    // Click another block to blur so updateEmptyState applies data-empty.
+    await helper.clickBlockInIframe('block-1-uuid');
+    await expect(buttonField).toHaveAttribute('data-empty', '', { timeout: 5000 });
+
+    // Even in the data-empty state, the host element's `position` must NOT
+    // be forced to `relative` by the bridge. The frontend's natural styling
+    // (no position set) should give `static`.
+    const computedPosition = await buttonField.evaluate(
+      (el) => window.getComputedStyle(el).position,
+    );
+    expect(computedPosition).toBe('static');
+  });
+});

--- a/tests-playwright/integration/inline-editing-fields.spec.ts
+++ b/tests-playwright/integration/inline-editing-fields.spec.ts
@@ -118,43 +118,42 @@ test.describe('Inline editing - linkable/media fields', () => {
     await expect(linkButton).toBeVisible();
   });
 
-  test('hover state shows dashed border on linkable field', async ({ page }) => {
+  test('hover state shows dashed outline on linkable field', async ({ page }) => {
+    // The hover affordance is now drawn with CSS `outline` (renders
+    // outside the box, no layout impact) instead of a positioned
+    // `::after` pseudo-element. The visual is the same — dashed cyan
+    // border — but the host element's `position` is no longer forced
+    // to relative just to anchor the pseudo. See host-css-preservation
+    // spec for the regression that drove the change.
     const helper = new AdminUIHelper(page);
 
     await helper.login();
     await helper.navigateToEdit('/test-page');
 
-    // Hover over the linkable element
     const iframe = helper.getIframe();
     const linkableElement = iframe.locator('[data-edit-link="buttonLink"]');
     await linkableElement.hover();
 
-    // Check that the ::after pseudo-element creates a dashed border
-    // We verify by checking computed style
-    const hasHoverStyle = await linkableElement.evaluate((el) => {
-      const afterStyle = window.getComputedStyle(el, '::after');
-      return afterStyle.borderStyle.includes('dashed');
-    });
-    expect(hasHoverStyle).toBe(true);
+    const outlineStyle = await linkableElement.evaluate(
+      (el) => window.getComputedStyle(el).outlineStyle,
+    );
+    expect(outlineStyle).toBe('dashed');
   });
 
-  test('hover state shows dashed border on media field', async ({ page }) => {
+  test('hover state shows dashed outline on media field', async ({ page }) => {
     const helper = new AdminUIHelper(page);
 
     await helper.login();
     await helper.navigateToEdit('/test-page');
 
-    // Hover over the media element (scope to hero block to avoid strict mode violation)
     const iframe = helper.getIframe();
     const heroBlock = iframe.locator('[data-block-uid="block-4-hero"]');
     const mediaElement = heroBlock.locator('[data-edit-media="image"]');
     await mediaElement.hover();
 
-    // Check that the ::after pseudo-element creates a dashed border
-    const hasHoverStyle = await mediaElement.evaluate((el) => {
-      const afterStyle = window.getComputedStyle(el, '::after');
-      return afterStyle.borderStyle.includes('dashed');
-    });
-    expect(hasHoverStyle).toBe(true);
+    const outlineStyle = await mediaElement.evaluate(
+      (el) => window.getComputedStyle(el).outlineStyle,
+    );
+    expect(outlineStyle).toBe('dashed');
   });
 });

--- a/tests-playwright/integration/inline-editing-placeholders.spec.ts
+++ b/tests-playwright/integration/inline-editing-placeholders.spec.ts
@@ -55,14 +55,15 @@ test.describe('Inline Editing - Placeholders', () => {
     // Verify text is actually cleared in the DOM
     await expect(headingField).toHaveText('', { timeout: 3000 });
 
-    // Field is focused, so data-empty should NOT be set (placeholder hidden during editing)
-    await expect(headingField).not.toHaveAttribute('data-empty', '');
+    // data-empty now depends purely on whether the field has content —
+    // NOT on whether it's focused. The placeholder ::before is held
+    // invisible by `:focus::before { visibility: hidden }` while the
+    // user is editing, so it doesn't visually appear, but the layout
+    // space is preserved and the attribute stays set.
+    await expect(headingField).toHaveAttribute('data-empty', '', { timeout: 3000 });
 
-    // Click a different block to blur and let the cleared value sync via FORM_DATA
+    // After blur the placeholder ::before becomes visible again.
     await helper.clickBlockInIframe('block-1-uuid');
-
-    // After FORM_DATA re-render, applyPlaceholders should set data-empty on the
-    // now-empty heading field (even though the hero block is not selected)
     await expect(headingField).toHaveAttribute('data-empty', '', { timeout: 5000 });
   });
 
@@ -175,7 +176,13 @@ test.describe('Inline Editing - Placeholders', () => {
     await expect(headingField).toContainText('New heading');
   });
 
-  test('field without schema placeholder has no data-placeholder attribute', async ({ page }) => {
+  test('field with no schema placeholder gets the universal "Click to edit" fallback', async ({ page }) => {
+    // Hydra ships a universal placeholder fallback so EVERY editable text
+    // field has something rendered when empty. This both gives the field
+    // natural height (via the ::before flow, removing the need to force
+    // host CSS) and gives the user a hint they can click. The fallback is
+    // applied in getFieldPlaceholder when neither the instance template
+    // nor the schema defines one.
     const helper = new AdminUIHelper(page);
     await helper.login();
     await helper.navigateToEdit('/test-page');
@@ -183,15 +190,76 @@ test.describe('Inline Editing - Placeholders', () => {
     const iframe = helper.getIframe();
     const blockId = 'block-4-hero';
 
-    // Select the hero block
     await helper.clickBlockInIframe(blockId);
 
-    // Hero buttonText field has no placeholder in schema
+    // Hero buttonText field has no placeholder in schema — it must still
+    // receive the universal fallback.
     const buttonField = iframe.locator(`[data-block-uid="${blockId}"] [data-edit-text="buttonText"]`);
     await expect(buttonField).toBeVisible();
-    const hasPlaceholder = await buttonField.evaluate(el => el.hasAttribute('data-placeholder'));
-    expect(hasPlaceholder).toBe(false);
+    await expect(buttonField).toHaveAttribute('data-placeholder', 'Click to edit');
   });
+
+  test('field height stays constant across unfocused-empty, focused-empty, and one-line typed states', async ({ page }) => {
+    // The whole point of switching the placeholder ::before to
+    // `:focus::before { visibility: hidden }` (instead of display:none)
+    // is that the bridge stops mutating host CSS to keep the focused-
+    // empty field clickable. The invisible ::before holds the line open
+    // at the natural line-height of the frontend's font — so the height
+    // is the same in all three states:
+    //
+    //   (a) empty + unfocused  → placeholder visible (::before visible)
+    //   (b) empty + focused    → placeholder invisible (::before hidden but in layout)
+    //   (c) one line of typed text → content provides the height
+    //
+    // If a future change re-introduces `display: none` on the focus
+    // pseudo, or adds an unnecessary host-CSS min-height override, the
+    // heights diverge and this test catches it.
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/test-page');
+
+    const iframe = helper.getIframe();
+    const blockId = 'block-1-uuid'; // Slate block (plain div wrapper)
+    const editField = iframe.locator(
+      `[data-block-uid="${blockId}"][data-edit-text="value"], [data-block-uid="${blockId}"] [data-edit-text="value"]`,
+    ).first();
+
+    // (a) Empty + unfocused. Clear text, then click ANOTHER block to
+    // blur. updateEmptyState applies data-empty; placeholder ::before
+    // renders the schema-defined "Type text…" hint in normal flow.
+    await helper.clickBlockInIframe(blockId);
+    await editField.click();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.press('Backspace');
+    await expect(editField).toHaveText('', { timeout: 3000 });
+    await helper.clickBlockInIframe('block-2-uuid');
+    await expect(editField).toHaveAttribute('data-empty', '', { timeout: 3000 });
+    const unfocusedEmptyBox = await editField.boundingBox();
+    expect(unfocusedEmptyBox).not.toBeNull();
+    expect(unfocusedEmptyBox!.height).toBeGreaterThan(10);
+
+    // (b) Empty + focused. Click back into the field. data-empty stays
+    // set (we no longer toggle it on focus); :focus::before hides the
+    // placeholder TEXT via visibility:hidden but the layout space stays.
+    await editField.click();
+    const focusedEmptyBox = await editField.boundingBox();
+    expect(focusedEmptyBox).not.toBeNull();
+    expect(focusedEmptyBox!.height).toBeGreaterThan(10);
+    // Height must NOT jump between unfocused-empty and focused-empty.
+    expect(Math.abs(focusedEmptyBox!.height - unfocusedEmptyBox!.height)).toBeLessThan(2);
+
+    // (c) After the first keystroke. data-empty toggles off, ::before
+    // disappears, content provides the height. Single-line typed text
+    // sits at the same line-height as the placeholder did.
+    await page.keyboard.type('x');
+    await expect(editField).not.toHaveAttribute('data-empty', '', { timeout: 3000 });
+    const typedBox = await editField.boundingBox();
+    expect(typedBox).not.toBeNull();
+    expect(typedBox!.height).toBeGreaterThan(10);
+    // Height must NOT jump from focused-empty to one-line typed.
+    expect(Math.abs(typedBox!.height - focusedEmptyBox!.height)).toBeLessThan(2);
+  });
+
 
   test('slate block shows Type text placeholder from schema', async ({ page }) => {
     const helper = new AdminUIHelper(page);


### PR DESCRIPTION
## Summary

- Stops the bridge from mutating host-page CSS. The injected stylesheet was forcing `position: relative` on every `[data-edit-media]`, `[data-edit-link]`, and empty `[data-edit-text]` host element — only so a `:hover::after` border or absolutely-positioned placeholder `::before` could anchor. Frontends that set their own position on these elements were silently overridden (the reported bug was around images).
- Hover affordance now uses CSS `outline` instead of `:hover::after` — renders outside the box, ignores layout, needs no positioned parent. Visual unchanged.
- Universal `Click to edit` fallback in `getFieldPlaceholder` so every empty editable field has a `::before` placeholder. The placeholder text is in normal flow, so its line-height holds the field open without any `min-height` override on the host.
- `:focus::before` switched from `display: none` to `visibility: hidden` — placeholder text is hidden while the user is focused, but its layout space remains. Field height stays identical across unfocused-empty, focused-empty, and one-line typed states.
- Dead code removed: `.volto-hydra--outline` and `.highlighted-block` CSS rules (no JS adds either class); `handleTransformTimeout` function (no callers).

## Test plan

- [x] New `tests-playwright/integration/host-css-preservation.spec.ts` — asserts host `[data-edit-media]`, `[data-edit-link]`, and empty `[data-edit-text]` keep `computed style.position === 'static'`; working-size media is not touched by `ensureElementsHaveMinSize`.
- [x] `inline-editing-placeholders.spec.ts` — height-stable test asserts `boundingBox().height` stays within ±2px across unfocused-empty → focused-empty → first-keystroke.
- [x] `inline-editing-placeholders.spec.ts:34` — updated to the new contract (`data-empty` reflects content, not focus).
- [x] `inline-editing-fields.spec.ts` — hover tests updated to assert `computed style.outlineStyle === 'dashed'`.
- [x] Directly-affected suites: 19/19 ✓
- [x] Broader regression sweep over `inline-editing-*`, `block-selection`, `container-blocks`, `inline-media-link-editing`: 292 pass / 4 skipped / 0 actual failures (1 known prospective-formatting flake confirmed by 3× retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)