### PR TITLE
doc videos: on-screen captions + tolerate static media-asset URLs

### DIFF
--- a/tests-playwright/demo-video/caption.ts
+++ b/tests-playwright/demo-video/caption.ts
@@ -1,0 +1,58 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * On-screen captions burned into the Playwright-recorded demo video.
+ *
+ * Playwright has no native video-caption API, so we render the caption as a
+ * single fixed overlay inside the recorded page. The demo capture already
+ * describes each beat with a label; `showCaption` turns that label into text
+ * the viewer actually sees, so the loop reads as a narrated walkthrough
+ * instead of a silent screen recording.
+ *
+ * The overlay is `pointer-events: none` and lives on the top-level admin page
+ * (not the iframe), so it never intercepts the actions being demoed and
+ * survives iframe reloads / frontend switches.
+ */
+const CAPTION_ID = '__hydra_demo_caption__';
+
+/** Show or update the caption. Pass '' to hide it. */
+export async function showCaption(page: Page, text: string): Promise<void> {
+  await page.evaluate(
+    ({ id, text }) => {
+      let el = document.getElementById(id) as HTMLDivElement | null;
+      if (!el) {
+        el = document.createElement('div');
+        el.id = id;
+        Object.assign(el.style, {
+          position: 'fixed',
+          left: '50%',
+          bottom: '32px',
+          transform: 'translateX(-50%)',
+          zIndex: '2147483647',
+          maxWidth: 'min(82vw, 880px)',
+          padding: '12px 22px',
+          background: 'rgba(17, 17, 26, 0.86)',
+          color: '#fff',
+          font: '600 20px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif',
+          textAlign: 'center',
+          borderRadius: '12px',
+          boxShadow: '0 6px 24px rgba(0, 0, 0, 0.35)',
+          pointerEvents: 'none',
+          opacity: '0',
+          transition: 'opacity 180ms ease',
+        } as CSSStyleDeclaration);
+        document.body.appendChild(el);
+      }
+      el.textContent = text;
+      el.style.opacity = text ? '1' : '0';
+    },
+    { id: CAPTION_ID, text },
+  );
+}
+
+/** Remove the caption overlay entirely. */
+export async function clearCaption(page: Page): Promise<void> {
+  await page.evaluate((id) => {
+    document.getElementById(id)?.remove();
+  }, CAPTION_ID);
+}

--- a/tests-playwright/demo-video/capture.spec.ts
+++ b/tests-playwright/demo-video/capture.spec.ts
@@ -22,15 +22,18 @@ import { fileURLToPath } from 'url';
 import { test, expect } from '../fixtures';
 import { AdminUIHelper } from '../helpers/AdminUIHelper';
 import { PORTS, URLS } from '../ports';
+import { showCaption } from './caption';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SHOWCASE_PATH = '/showcase-page';
 const BEAT_MS = 900;
 const TRIM_MARKER_FILE = path.join(SCRIPT_DIR, '.recordings', 'trim-ms.txt');
 
-async function beat(page: import('@playwright/test').Page, label: string) {
-  // No-op marker that just paces the recording. `label` shows up in the
-  // playwright trace if anyone enables tracing for debugging.
+async function beat(page: import('@playwright/test').Page, caption: string) {
+  // Paces the recording AND shows `caption` as an on-screen caption burned
+  // into the video, so the loop reads as a narrated walkthrough. The caption
+  // also shows up in the playwright trace for debugging.
+  await showCaption(page, caption);
   await page.waitForTimeout(BEAT_MS);
 }
 
@@ -98,7 +101,7 @@ test('hydra-demo — homepage hero loop', async ({ page }) => {
   await page.keyboard.type(' Edit anywhere.', { delay: 40 });
   await expect(iframe.locator('[data-block-uid="intro"]'))
     .toContainText('Edit anywhere.', { timeout: 5_000 });
-  await beat(page, 'slate edit');
+  await beat(page, 'Edit any text, inline');
 
   // Beat 2 — bold the phrase we just typed (Quanta toolbar).
   // No DOM-level assertion — Slate's bold rendering varies by frontend
@@ -107,21 +110,21 @@ test('hydra-demo — homepage hero loop', async ({ page }) => {
   await page.keyboard.press('Shift+Home');
   await page.waitForTimeout(200);
   await page.keyboard.press('Meta+B');
-  await beat(page, 'format');
+  await beat(page, 'Format with the toolbar');
 
   // Beat 3 — drop into block mode, drag the intro paragraph past the
   // adjacent column block to show DnD reflow. The dragBlockAfter helper
   // asserts the drop completed; the post-drop DOM order is implicit.
   await helper.escapeFromEditing();
-  await beat(page, 'block mode');
+  await beat(page, 'Switch to block mode');
   await helper.dragBlockAfter('intro', 'after-columns');
-  await beat(page, 'dnd');
+  await beat(page, 'Drag blocks to reorder');
 
   // Beat 4 — click into the columns container. waitForBlockSelectedInAdmin
   // is the assertion; the helper fails if the selection state doesn't land.
   await helper.clickBlockInIframe('columns-1');
   await helper.waitForBlockSelectedInAdmin('columns-1');
-  await beat(page, 'container selected');
+  await beat(page, 'Select a container block');
 
   // Beat 5 — open the frontend switcher panel, switch to mobile
   // viewport, then click F7 Mobile. The iframe swaps to the F7
@@ -134,6 +137,7 @@ test('hydra-demo — homepage hero loop', async ({ page }) => {
   // read the entry names (each frontend has a label like "Nuxt blog"
   // or "F7 Mobile") and see the mobile-width transition land before
   // the F7 frontend loads.
+  await showCaption(page, 'Preview in any frontend');
   await page.locator('#toolbar-frontend-switcher').click();
   const panel = page.locator('.frontend-switcher-panel');
   await panel.waitFor({ state: 'visible' });
@@ -142,6 +146,7 @@ test('hydra-demo — homepage hero loop', async ({ page }) => {
 
   // Switch to mobile viewport first so the F7 frontend lands at the
   // intended phone width rather than full-bleed desktop.
+  await showCaption(page, 'Switch to a mobile view');
   await panel.getByLabel('Mobile').click();
   // Allow the iframe-max-width transition to finish visibly.
   await page.waitForTimeout(1_500);
@@ -156,5 +161,6 @@ test('hydra-demo — homepage hero loop', async ({ page }) => {
   }).toPass({ timeout: 5_000 });
   // Let the F7 frontend finish loading inside the iframe so the swap
   // is visibly captured (not just the URL change).
+  await showCaption(page, 'Same content, another design system');
   await page.waitForTimeout(3_000);
 });

--- a/tests-playwright/fixtures/plone-content-validator.cjs
+++ b/tests-playwright/fixtures/plone-content-validator.cjs
@@ -365,6 +365,10 @@ function checkIntegrity(contentDir) {
     if (/^https?:\/\//.test(ref)) return null;             // external — well-formed, unverifiable offline
     if (/^(mailto:|tel:|data:)/.test(ref)) return null;    // known schemes
     if (ref.startsWith('#')) return null;                  // in-page anchor
+    // Static frontend media assets (e.g. generated doc demo clips served from
+    // the frontend's public/ dir, like `/docs/cards/x.mp4`) — not Plone
+    // content, verifiable only in a built frontend, like external URLs.
+    if (/\.(mp4|webm|mov|m4v|ogv)(\?|#|$)/i.test(ref)) return null;
     if (ref.startsWith('/') || ref.startsWith('../')) {
       // strip ../ prefixes, scale suffixes (@@images/…) and resource views (/++…)
       let base = ref.replace(/^(\.\.\/)+/, '');


### PR DESCRIPTION
## What

Adds on-screen **captions** to the demo-video capture, so the docs-homepage loop reads as a narrated walkthrough instead of a silent screen recording.

Playwright has no native video-caption API, so this renders the caption as a single fixed overlay inside the recorded admin page (`caption.ts`) and drives it from the capture's **beat labels** — which were previously no-op debug strings. Each beat now narrates itself:

- "Edit any text, inline"
- "Format with the toolbar"
- "Switch to block mode" → "Drag blocks to reorder"
- "Select a container block"
- "Preview in any frontend" → "Switch to a mobile view" → "Same content, another design system"

The overlay is `pointer-events: none` and lives on the top-level admin page (not the iframe), so it never intercepts the demoed actions and survives iframe reloads / frontend switches.

## Reusable

`showCaption(page, text)` / `clearCaption(page)` — usable by any Playwright-recorded doc clip.

## Verified

- The overlay renders, centres, and hides (opacity → 0 on empty text) — checked standalone.
- `caption.ts` typechecks; the capture spec edits are additive (import + caption text on existing beats). Full render requires `pnpm demo:capture` + `pnpm demo:encode` (the 4 demo servers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr
