### PR TITLE
Validator: recognize Plone action/view URLs as valid references

### DIFF
--- a/tests-playwright/fixtures/plone-content-validator.cjs
+++ b/tests-playwright/fixtures/plone-content-validator.cjs
@@ -372,6 +372,15 @@ function checkIntegrity(contentDir) {
       base = base.split('/@@')[0].split('/++')[0].replace(/\/+$/, '') || '/';
       return pathMap.has(base) ? null : `path not in content: ${base}`;
     }
+    // Plone action / browser-view URLs relative to the current context (they
+    // don't match the absolute-path branch above). These are UI actions, not
+    // content references — they resolve at runtime for whatever container the
+    // page lives in, so they can't (and shouldn't) be checked as content paths.
+    // e.g. `./add?type=Document` (add form), `./edit`, `@@some-view`, `++resource++…`.
+    const relAction = ref.replace(/^\.\//, '');
+    if (/^(@@|\+\+)/.test(relAction)) return null;
+    if (/^(add|edit|view|delete|sharing|contents|folder_contents|login|logout|history)(\?|\/|#|$)/.test(relAction))
+      return null;
     return `unrecognized reference form: ${ref.slice(0, 60)}`;
   }
 


### PR DESCRIPTION
The content validator (`refFailure`) flagged relative Plone action/view URLs as "unrecognized reference form" — e.g. `./add?type=Document`, an intentional add-form link on demo pages. These are UI actions on the current context, not content references; they resolve at runtime for whatever container the page lives in and cant be checked as content paths.

Recognize them explicitly (named forms, not a blanket skip — keeping the "nothing silently accepted" ethos): `@@view`/`++resource++` browser views, and common relative actions (add/edit/view/delete/sharing/contents/folder_contents/login/logout/history) with optional query/anchor. Everything else still fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)