### PR TITLE
block-sanity: discovery problems fail as tests, not a globalSetup block

### DIFF
--- a/tests-playwright/bridge/block-sanity.spec.ts
+++ b/tests-playwright/bridge/block-sanity.spec.ts
@@ -39,6 +39,7 @@ interface DiscoveredBlock {
   slateIssue?: boolean;
   field?: string;
   issues?: string[];
+  noExample?: boolean;
 }
 
 // Read discovered blocks (written by globalSetup)
@@ -84,6 +85,18 @@ test.describe('Block sanity (auto-discovered)', () => {
             `occurrence(s), e.g. ${block.pagePath}) but is not registered in the frontend's ` +
             `blocksConfig, so it renders as "Not implemented Block". Register its schema ` +
             `(customBlocks) or migrate the content to an existing type.`,
+        );
+      });
+      continue;
+    }
+    // A frontend-registered type with no content example — fails as its own
+    // test (nothing to render) rather than blocking the suite.
+    if (block.noExample) {
+      test(`${block.blockType} block has a content example to render`, () => {
+        throw new Error(
+          `Block @type "${block.blockType}" is registered in the frontend but no content ` +
+            `example exists to run its render test. Add a fixture (a page with a populated ` +
+            `instance), or mark the type restricted if it only belongs inside a parent container.`,
         );
       });
       continue;

--- a/tests-playwright/bridge/block-sanity.spec.ts
+++ b/tests-playwright/bridge/block-sanity.spec.ts
@@ -31,6 +31,11 @@ interface DiscoveredBlock {
   pagePath: string;
   blockData: Record<string, unknown>;
   isListing: boolean;
+  // Set by discovery for @types used in content but not registered in the
+  // frontend's blocksConfig. These become a failing test rather than blocking
+  // the whole suite in globalSetup.
+  unregistered?: boolean;
+  occurrenceCount?: number;
 }
 
 // Read discovered blocks (written by globalSetup)
@@ -66,6 +71,20 @@ const test = base.extend<{ helper: AdminUIHelper }>({
 
 test.describe('Block sanity (auto-discovered)', () => {
   for (const block of discoveredBlocks) {
+    // A block @type used in content but not registered in the frontend's
+    // blocksConfig fails as its own test (it renders as "Not implemented
+    // Block") rather than blocking the whole suite.
+    if (block.unregistered) {
+      test(`${block.blockType} block @type is registered in the frontend`, () => {
+        throw new Error(
+          `Block @type "${block.blockType}" is used in content (${block.occurrenceCount} ` +
+            `occurrence(s), e.g. ${block.pagePath}) but is not registered in the frontend's ` +
+            `blocksConfig, so it renders as "Not implemented Block". Register its schema ` +
+            `(customBlocks) or migrate the content to an existing type.`,
+        );
+      });
+      continue;
+    }
     const labelVariation = block.variation && block.variation !== 'default'
       ? ` (${block.variation})`
       : '';

--- a/tests-playwright/bridge/block-sanity.spec.ts
+++ b/tests-playwright/bridge/block-sanity.spec.ts
@@ -31,11 +31,14 @@ interface DiscoveredBlock {
   pagePath: string;
   blockData: Record<string, unknown>;
   isListing: boolean;
-  // Set by discovery for @types used in content but not registered in the
-  // frontend's blocksConfig. These become a failing test rather than blocking
-  // the whole suite in globalSetup.
+  // Set by discovery for content/schema problems that become a failing test
+  // rather than blocking the whole suite in globalSetup.
   unregistered?: boolean;
   occurrenceCount?: number;
+  shapeIssue?: boolean;
+  slateIssue?: boolean;
+  field?: string;
+  issues?: string[];
 }
 
 // Read discovered blocks (written by globalSetup)
@@ -81,6 +84,20 @@ test.describe('Block sanity (auto-discovered)', () => {
             `occurrence(s), e.g. ${block.pagePath}) but is not registered in the frontend's ` +
             `blocksConfig, so it renders as "Not implemented Block". Register its schema ` +
             `(customBlocks) or migrate the content to an existing type.`,
+        );
+      });
+      continue;
+    }
+    // Content/schema shape mismatch (e.g. a field declared slate but holding a
+    // string) — fails as its own test rather than blocking the suite.
+    if (block.shapeIssue || block.slateIssue) {
+      const kind = block.shapeIssue ? 'data shape' : 'slate structure';
+      test(`${block.blockType} block [${block.blockId}] has valid ${kind}`, () => {
+        throw new Error(
+          `Block "${block.blockType}" [${block.blockId}] on ${block.pagePath}` +
+            (block.field ? ` field "${block.field}"` : '') +
+            ` has ${kind} that does not match its schema:\n` +
+            (block.issues || []).map((m) => `  - ${m}`).join('\n'),
         );
       });
       continue;

--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -717,31 +717,28 @@ async function discoverBlocks(apiUrl, maxPages = Infinity, blocksConfig = {}, fr
     });
   }
 
-  if (shapeIssues.length) {
-    const lines = shapeIssues.flatMap((e) => [
-      `  ${e.pagePath} [${e.blockId}] (${e.blockType}):`,
-      ...e.issues.map((msg) => `    - ${msg}`),
-    ]);
-    throw new Error(
-      `Discovery found ${shapeIssues.length} block(s) whose data shape doesn't match the ` +
-        `declared widget/type in the block schema. These will crash Volto's sidebar widgets ` +
-        `(e.g. UrlWidget expecting a string but getting an array). Either fix the content ` +
-        `or update the schema.\n` +
-        lines.join('\n'),
-    );
+  // Like unregistered types, shape and slate issues are real content/schema
+  // problems but should each be a failing test rather than blocking the whole
+  // suite in globalSetup. Emit a synthetic discovered-block entry per issue.
+  for (const e of shapeIssues) {
+    result.push({
+      blockType: e.blockType,
+      blockId: e.blockId,
+      pagePath: e.pagePath,
+      shapeIssue: true,
+      issues: e.issues,
+    });
   }
 
-  if (slateIssues.length) {
-    const lines = slateIssues.flatMap((e) => [
-      `  ${e.pagePath} [${e.blockId}] field "${e.field}":`,
-      ...e.issues.map((msg) => `    - ${msg}`),
-    ]);
-    throw new Error(
-      `Discovery found ${slateIssues.length} slate field(s) with structural issues. ` +
-        `Each slate field must be a single element root with a string \`type\`; ` +
-        `text leaves must live inside an element.\n` +
-        lines.join('\n'),
-    );
+  for (const e of slateIssues) {
+    result.push({
+      blockType: e.blockType || 'slate',
+      blockId: e.blockId,
+      pagePath: e.pagePath,
+      slateIssue: true,
+      field: e.field,
+      issues: e.issues,
+    });
   }
 
   // Every block type the FRONTEND registers needs at least one content

--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -756,13 +756,10 @@ async function discoverBlocks(apiUrl, maxPages = Infinity, blocksConfig = {}, fr
       if (cfg?.restricted) continue;
       if (!discoveredTypes.has(blockType)) missing.push(blockType);
     }
-    if (missing.length) {
-      throw new Error(
-        `Discovery found ${missing.length} frontend-registered block type(s) with no content ` +
-          `example to run the sanity render test against. Add a fixture (page with a populated ` +
-          `instance) or mark the type restricted if it only belongs inside a parent container.\n` +
-          missing.map((t) => `  - ${t}`).join('\n'),
-      );
+    // A registered type with no content example can't get a render test — but
+    // that is a failing test for that type, not a reason to block the suite.
+    for (const blockType of missing) {
+      result.push({ blockType, noExample: true });
     }
   }
 

--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -701,19 +701,20 @@ async function discoverBlocks(apiUrl, maxPages = Infinity, blocksConfig = {}, fr
     );
   }
 
-  if (unregisteredTypes.size) {
-    const lines = [];
-    for (const [blockType, occurrences] of unregisteredTypes) {
-      const sample = occurrences.slice(0, 5).map((o) => `${o.pagePath} [${o.blockId}]`);
-      const more = occurrences.length > 5 ? ` (+ ${occurrences.length - 5} more)` : '';
-      lines.push(`  - "${blockType}": ${occurrences.length} occurrence(s) — e.g. ${sample.join(', ')}${more}`);
-    }
-    throw new Error(
-      `Discovery found ${unregisteredTypes.size} block @type(s) used in content but not registered ` +
-        `in the frontend's blocksConfig. The renderer will fall through to "Not implemented Block". ` +
-        `Either register the schema (customBlocks) or migrate the content to an existing type.\n` +
-        lines.join('\n'),
-    );
+  // A block @type used in content but not registered in the frontend's
+  // blocksConfig is a real problem (it renders as "Not implemented Block"), but
+  // it should NOT block the whole suite in globalSetup — it is just another
+  // failing test. Emit a synthetic discovered-block entry per unregistered
+  // type so block-sanity generates one failing test each, while the registered
+  // blocks still run.
+  for (const [blockType, occurrences] of unregisteredTypes) {
+    result.push({
+      blockType,
+      blockId: occurrences[0].blockId,
+      pagePath: occurrences[0].pagePath,
+      unregistered: true,
+      occurrenceCount: occurrences.length,
+    });
   }
 
   if (shapeIssues.length) {


### PR DESCRIPTION
## Problem

`discoverBlocks` throws in `globalSetup` when it finds any of: a block `@type` used in content but not registered in the frontend's `blocksConfig`, a data-shape mismatch, a slate structural issue, or a frontend-registered type with no content example. Any one of these aborts the **entire** block-sanity suite — 0 tests run, so a single unregistered type hides all the blocks that would otherwise pass.

## Change

These are real problems, but each should be its own failing test rather than a hard block. `discoverBlocks` now pushes a synthetic discovered-block entry per problem (`unregistered` / `shapeIssue` / `slateIssue` / `noExample`) instead of throwing, and `block-sanity.spec.ts` generates one failing test each. The registered blocks still run and report normally. Only a genuine infra error (a failed `@search` fetch) still throws.

`page-integrity.spec.ts` is unaffected (it dedupes on `pagePath`).

## Effect

block-sanity always runs and reports every discovery problem as an individual, addressable failing test — you watch the failing count go down as schemas/fixtures are added, instead of facing an all-or-nothing wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
