### PR TITLE
fieldRules: add contains/notContains array-membership operators

### DIFF
--- a/docs/content/content/content/docs/custom-blocks/data.json
+++ b/docs/content/content/content/docs/custom-blocks/data.json
@@ -1730,7 +1730,7 @@
     },
     "p-32": {
       "@type": "slate",
-      "plaintext": "Condition operators: `is`, `isNot`, `isSet`, `isNotSet`, `gt`, `gte`, `lt`, `lte`.",
+      "plaintext": "Condition operators: `is`, `isNot`, `isSet`, `isNotSet`, `gt`, `gte`, `lt`, `lte`, `contains`, `notContains`.",
       "value": [
         {
           "type": "p",
@@ -1824,6 +1824,28 @@
               ]
             },
             {
+              "text": ", "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "contains"
+                }
+              ]
+            },
+            {
+              "text": ", "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "notContains"
+                }
+              ]
+            },
+            {
               "text": "."
             }
           ]
@@ -1831,6 +1853,83 @@
       ]
     },
     "p-33": {
+      "@type": "slate",
+      "plaintext": "`contains` / `notContains` test **array membership** — use them with a multiselect field to reveal each option's own field. `{ contains: 'date' }` matches when the value is an array that includes `'date'` (a non-array / unset multiselect never contains anything, so the condition fails):",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "contains"
+                }
+              ]
+            },
+            {
+              "text": " / "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "notContains"
+                }
+              ]
+            },
+            {
+              "text": " test "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "array membership"
+                }
+              ]
+            },
+            {
+              "text": " — use them with a multiselect field to reveal each option's own field. "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "{ contains: 'date' }"
+                }
+              ]
+            },
+            {
+              "text": " matches when the value is an array that includes "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "'date'"
+                }
+              ]
+            },
+            {
+              "text": " (a non-array / unset multiselect never contains anything, so the condition fails):"
+            }
+          ]
+        }
+      ]
+    },
+    "ce-34": {
+      "@type": "codeExample",
+      "tabs": [
+        {
+          "@id": "ce-34-javascript-cc356f",
+          "label": "Javascript",
+          "language": "javascript",
+          "code": "schemaEnhancer: {\n    fieldRules: {\n        // `elements` is a multiselect: ['image', 'date', 'tag'].\n        // Show each element's field only when it's selected.\n        date: { when: { elements: { contains: 'date' } }, else: false },\n        tag: { when: { elements: { contains: 'tag' } }, else: false },\n    },\n}"
+        }
+      ]
+    },
+    "p-35": {
       "@type": "slate",
       "plaintext": "Field paths: `../field` for the parent block's field, `/field` for a page metadata field.",
       "value": [
@@ -1866,7 +1965,7 @@
         }
       ]
     },
-    "h-34": {
+    "h-36": {
       "@type": "slate",
       "plaintext": "Block Conversion & fieldMappings",
       "value": [
@@ -1880,7 +1979,7 @@
         }
       ]
     },
-    "p-35": {
+    "p-37": {
       "@type": "slate",
       "plaintext": "`fieldMappings` (plural) on a block config defines how fields map between block types. This enables three things:",
       "value": [
@@ -1902,7 +2001,7 @@
         }
       ]
     },
-    "ul-36": {
+    "ul-38": {
       "@type": "slate",
       "plaintext": "\"Convert to...\" UI action — editors can convert a block to another type (e.g. teaser → image). Listing item types — query results are mapped to item blocks via @default (see Listings). Synchronised container children — a parent controls child type, all children convert together (see Container Blocks › Synchronised Block Types).",
       "value": [
@@ -2000,7 +2099,7 @@
         }
       ]
     },
-    "p-37": {
+    "p-39": {
       "@type": "slate",
       "plaintext": "Each key in `fieldMappings` is either a **specific block type name** or **`@default`**.",
       "value": [
@@ -2047,7 +2146,7 @@
         }
       ]
     },
-    "h-38": {
+    "h-40": {
       "@type": "slate",
       "plaintext": "@default — the canonical content shape",
       "value": [
@@ -2069,7 +2168,7 @@
         }
       ]
     },
-    "p-39": {
+    "p-41": {
       "@type": "slate",
       "plaintext": "`@default` is a virtual type representing canonical Plone content item fields: `@id`, `title`, `description`, `image`. These are the same fields that listing query results provide. A block with `fieldMappings['@default']` is saying \"I can be populated from standard content item fields.\" The keys in `@default` must only use these four canonical fields — using other keys (e.g. `label`, `field`, `required`) is invalid and produces a console warning.",
       "value": [
@@ -2190,7 +2289,7 @@
         }
       ]
     },
-    "h-40": {
+    "h-42": {
       "@type": "slate",
       "plaintext": "Explicit type-to-type mappings",
       "value": [
@@ -2204,7 +2303,7 @@
         }
       ]
     },
-    "p-41": {
+    "p-43": {
       "@type": "slate",
       "plaintext": "Use these when blocks share fields that aren't part of the `@default` set — for example, facet types sharing `{ title, field, hidden }` or form field types sharing `{ label, description, required }`.",
       "value": [
@@ -2251,18 +2350,18 @@
         }
       ]
     },
-    "ce-42": {
+    "ce-44": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-42-javascript-d056e2",
+          "@id": "ce-44-javascript-00eb5b",
           "label": "Javascript",
           "language": "javascript",
           "code": "// Content item types: use @default (canonical fields) + explicit cross-mappings\nteaser: {\n    fieldMappings: {\n        '@default': { '@id': 'href', 'title': 'title', 'image': 'preview_image' },\n        image: { 'href': 'href', 'alt': 'title', 'url': 'preview_image' },\n    },\n},\nimage: {\n    fieldMappings: {\n        '@default': { '@id': 'href', 'title': 'alt', 'image': 'url' },\n        teaser: { 'href': 'href', 'title': 'alt', 'preview_image': 'url' },\n    },\n},\n\n// Non-content types: use explicit hub-type mappings (NOT @default).\n// All facet types map through checkboxFacet as a hub:\nselectFacet:  { fieldMappings: { checkboxFacet: { title: 'title', field: 'field', hidden: 'hidden' } } },\ncheckboxFacet: { fieldMappings: { selectFacet: { /* ... */ }, daterangeFacet: { /* ... */ } } },"
         }
       ]
     },
-    "h-43": {
+    "h-45": {
       "@type": "slate",
       "plaintext": "Conversion graph rules",
       "value": [
@@ -2276,7 +2375,7 @@
         }
       ]
     },
-    "ul-44": {
+    "ul-46": {
       "@type": "slate",
       "plaintext": "Explicit fieldMappings[typeName] always creates a conversion edge. @default only creates edges between types that both have valid @default mappings (keys from { @id, title, description, image }). Types with non-canonical @default keys are ignored. Types without fieldMappings never appear in the \"Convert to...\" menu. Transitive conversions use paths through intermediate types (e.g. hero → teaser → image). Unmapped fields are kept in the data so converting back restores them.",
       "value": [
@@ -2390,7 +2489,7 @@
         }
       ]
     },
-    "h-45": {
+    "h-47": {
       "@type": "slate",
       "plaintext": "Mapping value format",
       "value": [
@@ -2404,7 +2503,7 @@
         }
       ]
     },
-    "p-46": {
+    "p-48": {
       "@type": "slate",
       "plaintext": "A mapping value is either a string (simple field rename) or `{ field, type }` (rename with type conversion):",
       "value": [
@@ -2429,18 +2528,18 @@
         }
       ]
     },
-    "ce-47": {
+    "ce-49": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-47-json-b42b95",
+          "@id": "ce-49-json-2e1a67",
           "label": "Json",
           "language": "json",
           "code": "{\n    \"@id\": { \"field\": \"href\", \"type\": \"link\" },\n    \"title\": \"title\",\n    \"description\": \"description\",\n    \"image\": \"preview_image\"\n}"
         }
       ]
     },
-    "p-48": {
+    "p-50": {
       "@type": "slate",
       "plaintext": "When `type` is specified, the value is converted at runtime:",
       "value": [
@@ -2465,7 +2564,7 @@
         }
       ]
     },
-    "tbl-49": {
+    "tbl-51": {
       "@type": "slateTable",
       "table": {
         "fixed": true,
@@ -2476,10 +2575,10 @@
         "striped": false,
         "rows": [
           {
-            "key": "tbl-49-r0",
+            "key": "tbl-51-r0",
             "cells": [
               {
-                "key": "tbl-49-r0c0",
+                "key": "tbl-51-r0c0",
                 "type": "header",
                 "value": [
                   {
@@ -2493,7 +2592,7 @@
                 ]
               },
               {
-                "key": "tbl-49-r0c1",
+                "key": "tbl-51-r0c1",
                 "type": "header",
                 "value": [
                   {
@@ -2509,10 +2608,10 @@
             ]
           },
           {
-            "key": "tbl-49-r1",
+            "key": "tbl-51-r1",
             "cells": [
               {
-                "key": "tbl-49-r1c0",
+                "key": "tbl-51-r1c0",
                 "type": "data",
                 "value": [
                   {
@@ -2531,7 +2630,7 @@
                 ]
               },
               {
-                "key": "tbl-49-r1c1",
+                "key": "tbl-51-r1c1",
                 "type": "data",
                 "value": [
                   {
@@ -2558,10 +2657,10 @@
             ]
           },
           {
-            "key": "tbl-49-r2",
+            "key": "tbl-51-r2",
             "cells": [
               {
-                "key": "tbl-49-r2c0",
+                "key": "tbl-51-r2c0",
                 "type": "data",
                 "value": [
                   {
@@ -2580,7 +2679,7 @@
                 ]
               },
               {
-                "key": "tbl-49-r2c1",
+                "key": "tbl-51-r2c1",
                 "type": "data",
                 "value": [
                   {
@@ -2607,10 +2706,10 @@
             ]
           },
           {
-            "key": "tbl-49-r3",
+            "key": "tbl-51-r3",
             "cells": [
               {
-                "key": "tbl-49-r3c0",
+                "key": "tbl-51-r3c0",
                 "type": "data",
                 "value": [
                   {
@@ -2629,7 +2728,7 @@
                 ]
               },
               {
-                "key": "tbl-49-r3c1",
+                "key": "tbl-51-r3c1",
                 "type": "data",
                 "value": [
                   {
@@ -2656,10 +2755,10 @@
             ]
           },
           {
-            "key": "tbl-49-r4",
+            "key": "tbl-51-r4",
             "cells": [
               {
-                "key": "tbl-49-r4c0",
+                "key": "tbl-51-r4c0",
                 "type": "data",
                 "value": [
                   {
@@ -2678,7 +2777,7 @@
                 ]
               },
               {
-                "key": "tbl-49-r4c1",
+                "key": "tbl-51-r4c1",
                 "type": "data",
                 "value": [
                   {
@@ -2702,10 +2801,10 @@
             ]
           },
           {
-            "key": "tbl-49-r5",
+            "key": "tbl-51-r5",
             "cells": [
               {
-                "key": "tbl-49-r5c0",
+                "key": "tbl-51-r5c0",
                 "type": "data",
                 "value": [
                   {
@@ -2724,7 +2823,7 @@
                 ]
               },
               {
-                "key": "tbl-49-r5c1",
+                "key": "tbl-51-r5c1",
                 "type": "data",
                 "value": [
                   {
@@ -2742,7 +2841,7 @@
         ]
       }
     },
-    "h-50": {
+    "h-52": {
       "@type": "slate",
       "plaintext": "FieldMappingWidget",
       "value": [
@@ -2756,7 +2855,7 @@
         }
       ]
     },
-    "p-51": {
+    "p-53": {
       "@type": "slate",
       "plaintext": "When a parent block has `mappingField` set in its `inheritSchemaFrom` recipe, the admin sidebar shows a widget that lets editors configure field mappings visually:",
       "value": [
@@ -2792,7 +2891,7 @@
         }
       ]
     },
-    "ul-52": {
+    "ul-54": {
       "@type": "slate",
       "plaintext": "Shows the @default source fields (@id, title, description, image) on the left. For each source field, lets the editor pick a field from the selected child type's schema. Auto-detects the conversion type from the target field definition (e.g. object_browser with mode=link → type: \"link\"). Saves the result as fieldMapping (singular) on the block data.",
       "value": [
@@ -2945,7 +3044,7 @@
         }
       ]
     },
-    "p-53": {
+    "p-55": {
       "@type": "slate",
       "plaintext": "The saved `fieldMapping` is read at render time by `expandListingBlocks` — no block registry access needed at render time.",
       "value": [
@@ -2981,7 +3080,7 @@
         }
       ]
     },
-    "h-54": {
+    "h-56": {
       "@type": "slate",
       "plaintext": "HTML Paste Support (TODO)",
       "value": [
@@ -2995,7 +3094,7 @@
         }
       ]
     },
-    "p-55": {
+    "p-57": {
       "@type": "slate",
       "plaintext": "When the editor pastes rich HTML into the page, Hydra will eventually be able to recognise it as a custom block by matching against a CSS selector mapping. The proposed shape:",
       "value": [
@@ -3009,18 +3108,18 @@
         }
       ]
     },
-    "ce-56": {
+    "ce-58": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-56-javascript-21e0d8",
+          "@id": "ce-58-javascript-81cc43",
           "label": "Javascript",
           "language": "javascript",
           "code": "video: {\n    fieldMappings: {\n        'css:video': { 'src': 'url', 'caption[@class=\"alt\"]': 'alt' },\n    },\n}"
         }
       ]
     },
-    "p-57": {
+    "p-59": {
       "@type": "slate",
       "plaintext": "The `css:<selector>` key in `fieldMappings` matches a pasted HTML element; the value maps element attributes to block fields. Not yet implemented — open question on whether this should run via `htmlTagsToSlate` (bypassing slate conversion) or be encoded into slate so attributes/classes survive.",
       "value": [
@@ -3104,30 +3203,32 @@
       "ul-31",
       "p-32",
       "p-33",
-      "h-34",
+      "ce-34",
       "p-35",
-      "ul-36",
+      "h-36",
       "p-37",
-      "h-38",
+      "ul-38",
       "p-39",
       "h-40",
       "p-41",
-      "ce-42",
-      "h-43",
-      "ul-44",
+      "h-42",
+      "p-43",
+      "ce-44",
       "h-45",
-      "p-46",
-      "ce-47",
+      "ul-46",
+      "h-47",
       "p-48",
-      "tbl-49",
-      "h-50",
-      "p-51",
-      "ul-52",
+      "ce-49",
+      "p-50",
+      "tbl-51",
+      "h-52",
       "p-53",
-      "h-54",
+      "ul-54",
       "p-55",
-      "ce-56",
-      "p-57"
+      "h-56",
+      "p-57",
+      "ce-58",
+      "p-59"
     ]
   }
 }

--- a/docs/custom-blocks.md
+++ b/docs/custom-blocks.md
@@ -199,7 +199,20 @@ const bridge = initBridge({
 - `[rule, rule, ...]` — switch: first matching rule wins. A bare `false` in the array is a catch-all hide: `[{ when: A }, { when: B }, false]` shows on A or B, hides otherwise.
 - `'parent.child': false` — hide a field inside a widget's inner schema
 
-Condition operators: `is`, `isNot`, `isSet`, `isNotSet`, `gt`, `gte`, `lt`, `lte`.
+Condition operators: `is`, `isNot`, `isSet`, `isNotSet`, `gt`, `gte`, `lt`, `lte`, `contains`, `notContains`.
+
+`contains` / `notContains` test **array membership** — use them with a multiselect field to reveal each option's own field. `{ contains: 'date' }` matches when the value is an array that includes `'date'` (a non-array / unset multiselect never contains anything, so the condition fails):
+
+```javascript
+schemaEnhancer: {
+    fieldRules: {
+        // `elements` is a multiselect: ['image', 'date', 'tag'].
+        // Show each element's field only when it's selected.
+        date: { when: { elements: { contains: 'date' } }, else: false },
+        tag: { when: { elements: { contains: 'tag' } }, else: false },
+    },
+}
+```
 
 Field paths: `../field` for the parent block's field, `/field` for a page metadata field.
 

--- a/packages/volto-hydra/src/utils/schemaInheritance.js
+++ b/packages/volto-hydra/src/utils/schemaInheritance.js
@@ -1535,6 +1535,7 @@ function createEnhancerByType(type, config) {
  *   { fieldName: { isNot: v } }    — inequality
  *   { fieldName: { gte: n } }      — numeric comparison (gt, gte, lt, lte)
  *   { fieldName: { isSet: true } } — truthy check
+ *   { fieldName: { contains: v } } — array membership (multiselect includes v)
  *   { '../field': value }          — parent/root field path
  *
  * Field definitions can include a `fieldset` property to specify placement:
@@ -1746,11 +1747,14 @@ function evaluateWhenCondition(when, formData, args) {
 
 /**
  * Evaluate operator conditions against a value.
- * Operators: is, isNot, gt, gte, lt, lte, isSet, isNotSet
+ * Operators: is, isNot, gt, gte, lt, lte, isSet, isNotSet, contains, notContains
+ * `contains`/`notContains` test array membership (for multiselect fields):
+ * `{ contains: 'date' }` matches when `value` is an array that includes 'date'.
  * @private
  */
 function evaluateOperators(value, operators) {
-  const { is, isNot, gt, gte, lt, lte, isSet, isNotSet } = operators;
+  const { is, isNot, gt, gte, lt, lte, isSet, isNotSet, contains, notContains } =
+    operators;
 
   if (isSet !== undefined) {
     const hasValue = value !== undefined && value !== null && value !== '';
@@ -1759,6 +1763,14 @@ function evaluateOperators(value, operators) {
   if (isNotSet !== undefined) {
     const hasValue = value !== undefined && value !== null && value !== '';
     if (isNotSet ? hasValue : !hasValue) return false;
+  }
+  if (contains !== undefined) {
+    // Array membership: a non-array value (missing/unset multiselect) never
+    // contains anything, so the condition fails.
+    if (!Array.isArray(value) || !value.includes(contains)) return false;
+  }
+  if (notContains !== undefined) {
+    if (Array.isArray(value) && value.includes(notContains)) return false;
   }
   if (is !== undefined && value !== is) return false;
   if (isNot !== undefined && value === isNot) return false;

--- a/packages/volto-hydra/src/utils/schemaInheritance.test.js
+++ b/packages/volto-hydra/src/utils/schemaInheritance.test.js
@@ -167,4 +167,36 @@ describe('fieldRules — contains operator (multiselect-driven visibility)', () 
       expect(out.properties.date).toBeUndefined();
     }
   });
+
+  // notContains is the inverse: keep the field UNLESS the array holds the value.
+  const notContainsRecipe = {
+    fieldRules: {
+      date: { when: { elements: { notContains: 'date' } }, else: false },
+    },
+  };
+
+  test('notContains keeps the field when the array omits the value', () => {
+    const enhancer = createSchemaEnhancerFromRecipe(notContainsRecipe);
+    const out = enhancer({
+      schema: baseSchema(),
+      formData: { elements: ['image', 'tag'] },
+    });
+    expect(out.properties.date).toBeDefined();
+  });
+
+  test('notContains hides the field when the array holds the value', () => {
+    const enhancer = createSchemaEnhancerFromRecipe(notContainsRecipe);
+    const out = enhancer({
+      schema: baseSchema(),
+      formData: { elements: ['image', 'date'] },
+    });
+    expect(out.properties.date).toBeUndefined();
+  });
+
+  test('notContains matches (keeps) when the multiselect is unset', () => {
+    // A non-array value contains nothing, so notContains is satisfied.
+    const enhancer = createSchemaEnhancerFromRecipe(notContainsRecipe);
+    const out = enhancer({ schema: baseSchema(), formData: {} });
+    expect(out.properties.date).toBeDefined();
+  });
 });

--- a/packages/volto-hydra/src/utils/schemaInheritance.test.js
+++ b/packages/volto-hydra/src/utils/schemaInheritance.test.js
@@ -9,7 +9,10 @@ vi.mock('../context', () => ({
   getLiveBlockData: () => undefined,
 }));
 
-import { applyBlockDefaultsWithContext } from './schemaInheritance';
+import {
+  applyBlockDefaultsWithContext,
+  createSchemaEnhancerFromRecipe,
+} from './schemaInheritance';
 
 /**
  * The store-on-add path: when a block is added into a slot region inside a
@@ -107,5 +110,61 @@ describe('applyBlockDefaultsWithContext — slotId inheritance on add', () => {
     expect(result.slotId).toBe('primary');
     expect(result.templateId).toBe('/t/test-layout');
     expect(result.templateInstanceId).toBe('inst-1');
+  });
+});
+
+/**
+ * fieldRules `contains` operator — array membership.
+ *
+ * The block schema pattern this enables: a multiselect field (e.g. a card's
+ * `elements: ['image', 'date', 'tag']`) that conditionally reveals each
+ * element's data field. Without an array-membership operator a multiselect
+ * can't drive conditional visibility (isSet only tells you the array is
+ * non-empty, not which values it holds). Tested through the public recipe
+ * entry, exactly as the frontend sends it.
+ */
+describe('fieldRules — contains operator (multiselect-driven visibility)', () => {
+  const baseSchema = () => ({
+    fieldsets: [{ id: 'default', title: 'Default', fields: ['elements', 'date'] }],
+    properties: {
+      elements: { title: 'Elements', type: 'array' },
+      date: { title: 'Date' },
+    },
+    required: [],
+  });
+
+  // Show `date` only when the `elements` multiselect includes 'date'.
+  const recipe = {
+    fieldRules: {
+      date: { when: { elements: { contains: 'date' } }, else: false },
+    },
+  };
+
+  test('keeps the field when the multiselect array includes the value', () => {
+    const enhancer = createSchemaEnhancerFromRecipe(recipe);
+    const out = enhancer({
+      schema: baseSchema(),
+      formData: { elements: ['image', 'date'] },
+    });
+    expect(out.properties.date).toBeDefined();
+    expect(out.fieldsets[0].fields).toContain('date');
+  });
+
+  test('hides the field when the multiselect array omits the value', () => {
+    const enhancer = createSchemaEnhancerFromRecipe(recipe);
+    const out = enhancer({
+      schema: baseSchema(),
+      formData: { elements: ['image', 'tag'] },
+    });
+    expect(out.properties.date).toBeUndefined();
+    expect(out.fieldsets[0].fields).not.toContain('date');
+  });
+
+  test('hides the field when the multiselect is empty or unset', () => {
+    const enhancer = createSchemaEnhancerFromRecipe(recipe);
+    for (const formData of [{ elements: [] }, {}]) {
+      const out = enhancer({ schema: baseSchema(), formData });
+      expect(out.properties.date).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## What

Adds `contains` / `notContains` operators to `fieldRules` `when` conditions, testing **array membership**.

The condition operators only tested scalars (`is`, `isSet`, `gte`, …), so a **multiselect** field couldn't drive conditional field visibility — `isSet` only tells you the array is non-empty, not which values it holds. This adds the missing piece:

```js
schemaEnhancer: {
  fieldRules: {
    // `elements` is a multiselect: ['image', 'date', 'tag'].
    // Reveal each element's own field only when it's selected.
    date: { when: { elements: { contains: 'date' } }, else: false },
    tag:  { when: { elements: { contains: 'tag'  } }, else: false },
  },
}
```

`{ contains: 'date' }` matches when the value is an array that includes `'date'`; a non-array / unset multiselect never contains anything, so the condition fails closed. `notContains` is the inverse.

## Tests

TDD, via the public `createSchemaEnhancerFromRecipe` entry (exactly how a frontend sends the recipe): `contains` keeps/hides the field by membership and hides on empty/unset; `notContains` covers the inverse including the unset case. 9 cases in `schemaInheritance.test.js`.

## Docs

`custom-blocks.md` operator list + the multiselect example; docs content JSON re-synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr
