### PR TITLE
fix: pin send@0.19 at root so Volto SSR resolves express@4's send (Astro send@1.x hoist breaks redirects)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@plone/volto": "workspace:*",
+    "send": "~0.19.0",
     "volto-hydra": "workspace:*"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@plone/volto':
         specifier: workspace:*
         version: link:core/packages/volto
+      send:
+        specifier: ~0.19.0
+        version: 0.19.2
       volto-hydra:
         specifier: workspace:*
         version: link:packages/volto-hydra
@@ -25769,7 +25772,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+      jest-jasmine2: 26.6.3
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -25936,7 +25939,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-jasmine2@26.6.3(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
+  jest-jasmine2@26.6.3:
     dependencies:
       '@babel/traverse': 7.29.7
       '@jest/environment': 26.6.2
@@ -25957,11 +25960,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:


### PR DESCRIPTION
## Problem

After the Astro example landed (#229), **Volto's SSR server crashes on every redirect** — `/`, `/edit`, login, etc. — with:

```
TypeError: Cannot read properties of undefined (reading 'lookup')
  at normalizeType (express/lib/utils.js)   // var mime = require('send').mime
  at res.format -> res.redirect (express/lib/response.js)
  at server.jsx (React-Router SSR redirect)
```

## Cause

`@astrojs/node` (added in #229) depends on **`send@1.2.1`**, which pnpm hoists to the workspace-root `node_modules/send`. Volto's SSR `express@4.x` is externalized, so at runtime it does `require('send').mime.lookup(...)` in its redirect path — but **`send@1.x` removed the `.mime` export** that express 4 relies on. So the hoisted `1.2.1` makes express 4's `res.redirect` throw, killing the SSR process.

`express@4` ships a *nested* `send@0.19.2` (which has `.mime`), but the built server resolves the **root** `node_modules/send` (the hoisted `1.2.1`) at runtime.

## Fix

Declare `send@~0.19.0` as a **direct root dependency**, so root `node_modules/send` resolves to `0.19.2` (the version `express@4` needs). `@astrojs/node` keeps its own *nested* `send@1.x`, so Astro is unaffected. No webpack/externals changes; survives `pnpm install`.

## Verification

- Volto SSR now returns clean `302`s on `/`, `/edit`, `/contact-info` (previously crashed); zero crashes across repeated redirects.
- `@astrojs/node` still resolves `send@^1.2.1` nested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9wenhxQPjyRgX5fSDjf8d
