### PR TITLE
feat(helpers): export getAccessToken (was private _getAccessToken)

### DIFF
--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -69,7 +69,7 @@ function _getTokenFromCookie() {
  * environments. Order: URL `access_token` param → sessionStorage →
  * cookie. Returns null on server.
  */
-function _getAccessToken() {
+export function getAccessToken() {
   if (typeof window === 'undefined') {
     return null;
   }
@@ -92,7 +92,7 @@ function _getAccessToken() {
  * matching requests.
  */
 function _getAuthHeaders() {
-  const token = _getAccessToken();
+  const token = getAccessToken();
   if (token) {
     return {
       Authorization: `Bearer ${token}`,


### PR DESCRIPTION
Exposes `getAccessToken` from `@volto-hydra/helpers` (previously the private `_getAccessToken`) so frontends can read the editor access token for authenticated REST calls during the public-render split — needed by SSG/SSR frontends that drop the bridge on the public render but still need the token in the editor iframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9wenhxQPjyRgX5fSDjf8d