### PR TITLE
fix(flattenScales): stop mutating frozen Redux image_scales

### DIFF
--- a/packages/volto-hydra/src/customizations/volto/helpers/Url/Url.js
+++ b/packages/volto-hydra/src/customizations/volto/helpers/Url/Url.js
@@ -332,17 +332,27 @@ export function flattenScales(path, image) {
   if (!image) return;
 
   const basePath = image.base_path || path;
+  // HYDRA: build a NEW scales object rather than mutating in place. The image
+  // data arrives FROZEN from the Redux store, so assigning to
+  // scales[key].download throws "Cannot assign to read only property
+  // 'download'" — surfaced via react-beautiful-dnd's error boundary when an
+  // image block / image-led teaser is selected for editing.
+  const sourceScales = image.scales || {};
+  const scales = {};
+  Object.keys(sourceScales).forEach((key) => {
+    scales[key] = {
+      ...sourceScales[key],
+      download: flattenToAppURL(
+        removeObjectIdFromURL(basePath, sourceScales[key].download),
+      ),
+    };
+  });
+
   const imageInfo = {
     ...image,
-    scales: image.scales || {},
+    scales,
     download: flattenToAppURL(removeObjectIdFromURL(basePath, image.download)),
   };
-
-  Object.keys(imageInfo.scales).forEach((key) => {
-    imageInfo.scales[key].download = flattenToAppURL(
-      removeObjectIdFromURL(basePath, image.scales[key].download),
-    );
-  });
 
   return imageInfo;
 }

--- a/packages/volto-hydra/src/customizations/volto/helpers/Url/Url.test.js
+++ b/packages/volto-hydra/src/customizations/volto/helpers/Url/Url.test.js
@@ -17,7 +17,7 @@
 import Cookies from 'js-cookie';
 import config from '@plone/volto/registry';
 import { getSavedUrlsCookieName } from '../../../../utils/cookieNames';
-import { flattenToAppURL, isInternalURL } from './Url';
+import { flattenToAppURL, isInternalURL, flattenScales } from './Url';
 
 beforeEach(() => {
   // Make config.settings deterministic — flattenToAppURL strips these
@@ -72,5 +72,44 @@ describe('isInternalURL (Hydra shadow)', () => {
 
   it('still rejects unknown absolute URLs', () => {
     expect(isInternalURL('https://elsewhere.example.org/x')).toBe(false);
+  });
+});
+
+// Deep-freeze, the way the Redux store hands block/image data to the editor.
+const deepFreeze = (o) => {
+  if (o && typeof o === 'object') {
+    Object.values(o).forEach(deepFreeze);
+    Object.freeze(o);
+  }
+  return o;
+};
+
+describe('flattenScales (Hydra shadow) — frozen image data', () => {
+  // Regression: image-led teasers carry `image_scales`; the data arrives FROZEN
+  // from the store. flattenScales aliased image.scales and then mutated
+  // scales[key].download in place → "Cannot assign to read only property
+  // 'download'", surfaced by react-beautiful-dnd's error boundary when editing
+  // a teaser inside a gridBlock.
+  it('does not mutate the frozen input (no read-only download error)', () => {
+    const image = deepFreeze({
+      'content-type': 'image/jpeg',
+      download: 'http://api.localhost/Plone/work/@@images/image.jpeg',
+      scales: {
+        preview: { download: 'http://api.localhost/Plone/work/@@images/image-400.jpeg' },
+        teaser: { download: 'http://api.localhost/Plone/work/@@images/image-600.jpeg' },
+      },
+    });
+
+    expect(() => flattenScales('/work', image)).not.toThrow();
+
+    const out = flattenScales('/work', image);
+    // download URLs flattened (apiPath stripped) on the OUTPUT...
+    expect(out.download).not.toContain('http://api.localhost');
+    expect(out.scales.preview.download).not.toContain('http://api.localhost');
+    expect(out.scales.teaser.download).not.toContain('http://api.localhost');
+    // ...and the frozen INPUT is left untouched.
+    expect(image.scales.preview.download).toBe(
+      'http://api.localhost/Plone/work/@@images/image-400.jpeg',
+    );
   });
 });

--- a/tests-playwright/fixtures/content/image-scales-test/data.json
+++ b/tests-playwright/fixtures/content/image-scales-test/data.json
@@ -1,0 +1,42 @@
+{
+  "@id": "/image-scales-test",
+  "@type": "Document",
+  "id": "image-scales-test",
+  "title": "Image Scales Test",
+  "description": "An image block whose image_scales carry a scales dict, as real Plone serializes them. Regression fixture for the flattenScales frozen-mutation crash.",
+  "UID": "image-scales-test-0000-0000-000000000000",
+  "review_state": "published",
+  "blocks": {
+    "title-block": { "@type": "title" },
+    "image-block-1": {
+      "@type": "image",
+      "url": "/image-scales-test/test-image.png",
+      "alt": "scaled image",
+      "image_field": "image",
+      "image_scales": {
+        "image": [
+          {
+            "content-type": "image/png",
+            "download": "@@images/image",
+            "filename": "test-image.png",
+            "width": 1200,
+            "height": 800,
+            "scales": {
+              "preview": {
+                "download": "@@images/image/preview",
+                "width": 400,
+                "height": 267
+              },
+              "large": {
+                "download": "@@images/image/large",
+                "width": 800,
+                "height": 533
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "blocks_layout": { "items": ["title-block", "image-block-1"] }
+}

--- a/tests-playwright/integration/image-block-frozen-scales.spec.ts
+++ b/tests-playwright/integration/image-block-frozen-scales.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '../fixtures';
+import { AdminUIHelper } from '../helpers/AdminUIHelper';
+
+/**
+ * Regression test for the editor crash
+ *   "Cannot assign to read only property 'download' of object '#<Object>'"
+ * surfaced through react-beautiful-dnd's error boundary as
+ *   "Sorry, something went wrong with your request".
+ *
+ * Root cause: flattenScales (helpers/Url/Url) mutated `scales[key].download`
+ * in place on the FROZEN Redux image data — it is the only `.download =`
+ * writer in Volto. The admin component that feeds it frozen scales is the
+ * Image block sidebar (Blocks/Image/ImageSidebar.jsx), which renders
+ * `<Image item={{ image_scales }} />` whenever the block data carries an
+ * `image_scales` object with a `scales` dict (the shape real Plone serializes
+ * for an `@type: image` block — see fixtures/content/image-scales-test).
+ *
+ * RED on the buggy in-place mutation -> crash on block selection.
+ * GREEN once flattenScales builds a new scales object instead of mutating.
+ */
+test.describe('image block sidebar — frozen image_scales', () => {
+  test('selecting an image block does not throw read-only download', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('console', (m) => {
+      if (m.type() === 'error') errors.push(m.text());
+    });
+    page.on('pageerror', (e) => errors.push(`${e.message}\n${e.stack ?? ''}`));
+
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    // fixtures/content is mounted at /_test_data by the mock-api server's
+    // default CONTENT_MOUNTS; navigateToEdit prepends that contentPrefix.
+    await helper.navigateToEdit('/image-scales-test');
+
+    // Raw click — NOT clickBlockInIframe — on purpose. Selecting the image
+    // block renders ImageSidebar -> <Image item> -> flattenScales on the
+    // frozen image_scales. On the buggy code that throws and App's error
+    // boundary recreates the whole tree, so the selection handle never
+    // appears; clickBlockInIframe would then fail with an opaque handle
+    // timeout instead of the read-only assertion below. The click alone is
+    // enough to trigger the sidebar render and the crash.
+    const block = helper
+      .getIframe()
+      .locator('[data-block-uid="image-block-1"]')
+      .first();
+    await block.waitFor({ state: 'attached', timeout: 10000 });
+    await block.scrollIntoViewIfNeeded();
+    await block.click();
+    await page.waitForTimeout(1000);
+
+    const downloadErrors = errors.filter((e) =>
+      /read[- ]only property '?download'?/i.test(e),
+    );
+    expect(
+      downloadErrors,
+      `read-only download crash reproduced:\n${downloadErrors.join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Selecting an image block (or an image-led teaser inside a grid) in the editor crashed with:

> Sorry, something went wrong with your request

surfaced through react-beautiful-dnd's error boundary. The underlying error:

> TypeError: Cannot assign to read only property 'download' of object '#&lt;Object&gt;'

## Root cause

`flattenScales` (the Hydra shadow of `@plone/volto/helpers/Url/Url`) shallow-copied the image with `{...image}`, so `imageInfo.scales` and every nested `scales[key]` still pointed at the **frozen** objects the Redux store hands the editor. It then assigned `scales[key].download` **in place** — the only `.download =` writer in this path. On frozen data that throws.

Call path: `ImageSidebar` → `<Image item={{ image_scales }}>` → `flattenScales`.

## Fix

Build a fresh `scales` object with spread copies instead of mutating in place. Output shape is unchanged.

## Tests

Both proven **RED** on the in-place mutation and **GREEN** on the fix:

- **Unit** — `Url/Url.test.js`: `flattenScales` must leave deep-frozen input untouched. (Verified RED→GREEN on this base.)
- **Integration** — `tests-playwright/integration/image-block-frozen-scales.spec.ts` + `fixtures/content/image-scales-test/`: admin-mock reproducer; selecting an image block whose `image_scales` carry a `scales` dict must not throw read-only download. The RED failure points straight at `flattenScales (Url.js) ← Image.jsx`.

> Note: the integration spec was verified RED→GREEN locally on the prior base; on a freshly-`pnpm install`ed checkout of `main` the local Volto dev server needs a clean rebuild to boot (`Cannot read properties of undefined (reading 'lookup')`) — environmental, unrelated to this change. CI exercises the full integration suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
