### PR TITLE
fix(getImageUrl): resolve preview_image_link scales against base_path

### DIFF
--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -1312,7 +1312,13 @@ export function getImageUrl(value, apiUrl = '') {
     const field = value.image_field;
     const scales = value.image_scales[field];
     if (scales?.[0]?.download) {
-      const baseUrl = value['@id'] || '';
+      // A `preview_image_link` relation (e.g. a case-study teaser pointing at a
+      // shared /logos/<client> image) serializes its scales on the LINKED image,
+      // not this item. plone.volto stamps each scale entry with `base_path` = the
+      // linked image's path; use it as the base (Volto's Image.jsx does the same:
+      // `image.base_path || item['@id']`). Otherwise the URL resolves against the
+      // referencing item and 404s / serves the wrong image.
+      const baseUrl = scales[0].base_path || value['@id'] || '';
       const prefix = baseUrl.startsWith('http') ? '' : apiUrl;
       return `${prefix}${baseUrl}/${scales[0].download}`;
     }

--- a/packages/hydra-js/getImageUrl.test.js
+++ b/packages/hydra-js/getImageUrl.test.js
@@ -1,0 +1,79 @@
+import { getImageUrl } from '@volto-hydra/helpers';
+
+/**
+ * getImageUrl builds an image URL from a catalog-brain/summary shape
+ * ({ '@id', image_field, image_scales }). Two cases matter:
+ *
+ *  - A normal leadimage: the scale lives on the item itself, so the URL is
+ *    <item @id>/<hashed download>.
+ *  - A `preview_image_link` relation (case-study teaser -> shared
+ *    /logos/<client> image): plone.volto serializes the scale on the LINKED
+ *    image and stamps `base_path` = the linked image's path. The URL must
+ *    resolve against base_path, NOT the referencing item's @id — otherwise it
+ *    requests /case-studies/<slug>/... and serves the wrong image (or 404s).
+ *    Mirrors Volto's Image.jsx: `image.base_path || item['@id']`.
+ *
+ * Always uses the content-hashed `download` (not `@@images/<field>`) so a
+ * replaced-in-place image yields a new URL and downstream caches (e.g. IPX)
+ * bust automatically.
+ */
+const API = 'http://api.test';
+
+describe('getImageUrl', () => {
+  test('preview_image_link: resolves the hashed scale against base_path (the linked logo)', () => {
+    const item = {
+      '@id': '/case-studies/justice-health-nsw',
+      image_field: 'preview_image_link',
+      image_scales: {
+        preview_image_link: [
+          {
+            download: '@@images/image-279-aaaaaaaa.png',
+            base_path: '/logos/justice-health-nsw',
+            width: 279,
+            height: 65,
+          },
+        ],
+      },
+    };
+    expect(getImageUrl(item, API)).toBe(
+      `${API}/logos/justice-health-nsw/@@images/image-279-aaaaaaaa.png`,
+    );
+  });
+
+  test('preview_image_link: never resolves against the referencing item @id', () => {
+    const item = {
+      '@id': '/case-studies/justice-health-nsw',
+      image_field: 'preview_image_link',
+      image_scales: {
+        preview_image_link: [
+          { download: '@@images/image-32-bbbb.png', base_path: '/logos/lecc' },
+        ],
+      },
+    };
+    const url = getImageUrl(item, API);
+    expect(url).not.toContain('/case-studies/');
+    expect(url).toBe(`${API}/logos/lecc/@@images/image-32-bbbb.png`);
+  });
+
+  test('leadimage (no base_path): resolves the hashed download against the item @id', () => {
+    const item = {
+      '@id': '/case-studies/archival-property-register',
+      image_field: 'image',
+      image_scales: { image: [{ download: '@@images/image-662-cccccccc.png' }] },
+    };
+    expect(getImageUrl(item, API)).toBe(
+      `${API}/case-studies/archival-property-register/@@images/image-662-cccccccc.png`,
+    );
+  });
+
+  test('absolute @id base is not re-prefixed with apiUrl', () => {
+    const item = {
+      '@id': 'http://api.test/case-studies/x',
+      image_field: 'image',
+      image_scales: { image: [{ download: '@@images/image-100-dddd.png' }] },
+    };
+    expect(getImageUrl(item, API)).toBe(
+      'http://api.test/case-studies/x/@@images/image-100-dddd.png',
+    );
+  });
+});


### PR DESCRIPTION
`getImageUrl` built the URL from the item's `@id`, so a `preview_image_link` relation (a teaser pointing at a shared image — e.g. a case-study logo at `/logos/<client>`) resolved the scale against the *referencing item* and served the wrong image / 404'd.

plone.volto stamps each such scale entry with `base_path` (the linked image's path). This uses it as the base, mirroring Volto's `Image.jsx`: `image.base_path || item['@id']`. Already uses the content-hashed `download`, so replaced-in-place images bust downstream caches.

Test: `packages/hydra-js/getImageUrl.test.js` (preview_image_link + leadimage cases).