### PR TITLE
Restrict add-chooser to the synced type in a synced container

### DIFF
--- a/packages/hydra-js/buildBlockPathMap.js
+++ b/packages/hydra-js/buildBlockPathMap.js
@@ -18,6 +18,44 @@ import { getBlockType } from '@volto-hydra/helpers';
 // importing from @volto-hydra/hydra-js (which would pull in Volto deps).
 const PAGE_BLOCK_UID = '_page';
 
+/**
+ * The block types you can ADD into a container field — the single source of
+ * truth every add path reads (it becomes each child's `allowedSiblingTypes`,
+ * which the block chooser, Enter-to-add and drag validation all consume).
+ *
+ * A plain field allows all of `allowedBlocks`. A SYNCED field — one whose
+ * blocks-field def declares an `itemTypeField` (a sibling field, e.g.
+ * `variation`, that drives every child's `@type`) — holds a single item type
+ * chosen once on the parent. Adding must not introduce a *different*
+ * convertible item type, so the addable set is:
+ *   the currently-synced type  +  any structural blocks that aren't convertible
+ *   item types (no `fieldMappings['@default']` — e.g. a `listing`).
+ * The other convertible item types are reached by changing the parent's
+ * `itemTypeField`, not by adding a foreign block into the synced container.
+ *
+ * @param {string[]} allowedBlocks   the field's allowedBlocks
+ * @param {string} [itemTypeField]   the field's sync field name (undefined = not synced)
+ * @param {Object} [containerBlock]  the container block's data (source of the synced type)
+ * @param {Object} [blocksConfig]
+ * @returns {string[]}
+ */
+export function addableSiblingTypes(
+  allowedBlocks,
+  itemTypeField,
+  containerBlock,
+  blocksConfig,
+) {
+  if (!Array.isArray(allowedBlocks) || !itemTypeField) return allowedBlocks;
+  const syncedType = containerBlock?.[itemTypeField];
+  if (!syncedType) return allowedBlocks;
+  return allowedBlocks.filter(
+    (type) =>
+      type === syncedType ||
+      // structural (non-convertible) blocks stay addable alongside the item type
+      !blocksConfig?.[type]?.fieldMappings?.['@default'],
+  );
+}
+
 // Cache for getBlockTypeSchema — keyed by blockType
 const _typeSchemaCache = new Map();
 
@@ -578,7 +616,12 @@ export function buildBlockPathMap(formData, blocksConfig, intl = {}) {
         // set: that set is the UNION of all page regions' allowedBlocks, so it can't express
         // per-region restrictions (footer vs items may allow different blocks). effectiveAllowedBlocks
         // already IS the region's field def; the old intersection was a no-op (region ⊆ union).
-        allowedSiblingTypes: effectiveAllowedBlocks || defaultPageAllowedBlocks,
+        allowedSiblingTypes: addableSiblingTypes(
+          effectiveAllowedBlocks || defaultPageAllowedBlocks,
+          fieldDef.itemTypeField,
+          parent,
+          blocksConfig,
+        ),
         allowedTemplates: fieldDef.allowedTemplates || null,
         maxSiblings: effectiveMaxLength,
         siblingCount: layout.length, // Total siblings in this container
@@ -725,7 +768,14 @@ export function buildBlockPathMap(formData, blocksConfig, intl = {}) {
         _schemaRef: storeSchema(blockSchema), // Deduplicated schema reference
         itemSchema: effectiveItemSchema, // null for typed items (schema from blocksConfig)
         dataPath: effectiveDataPath, // Store for later use
-        allowedSiblingTypes: hasAllowedBlocks ? fieldDef.allowedBlocks : [virtualType],
+        allowedSiblingTypes: hasAllowedBlocks
+          ? addableSiblingTypes(
+              fieldDef.allowedBlocks,
+              fieldDef.itemTypeField,
+              parent,
+              blocksConfig,
+            )
+          : [virtualType],
         maxSiblings: fieldDef.maxLength || null,
         siblingCount: itemsArray.length,
         addMode, // Table mode for this container (e.g., rows)

--- a/packages/hydra-js/regions.test.js
+++ b/packages/hydra-js/regions.test.js
@@ -9,7 +9,7 @@
  * No `regions` map, no synthesised 'items'.
  */
 
-import { getBlocksFieldNames, buildBlockPathMap, getPageAllowedBlocksFromRestricted } from './buildBlockPathMap.js';
+import { getBlocksFieldNames, buildBlockPathMap, getPageAllowedBlocksFromRestricted, addableSiblingTypes } from './buildBlockPathMap.js';
 import { mapLayoutItems } from './containerOps.js';
 
 describe('getBlocksFieldNames', () => {
@@ -140,5 +140,69 @@ describe('buildBlockPathMap — page blocks fields', () => {
       blocksConfig,
     );
     expect(map['footer-1']?.region).toBe('footer');
+  });
+});
+
+describe('addableSiblingTypes — synced container add restriction', () => {
+  const blocksConfig = {
+    grid: {
+      blockSchema: {
+        properties: {
+          items: {
+            widget: 'blocks_layout',
+            itemTypeField: 'variation',
+            allowedBlocks: ['card', 'contentBlock', 'image', 'listing'],
+          },
+          variation: { widget: 'blockTypeSelect' },
+        },
+      },
+    },
+    // Convertible item types (have an @default mapping).
+    card: { fieldMappings: { '@default': { '@id': 'url', title: 'title' } } },
+    contentBlock: { fieldMappings: { '@default': { '@id': 'url', title: 'title' } } },
+    image: { fieldMappings: { '@default': { '@id': 'url', image: 'image' } } },
+    // Structural child — no @default mapping.
+    listing: {},
+  };
+
+  test('restricts convertible item types to the synced one, keeps structural', () => {
+    const allowed = ['card', 'contentBlock', 'image', 'listing'];
+    const grid = { '@type': 'grid', variation: 'card' };
+    expect(addableSiblingTypes(allowed, 'variation', grid, blocksConfig)).toEqual([
+      'card',
+      'listing',
+    ]);
+  });
+
+  test('a plain field (no itemTypeField) is unchanged', () => {
+    expect(
+      addableSiblingTypes(['slate', 'image'], undefined, {}, blocksConfig),
+    ).toEqual(['slate', 'image']);
+  });
+
+  test('an unset synced type leaves the full list (no over-restriction)', () => {
+    const grid = { '@type': 'grid' };
+    expect(
+      addableSiblingTypes(['card', 'listing'], 'variation', grid, blocksConfig),
+    ).toEqual(['card', 'listing']);
+  });
+
+  test('buildBlockPathMap: a card grid child can only add the card + listing, not another item type', () => {
+    const formData = {
+      '@type': 'Document',
+      blocks: {
+        'grid-1': {
+          '@type': 'grid',
+          variation: 'card',
+          blocks: { 'card-1': { '@type': 'card' } },
+          blocks_layout: { items: ['card-1'] },
+        },
+      },
+      blocks_layout: { items: ['grid-1'] },
+    };
+    const map = buildBlockPathMap(formData, blocksConfig);
+    expect(map['card-1'].allowedSiblingTypes).toEqual(['card', 'listing']);
+    expect(map['card-1'].allowedSiblingTypes).not.toContain('contentBlock');
+    expect(map['card-1'].allowedSiblingTypes).not.toContain('image');
   });
 });


### PR DESCRIPTION
## Problem

A blocks field with an `itemTypeField` (a **synced container** — e.g. a card grid whose `variation` drives every child's `@type`) is meant to hold one item type, chosen once on the parent. But the block **add chooser** offered the field's entire `allowedBlocks`, so you could add a *different* convertible item type — e.g. drop a `contentBlock` or `image` into a card grid — silently breaking the sync.

The `allowedBlocks` list can't just be narrowed: `variation`'s dropdown choices are computed from it. And the Enter-to-add path already stayed on the source type — only the chooser leaked.

## Fix — centralised

`allowedSiblingTypes` on the blockPathMap is the single source every add path reads (chooser, Enter-add, drag validation). It's now computed through one helper, `addableSiblingTypes`, applied at **both** `buildBlockPathMap` chokepoints (blocks_layout + object_list):

- not a synced field → `allowedBlocks` unchanged;
- synced → the **currently-synced type** + **structural blocks that aren't convertible item types** (no `fieldMappings['@default']`, e.g. `listing`).

The other item types are reached by changing the parent's `itemTypeField`, not by adding a foreign block.

## Tests

`packages/hydra-js/regions.test.js`: unit cases for the helper (restricts convertible types to the synced one, keeps structural, leaves plain/unset fields alone) + a `buildBlockPathMap` guard that a card grid child can only add `card` + `listing`, not `contentBlock`/`image`. Full hydra-js suite green (151).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr
