### PR TITLE
feat(#245): widget:'object' nesting + unified /-path field access, DOM→pathMap guardrail

### DIFF
--- a/docs/container-blocks.md
+++ b/docs/container-blocks.md
@@ -188,28 +188,23 @@ table: { widget: 'object', schema: { properties: {
   "table": { "blocks": { "b1": { /* … */ } }, "blocks_layout": { "body": ["b1"] } } }
 ```
 
-A **plain field** inside an object is edited in the canvas like any top-level field — you just address it by its **`/`-path**. A `data-edit-*` value is a path resolved against the schema:
-
-- `field` — this block's own field
-- `content/field` — descend the `content` object to a nested field (object keys mirror the storage path)
-- `..` — the parent **block** (never up an object level)
-- `/field` — a page/root field
-
-The **same `/`-path works for every inline field kind** — text, links, and media — because they all resolve a field the same way:
-
-<!-- codeExample: html -->
-```html
-<!-- all three fields live on the `content` object of this block -->
-<h3 data-edit-text="content/headline">…</h3>
-<a  data-edit-link="content/href">…</a>
-<img data-edit-media="content/image" />
-```
-
-Each writes back to its nested location (`block.content.headline`, `block.content.href`, `block.content.image`) — never a flat key.
+A **plain field** inside an object is edited in the canvas like any top-level field — address it inline with its `/`-path (`data-edit-text="content/headline"`, and the same for `data-edit-link` / `data-edit-media`). The object is *transparent*: `content/headline` writes back to `block.content.headline`, never a flat key. See [Field Path Syntax](visual-editing.md#field-path-syntax) for the full grammar (`/` object descent, `..` = parent block, `/field` = page).
 
 Blocks inside a nested container are edited in the canvas like any other container. The sidebar prefixes a nested container's **title** with the path (e.g. **Table / Rows**) so the nesting is visible.
 
 This replaces `dataPath`: declare the container inside the object rather than hoisting it to the block's top level with a `dataPath` back-reference.
+
+## Container schema reference
+
+A block's schema is a standard [Volto block schema](https://6.docs.plone.org/volto/blocks/editcomponent.html) (fieldsets, `properties`, widgets, `default`, etc.). Hydra reads three container-oriented `widget` values plus a few per-field keys — those are:
+
+| `widget` | Storage | Key fields |
+|---|---|---|
+| `blocks_layout` | children are ids in the parent's shared `blocks` dict; this field's name is a region key under `blocks_layout` | `allowedBlocks`, `maxLength`, `allowedTemplates` |
+| `object_list` | inline array on the field itself | `idField` (default `@id`), `schema` (item schema), `allowedBlocks` + `typeField` (typed items), `defaultBlockType`, `maxLength`, `addMode: 'table'` |
+| `object` | groups sub-fields under one key; sub-fields (plain OR the two container widgets above) nest inside | `schema` (the nested properties) |
+
+All three can nest inside `object`, and a container may mix a `blocks_layout` region and an `object_list` region. Everything else in a field def (`title`, `default`, `type`, `choices`, `mode`, …) is plain Volto and behaves as documented there.
 
 ## Rendering Containers in Your Frontend
 

--- a/docs/container-blocks.md
+++ b/docs/container-blocks.md
@@ -100,7 +100,7 @@ The backend deserializer only saves values for **registered fields**. `blocks` a
 
 ## object_list: a region stored inline
 
-The other storage choice for a region. Instead of ordering in the shared `blocks_layout` dict, all items share one inline schema and are stored as an array with an ID field on the field itself. Use `dataPath` when the data is nested within the block:
+The other storage choice for a region. Instead of ordering in the shared `blocks_layout` dict, all items share one inline schema and are stored as an array with an ID field, at the field itself. (To place the array deeper — e.g. `block.table.rows` — nest the field inside a `widget: 'object'`; see below.)
 
 <!-- codeExample: javascript -->
 ```javascript
@@ -109,7 +109,6 @@ slides: {
     title: 'Slides',
     widget: 'object_list',
     idField: '@id',
-    dataPath: ['data', 'rows'],  // optional path when data is nested
     schema: {
         properties: {
             title: { title: 'Title' },
@@ -119,15 +118,13 @@ slides: {
     }
 }
 
-// Resulting data (note: nested under dataPath)
+// Resulting data — the array is stored at the field
 {
   "@type": "slider",
-  "data": {
-    "slides": [
-      { "@id": "slide-1", "title": "First", "image": "..." },
-      { "@id": "slide-2", "title": "Second", "image": "..." }
-    ]
-  }
+  "slides": [
+    { "@id": "slide-1", "title": "First", "image": "..." },
+    { "@id": "slide-2", "title": "Second", "image": "..." }
+  ]
 }
 ```
 
@@ -159,6 +156,42 @@ facets: {
 
 Both `blocks_layout` and `object_list` look the same in the editing UI and blocks can be dragged between them — data is automatically adapted when moving between formats (ID fields added/stripped, type fields set appropriately).
 
+## widget: 'object': nesting fields (and containers) inside a block field
+
+A `widget: 'object'` field groups sub-fields under one key. Its `schema.properties` are first-class — plain fields OR nested containers — and everything nests **inside** the object, exactly where the schema puts it. No `dataPath` indirection.
+
+An **`object_list`** inside an object stores its array at `object.<field>`:
+
+<!-- codeExample: javascript -->
+```javascript
+// A table block whose rows live at block.table.rows
+table: {
+    widget: 'object',
+    schema: { properties: {
+        rows: { widget: 'object_list', idField: 'key',
+                schema: { properties: { cells: { widget: 'object_list', idField: 'key' /* … */ } } } },
+    } },
+}
+// data
+{ "@type": "slateTable", "table": { "rows": [ { "key": "r1", "cells": [ /* … */ ] } ] } }
+```
+
+A **`blocks_layout`** inside an object makes the object its own mini-container: it holds its own `blocks` dict + `blocks_layout`, just like a columns/grid container block, one level deeper:
+
+<!-- codeExample: javascript -->
+```javascript
+table: { widget: 'object', schema: { properties: {
+    body: { widget: 'blocks_layout' },
+} } }
+// data
+{ "@type": "slateTable",
+  "table": { "blocks": { "b1": { /* … */ } }, "blocks_layout": { "body": ["b1"] } } }
+```
+
+A nested field keeps its normal row in the parent's child widget; the sidebar prefixes the row **title** with the path (e.g. **Table / Rows**) so the nesting is visible. Blocks inside a nested container are edited in the canvas like any other container.
+
+This replaces `dataPath`: declare the container inside the object rather than hoisting it to the block's top level with a `dataPath` back-reference.
+
 ## Rendering Containers in Your Frontend
 
 Add `data-block-uid` to each child element. You don't need to mark the container element itself:
@@ -186,29 +219,28 @@ Add `data-block-uid` to each child element. You don't need to mark the container
 
 ## Table Mode
 
-Set `addMode: 'table'` for table-like structures (rows containing cells). This lets users add and remove columns as easily as rows:
+Set `addMode: 'table'` for table-like structures (rows containing cells). This lets users add and remove columns as easily as rows. The rows live inside a `table` object field (`block.table.rows`) — no `dataPath`:
 
 <!-- codeExample: javascript -->
 ```javascript
-rows: {
-    widget: 'object_list',
-    idField: 'key',
-    addMode: 'table',
-    dataPath: ['table', 'rows'],
-    schema: {
-        properties: {
-            cells: {
-                widget: 'object_list',
-                idField: 'key',
-                schema: {
-                    properties: {
-                        value: { title: 'Content',
-                                 widget: 'slate' }
-                    }
-                }
-            }
-        }
-    }
+table: {
+    widget: 'object',
+    schema: { properties: {
+        rows: {
+            widget: 'object_list',
+            idField: 'key',
+            addMode: 'table',
+            schema: { properties: {
+                cells: {
+                    widget: 'object_list',
+                    idField: 'key',
+                    schema: { properties: {
+                        value: { title: 'Content', widget: 'slate' },
+                    } },
+                },
+            } },
+        },
+    } },
 }
 ```
 

--- a/docs/container-blocks.md
+++ b/docs/container-blocks.md
@@ -188,7 +188,26 @@ table: { widget: 'object', schema: { properties: {
   "table": { "blocks": { "b1": { /* … */ } }, "blocks_layout": { "body": ["b1"] } } }
 ```
 
-A nested field keeps its normal row in the parent's child widget; the sidebar prefixes the row **title** with the path (e.g. **Table / Rows**) so the nesting is visible. Blocks inside a nested container are edited in the canvas like any other container.
+A **plain field** inside an object is edited in the canvas like any top-level field — you just address it by its **`/`-path**. A `data-edit-*` value is a path resolved against the schema:
+
+- `field` — this block's own field
+- `content/field` — descend the `content` object to a nested field (object keys mirror the storage path)
+- `..` — the parent **block** (never up an object level)
+- `/field` — a page/root field
+
+The **same `/`-path works for every inline field kind** — text, links, and media — because they all resolve a field the same way:
+
+<!-- codeExample: html -->
+```html
+<!-- all three fields live on the `content` object of this block -->
+<h3 data-edit-text="content/headline">…</h3>
+<a  data-edit-link="content/href">…</a>
+<img data-edit-media="content/image" />
+```
+
+Each writes back to its nested location (`block.content.headline`, `block.content.href`, `block.content.image`) — never a flat key.
+
+Blocks inside a nested container are edited in the canvas like any other container. The sidebar prefixes a nested container's **title** with the path (e.g. **Table / Rows**) so the nesting is visible.
 
 This replaces `dataPath`: declare the container inside the object rather than hoisting it to the block's top level with a `dataPath` back-reference.
 

--- a/docs/content/content/content/docs/container-blocks/data.json
+++ b/docs/content/content/content/docs/container-blocks/data.json
@@ -366,7 +366,109 @@
         }
       ]
     },
-    "h-10": {
+    "p-10": {
+      "@type": "slate",
+      "plaintext": "> **The region name is a key inside `blocks_layout` — not a top-level field.** The > ordering list lives at `blocks_layout.<region>` (a plain array of ids). A tempting > mistake is to store it as a top-level field named after the region: > > <!-- codeExample: json --> > ```json > // ✅ CORRECT — ordering keyed inside the shared blocks_layout dict > { \"@type\": \"slider\", \"blocks\": { … }, \"blocks_layout\": { \"slides\": [\"slide-1\", \"slide-2\"] } } > > // ❌ WRONG — an ad-hoc top-level `slides` field holding { items: [...] } > { \"@type\": \"slider\", \"blocks\": { … }, \"slides\": { \"items\": [\"slide-1\", \"slide-2\"] } } > ``` > > The wrong form may *look* fine in a frontend that reads it back the same way, but > `slides` is **not a registered field**, so the backend **silently drops it on save** > (see [Why these persist](#why-these-persist-and-separate-top-level-fields-dont)) — > and tools that walk the shared dict (the block path map, the sanity checks, the > editor's reorder/drag) never see the region, because they look under > `blocks_layout`, never at a field named for the region. Renderers must read the > ordering from `blocks_layout[<region>]`, not from `<region>.items`.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "> "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "The region name is a key inside `blocks_layout` — not a top-level field."
+                }
+              ]
+            },
+            {
+              "text": " The > ordering list lives at "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "blocks_layout.<region>"
+                }
+              ]
+            },
+            {
+              "text": " (a plain array of ids). A tempting > mistake is to store it as a top-level field named after the region: > > <!-- codeExample: json --> > ``"
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "json > // ✅ CORRECT — ordering keyed inside the shared blocks_layout dict > { \"@type\": \"slider\", \"blocks\": { … }, \"blocks_layout\": { \"slides\": [\"slide-1\", \"slide-2\"] } } > > // ❌ WRONG — an ad-hoc top-level "
+                }
+              ]
+            },
+            {
+              "text": "slides"
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": " field holding { items: [...] } > { \"@type\": \"slider\", \"blocks\": { … }, \"slides\": { \"items\": [\"slide-1\", \"slide-2\"] } } > "
+                }
+              ]
+            },
+            {
+              "text": "`"
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": " > > The wrong form may *look* fine in a frontend that reads it back the same way, but > "
+                }
+              ]
+            },
+            {
+              "text": "slides"
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": " is **not a registered field**, so the backend **silently drops it on save** > (see [Why these persist](#why-these-persist-and-separate-top-level-fields-dont)) — > and tools that walk the shared dict (the block path map, the sanity checks, the > editor's reorder/drag) never see the region, because they look under > "
+                }
+              ]
+            },
+            {
+              "text": "blocks_layout"
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": ", never at a field named for the region. Renderers must read the > ordering from "
+                }
+              ]
+            },
+            {
+              "text": "blocks_layout[<region>]"
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": ", not from "
+                }
+              ]
+            },
+            {
+              "text": "<region>.items`."
+            }
+          ]
+        }
+      ]
+    },
+    "h-11": {
       "@type": "slate",
       "plaintext": "Multiple regions",
       "value": [
@@ -380,7 +482,7 @@
         }
       ]
     },
-    "p-11": {
+    "p-12": {
       "@type": "slate",
       "plaintext": "A container (or the page) can declare more than one **region** — each a schema property with its own `allowedBlocks`. The default region is `items`.",
       "value": [
@@ -427,7 +529,7 @@
         }
       ]
     },
-    "p-12": {
+    "p-13": {
       "@type": "slate",
       "plaintext": "Storage is a property of **each region, not the container**: every region independently chooses `widget: 'blocks_layout'` or `widget: 'object_list'`, and a single container may **mix** them — e.g. a `blocks_layout` region for body content alongside an `object_list` region for a set of inline cards. A blocks_layout region keys its ordering inside the shared `blocks_layout` dict (its children in the shared `blocks` dict); an object_list region stores its items inline on its own field. So \"is this container object_list or blocks_layout?\" is never a meaningful question — you look at the region. Every blocks_layout region's children still share the one `blocks` dict; the regions only partition *ordering*.",
       "value": [
@@ -551,18 +653,18 @@
         }
       ]
     },
-    "ce-13": {
+    "ce-14": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-13-javascript-656230",
+          "@id": "ce-14-javascript-3ea062",
           "label": "Javascript",
           "language": "javascript",
           "code": "// Schema definition — a page with a header, main content, and a footer\nproperties: {\n    header: { widget: 'blocks_layout', title: 'Header', allowedBlocks: ['slate', 'image'], maxLength: 3 },\n    items:  { widget: 'blocks_layout', allowedBlocks: ['slate', 'image'] },\n    footer: { widget: 'blocks_layout', title: 'Footer', allowedBlocks: ['slate', 'link'] },\n}\n\n// Resulting data — ONE shared blocks dict, one list per blocks field\n{\n  \"blocks\": {\n    \"header-1\": { \"@type\": \"image\" },\n    \"hero-1\":   { \"@type\": \"slate\" },\n    \"footer-1\": { \"@type\": \"slate\" }\n  },\n  \"blocks_layout\": {\n    \"header\": [\"header-1\"],\n    \"items\":  [\"hero-1\"],\n    \"footer\": [\"footer-1\"]\n  }\n}"
         }
       ]
     },
-    "p-14": {
+    "p-15": {
       "@type": "slate",
       "plaintext": "Each blocks field has its own `allowedBlocks` / `maxLength`. A declared field appears in the editor even when empty (it gets a seeded empty block so it is editable and a drop target).",
       "value": [
@@ -598,7 +700,7 @@
         }
       ]
     },
-    "h-15": {
+    "h-16": {
       "@type": "slate",
       "plaintext": "Why these persist (and separate top-level fields don't)",
       "value": [
@@ -612,7 +714,7 @@
         }
       ]
     },
-    "p-16": {
+    "p-17": {
       "@type": "slate",
       "plaintext": "`blocks_layout` regions live as **keys inside the registered `blocks_layout` dict** rather than as separate top-level fields (the older `header_blocks` / `footer_blocks` style) for one concrete reason: **persistence**.",
       "value": [
@@ -678,7 +780,7 @@
         }
       ]
     },
-    "p-17": {
+    "p-18": {
       "@type": "slate",
       "plaintext": "The backend deserializer only saves values for **registered fields**. `blocks` and `blocks_layout` are registered behavior fields, so the entire `blocks_layout` dict — every list inside it — is stored verbatim. An ad-hoc top-level field like `footer_blocks` is **not** a registered field, so the backend **silently drops it on save**. (A footer might still appear on the live site if a layout template re-injects it on every load — but that footer is never actually persisted.) Keeping every region inside the registered `blocks_layout` dict makes them all persist for real.",
       "value": [
@@ -780,7 +882,7 @@
         }
       ]
     },
-    "h-18": {
+    "h-19": {
       "@type": "slate",
       "plaintext": "object_list: a region stored inline",
       "value": [
@@ -794,9 +896,9 @@
         }
       ]
     },
-    "p-19": {
+    "p-20": {
       "@type": "slate",
-      "plaintext": "The other storage choice for a region. Instead of ordering in the shared `blocks_layout` dict, all items share one inline schema and are stored as an array with an ID field on the field itself. Use `dataPath` when the data is nested within the block:",
+      "plaintext": "The other storage choice for a region. Instead of ordering in the shared `blocks_layout` dict, all items share one inline schema and are stored as an array with an ID field, at the field itself. (To place the array deeper — e.g. `block.table.rows` — nest the field inside a `widget: 'object'`; see below.)",
       "value": [
         {
           "type": "p",
@@ -813,35 +915,46 @@
               ]
             },
             {
-              "text": " dict, all items share one inline schema and are stored as an array with an ID field on the field itself. Use "
+              "text": " dict, all items share one inline schema and are stored as an array with an ID field, at the field itself. (To place the array deeper — e.g. "
             },
             {
               "type": "code",
               "children": [
                 {
-                  "text": "dataPath"
+                  "text": "block.table.rows"
                 }
               ]
             },
             {
-              "text": " when the data is nested within the block:"
+              "text": " — nest the field inside a "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "widget: 'object'"
+                }
+              ]
+            },
+            {
+              "text": "; see below.)"
             }
           ]
         }
       ]
     },
-    "ce-20": {
+    "ce-21": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-20-javascript-e91f7c",
+          "@id": "ce-21-javascript-83a0dc",
           "label": "Javascript",
           "language": "javascript",
-          "code": "// Schema\nslides: {\n    title: 'Slides',\n    widget: 'object_list',\n    idField: '@id',\n    dataPath: ['data', 'rows'],  // optional path when data is nested\n    schema: {\n        properties: {\n            title: { title: 'Title' },\n            image: { title: 'Image', widget: 'image' },\n            description: { title: 'Description', widget: 'slate' },\n        }\n    }\n}\n\n// Resulting data (note: nested under dataPath)\n{\n  \"@type\": \"slider\",\n  \"data\": {\n    \"slides\": [\n      { \"@id\": \"slide-1\", \"title\": \"First\", \"image\": \"...\" },\n      { \"@id\": \"slide-2\", \"title\": \"Second\", \"image\": \"...\" }\n    ]\n  }\n}"
+          "code": "// Schema\nslides: {\n    title: 'Slides',\n    widget: 'object_list',\n    idField: '@id',\n    schema: {\n        properties: {\n            title: { title: 'Title' },\n            image: { title: 'Image', widget: 'image' },\n            description: { title: 'Description', widget: 'slate' },\n        }\n    }\n}\n\n// Resulting data — the array is stored at the field\n{\n  \"@type\": \"slider\",\n  \"slides\": [\n    { \"@id\": \"slide-1\", \"title\": \"First\", \"image\": \"...\" },\n    { \"@id\": \"slide-2\", \"title\": \"Second\", \"image\": \"...\" }\n  ]\n}"
         }
       ]
     },
-    "h-21": {
+    "h-22": {
       "@type": "slate",
       "plaintext": "object_list with allowedBlocks: Typed Items",
       "value": [
@@ -855,7 +968,7 @@
         }
       ]
     },
-    "p-22": {
+    "p-23": {
       "@type": "slate",
       "plaintext": "When `allowedBlocks` is set on an `object_list`, items can have different types (like `blocks_layout`) but are still stored as an array. Each item's type is stored in the field specified by `typeField` (defaults to `'@type'`) and its schema is looked up from `blocks`:",
       "value": [
@@ -935,18 +1048,18 @@
         }
       ]
     },
-    "ce-23": {
+    "ce-24": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-23-html-308624",
+          "@id": "ce-24-javascript-6781ed",
           "label": "Javascript",
           "language": "javascript",
           "code": "facets: {\n    title: 'Facets',\n    widget: 'object_list',\n    allowedBlocks: ['checkboxFacet', 'selectFacet'],\n    typeField: 'type',\n    defaultBlockType: 'checkboxFacet',\n}\n\n// Resulting data\n{\n  \"@type\": \"search\",\n  \"facets\": [\n    { \"@id\": \"facet-1\", \"type\": \"checkboxFacet\",\n      \"title\": \"Content Type\", \"field\": \"portal_type\" },\n    { \"@id\": \"facet-2\", \"type\": \"selectFacet\",\n      \"title\": \"Subject\", \"field\": \"Subject\" }\n  ]\n}"
         }
       ]
     },
-    "p-24": {
+    "p-25": {
       "@type": "slate",
       "plaintext": "Both `blocks_layout` and `object_list` look the same in the editing UI and blocks can be dragged between them — data is automatically adapted when moving between formats (ID fields added/stripped, type fields set appropriately).",
       "value": [
@@ -982,7 +1095,939 @@
         }
       ]
     },
-    "h-25": {
+    "h-26": {
+      "@type": "slate",
+      "plaintext": "widget: 'object': nesting fields (and containers) inside a block field",
+      "value": [
+        {
+          "type": "h2",
+          "children": [
+            {
+              "text": "widget: 'object': nesting fields (and containers) inside a block field"
+            }
+          ]
+        }
+      ]
+    },
+    "p-27": {
+      "@type": "slate",
+      "plaintext": "A `widget: 'object'` field groups sub-fields under one key. Its `schema.properties` are first-class — plain fields OR nested containers — and everything nests **inside** the object, exactly where the schema puts it. No `dataPath` indirection.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "widget: 'object'"
+                }
+              ]
+            },
+            {
+              "text": " field groups sub-fields under one key. Its "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "schema.properties"
+                }
+              ]
+            },
+            {
+              "text": " are first-class — plain fields OR nested containers — and everything nests "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "inside"
+                }
+              ]
+            },
+            {
+              "text": " the object, exactly where the schema puts it. No "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "dataPath"
+                }
+              ]
+            },
+            {
+              "text": " indirection."
+            }
+          ]
+        }
+      ]
+    },
+    "p-28": {
+      "@type": "slate",
+      "plaintext": "An **`object_list`** inside an object stores its array at `object.<field>`:",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "An "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "`object_list`"
+                }
+              ]
+            },
+            {
+              "text": " inside an object stores its array at "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "object.<field>"
+                }
+              ]
+            },
+            {
+              "text": ":"
+            }
+          ]
+        }
+      ]
+    },
+    "ce-29": {
+      "@type": "codeExample",
+      "tabs": [
+        {
+          "@id": "ce-29-javascript-dd9f7e",
+          "label": "Javascript",
+          "language": "javascript",
+          "code": "// A table block whose rows live at block.table.rows\ntable: {\n    widget: 'object',\n    schema: { properties: {\n        rows: { widget: 'object_list', idField: 'key',\n                schema: { properties: { cells: { widget: 'object_list', idField: 'key' /* … */ } } } },\n    } },\n}\n// data\n{ \"@type\": \"slateTable\", \"table\": { \"rows\": [ { \"key\": \"r1\", \"cells\": [ /* … */ ] } ] } }"
+        }
+      ]
+    },
+    "p-30": {
+      "@type": "slate",
+      "plaintext": "A **`blocks_layout`** inside an object makes the object its own mini-container: it holds its own `blocks` dict + `blocks_layout`, just like a columns/grid container block, one level deeper:",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "`blocks_layout`"
+                }
+              ]
+            },
+            {
+              "text": " inside an object makes the object its own mini-container: it holds its own "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "blocks"
+                }
+              ]
+            },
+            {
+              "text": " dict + "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "blocks_layout"
+                }
+              ]
+            },
+            {
+              "text": ", just like a columns/grid container block, one level deeper:"
+            }
+          ]
+        }
+      ]
+    },
+    "ce-31": {
+      "@type": "codeExample",
+      "tabs": [
+        {
+          "@id": "ce-31-javascript-f90eb4",
+          "label": "Javascript",
+          "language": "javascript",
+          "code": "table: { widget: 'object', schema: { properties: {\n    body: { widget: 'blocks_layout' },\n} } }\n// data\n{ \"@type\": \"slateTable\",\n  \"table\": { \"blocks\": { \"b1\": { /* … */ } }, \"blocks_layout\": { \"body\": [\"b1\"] } } }"
+        }
+      ]
+    },
+    "p-32": {
+      "@type": "slate",
+      "plaintext": "A **plain field** inside an object is edited in the canvas like any top-level field — address it inline with its `/`-path (`data-edit-text=\"content/headline\"`, and the same for `data-edit-link` / `data-edit-media`). The object is *transparent*: `content/headline` writes back to `block.content.headline`, never a flat key. See [Field Path Syntax](visual-editing.md#field-path-syntax) for the full grammar (`/` object descent, `..` = parent block, `/field` = page).",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "plain field"
+                }
+              ]
+            },
+            {
+              "text": " inside an object is edited in the canvas like any top-level field — address it inline with its "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "/"
+                }
+              ]
+            },
+            {
+              "text": "-path ("
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "data-edit-text=\"content/headline\""
+                }
+              ]
+            },
+            {
+              "text": ", and the same for "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "data-edit-link"
+                }
+              ]
+            },
+            {
+              "text": " / "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "data-edit-media"
+                }
+              ]
+            },
+            {
+              "text": "). The object is "
+            },
+            {
+              "type": "em",
+              "children": [
+                {
+                  "text": "transparent"
+                }
+              ]
+            },
+            {
+              "text": ": "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "content/headline"
+                }
+              ]
+            },
+            {
+              "text": " writes back to "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "block.content.headline"
+                }
+              ]
+            },
+            {
+              "text": ", never a flat key. See "
+            },
+            {
+              "type": "link",
+              "data": {
+                "url": "visual-editing.md#field-path-syntax"
+              },
+              "children": [
+                {
+                  "text": "Field Path Syntax"
+                }
+              ]
+            },
+            {
+              "text": " for the full grammar ("
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "/"
+                }
+              ]
+            },
+            {
+              "text": " object descent, "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": ".."
+                }
+              ]
+            },
+            {
+              "text": " = parent block, "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "/field"
+                }
+              ]
+            },
+            {
+              "text": " = page)."
+            }
+          ]
+        }
+      ]
+    },
+    "p-33": {
+      "@type": "slate",
+      "plaintext": "Blocks inside a nested container are edited in the canvas like any other container. The sidebar prefixes a nested container's **title** with the path (e.g. **Table / Rows**) so the nesting is visible.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Blocks inside a nested container are edited in the canvas like any other container. The sidebar prefixes a nested container's "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "title"
+                }
+              ]
+            },
+            {
+              "text": " with the path (e.g. "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "Table / Rows"
+                }
+              ]
+            },
+            {
+              "text": ") so the nesting is visible."
+            }
+          ]
+        }
+      ]
+    },
+    "p-34": {
+      "@type": "slate",
+      "plaintext": "This replaces `dataPath`: declare the container inside the object rather than hoisting it to the block's top level with a `dataPath` back-reference.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This replaces "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "dataPath"
+                }
+              ]
+            },
+            {
+              "text": ": declare the container inside the object rather than hoisting it to the block's top level with a "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "dataPath"
+                }
+              ]
+            },
+            {
+              "text": " back-reference."
+            }
+          ]
+        }
+      ]
+    },
+    "h-35": {
+      "@type": "slate",
+      "plaintext": "Container schema reference",
+      "value": [
+        {
+          "type": "h2",
+          "children": [
+            {
+              "text": "Container schema reference"
+            }
+          ]
+        }
+      ]
+    },
+    "p-36": {
+      "@type": "slate",
+      "plaintext": "A block's schema is a standard [Volto block schema](https://6.docs.plone.org/volto/blocks/editcomponent.html) (fieldsets, `properties`, widgets, `default`, etc.). Hydra reads three container-oriented `widget` values plus a few per-field keys — those are:",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A block's schema is a standard "
+            },
+            {
+              "type": "link",
+              "data": {
+                "url": "https://6.docs.plone.org/volto/blocks/editcomponent.html"
+              },
+              "children": [
+                {
+                  "text": "Volto block schema"
+                }
+              ]
+            },
+            {
+              "text": " (fieldsets, "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "properties"
+                }
+              ]
+            },
+            {
+              "text": ", widgets, "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "default"
+                }
+              ]
+            },
+            {
+              "text": ", etc.). Hydra reads three container-oriented "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "widget"
+                }
+              ]
+            },
+            {
+              "text": " values plus a few per-field keys — those are:"
+            }
+          ]
+        }
+      ]
+    },
+    "tbl-37": {
+      "@type": "slateTable",
+      "table": {
+        "fixed": true,
+        "compact": false,
+        "basic": false,
+        "celled": true,
+        "inverted": false,
+        "striped": false,
+        "rows": [
+          {
+            "key": "tbl-37-r0",
+            "cells": [
+              {
+                "key": "tbl-37-r0c0",
+                "type": "header",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "widget"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-37-r0c1",
+                "type": "header",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "Storage"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-37-r0c2",
+                "type": "header",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "Key fields"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "key": "tbl-37-r1",
+            "cells": [
+              {
+                "key": "tbl-37-r1c0",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "blocks_layout"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-37-r1c1",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "children are ids in the parent's shared "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "blocks"
+                          }
+                        ]
+                      },
+                      {
+                        "text": " dict; this field's name is a region key under "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "blocks_layout"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-37-r1c2",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "allowedBlocks"
+                          }
+                        ]
+                      },
+                      {
+                        "text": ", "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "maxLength"
+                          }
+                        ]
+                      },
+                      {
+                        "text": ", "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "allowedTemplates"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "key": "tbl-37-r2",
+            "cells": [
+              {
+                "key": "tbl-37-r2c0",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "object_list"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-37-r2c1",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "inline array on the field itself"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-37-r2c2",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "idField"
+                          }
+                        ]
+                      },
+                      {
+                        "text": " (default "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "@id"
+                          }
+                        ]
+                      },
+                      {
+                        "text": "), "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "schema"
+                          }
+                        ]
+                      },
+                      {
+                        "text": " (item schema), "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "allowedBlocks"
+                          }
+                        ]
+                      },
+                      {
+                        "text": " + "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "typeField"
+                          }
+                        ]
+                      },
+                      {
+                        "text": " (typed items), "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "defaultBlockType"
+                          }
+                        ]
+                      },
+                      {
+                        "text": ", "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "maxLength"
+                          }
+                        ]
+                      },
+                      {
+                        "text": ", "
+                      },
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "addMode: 'table'"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "key": "tbl-37-r3",
+            "cells": [
+              {
+                "key": "tbl-37-r3c0",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "object"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-37-r3c1",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "groups sub-fields under one key; sub-fields (plain OR the two container widgets above) nest inside"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-37-r3c2",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "schema"
+                          }
+                        ]
+                      },
+                      {
+                        "text": " (the nested properties)"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "p-38": {
+      "@type": "slate",
+      "plaintext": "All three can nest inside `object`, and a container may mix a `blocks_layout` region and an `object_list` region. Everything else in a field def (`title`, `default`, `type`, `choices`, `mode`, …) is plain Volto and behaves as documented there.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "All three can nest inside "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "object"
+                }
+              ]
+            },
+            {
+              "text": ", and a container may mix a "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "blocks_layout"
+                }
+              ]
+            },
+            {
+              "text": " region and an "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "object_list"
+                }
+              ]
+            },
+            {
+              "text": " region. Everything else in a field def ("
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "title"
+                }
+              ]
+            },
+            {
+              "text": ", "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "default"
+                }
+              ]
+            },
+            {
+              "text": ", "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "type"
+                }
+              ]
+            },
+            {
+              "text": ", "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "choices"
+                }
+              ]
+            },
+            {
+              "text": ", "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "mode"
+                }
+              ]
+            },
+            {
+              "text": ", …) is plain Volto and behaves as documented there."
+            }
+          ]
+        }
+      ]
+    },
+    "h-39": {
       "@type": "slate",
       "plaintext": "Rendering Containers in Your Frontend",
       "value": [
@@ -996,7 +2041,7 @@
         }
       ]
     },
-    "p-26": {
+    "p-40": {
       "@type": "slate",
       "plaintext": "Add `data-block-uid` to each child element. You don't need to mark the container element itself:",
       "value": [
@@ -1021,18 +2066,18 @@
         }
       ]
     },
-    "ce-27": {
+    "ce-41": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-27-javascript-cf69cc",
+          "@id": "ce-41-javascript-85a3e1",
           "label": "Html",
           "language": "html",
           "code": "<div class=\"slider\" data-block-uid=\"slider-1\">\n  <div class=\"slide\" data-block-uid=\"slide-1\"\n       data-block-add=\"right\">\n    <img src=\"/news.jpg\"/>\n    <h2>Big News</h2>\n  </div>\n  <div class=\"slide\" data-block-uid=\"slide-2\"\n       data-block-add=\"right\">\n    ...\n  </div>\n  <a data-block-selector=\"-1\">Prev</a>\n  <a data-block-selector=\"+1\">Next</a>\n</div>"
         }
       ]
     },
-    "ul-28": {
+    "ul-42": {
       "@type": "slate",
       "plaintext": "data-block-add=\"bottom|right\" — Controls where the '+' button appears. By default it will be the opposite of its parent. Use \"bottom\" for vertical stacking, \"right\" for horizontal. data-block-selector=\"-1|+1|blockId\" — Tag paging buttons so sidebar selection can navigate paged containers. data-block-selector=\"uid1 uid2 uid3 …\" — Space-separated list of uids this element should \"expose\" when any of them is selected from the admin. The bridge matches with the CSS word-list operator ([data-block-selector~=...]), so one trigger can cover many descendants. Use it on a disclosure trigger (collapsed details, accordion header, hidden tab panel button) so that picking any block within from the sidebar opens / scrolls / activates the enclosing container. For <summary> triggers the bridge sets details.open = true directly (idempotent — won't toggle an already-open disclosure); for everything else it .click()s the trigger, skipping the click if aria-expanded=\"true\". The contextNavigation <summary> and accordion panel buttons use this pattern; the carousel +1 / -1 / specific-slide-uid form above is a special case of the same attribute.",
       "value": [
@@ -1179,7 +2224,7 @@
         }
       ]
     },
-    "h-29": {
+    "h-43": {
       "@type": "slate",
       "plaintext": "Table Mode",
       "value": [
@@ -1193,9 +2238,9 @@
         }
       ]
     },
-    "p-30": {
+    "p-44": {
       "@type": "slate",
-      "plaintext": "Set `addMode: 'table'` for table-like structures (rows containing cells). This lets users add and remove columns as easily as rows:",
+      "plaintext": "Set `addMode: 'table'` for table-like structures (rows containing cells). This lets users add and remove columns as easily as rows. The rows live inside a `table` object field (`block.table.rows`) — no `dataPath`:",
       "value": [
         {
           "type": "p",
@@ -1212,24 +2257,57 @@
               ]
             },
             {
-              "text": " for table-like structures (rows containing cells). This lets users add and remove columns as easily as rows:"
+              "text": " for table-like structures (rows containing cells). This lets users add and remove columns as easily as rows. The rows live inside a "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "table"
+                }
+              ]
+            },
+            {
+              "text": " object field ("
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "block.table.rows"
+                }
+              ]
+            },
+            {
+              "text": ") — no "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "dataPath"
+                }
+              ]
+            },
+            {
+              "text": ":"
             }
           ]
         }
       ]
     },
-    "ce-31": {
+    "ce-45": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-31-javascript-f90eb4",
+          "@id": "ce-45-javascript-1cff8e",
           "label": "Javascript",
           "language": "javascript",
-          "code": "rows: {\n    widget: 'object_list',\n    idField: 'key',\n    addMode: 'table',\n    dataPath: ['table', 'rows'],\n    schema: {\n        properties: {\n            cells: {\n                widget: 'object_list',\n                idField: 'key',\n                schema: {\n                    properties: {\n                        value: { title: 'Content',\n                                 widget: 'slate' }\n                    }\n                }\n            }\n        }\n    }\n}"
+          "code": "table: {\n    widget: 'object',\n    schema: { properties: {\n        rows: {\n            widget: 'object_list',\n            idField: 'key',\n            addMode: 'table',\n            schema: { properties: {\n                cells: {\n                    widget: 'object_list',\n                    idField: 'key',\n                    schema: { properties: {\n                        value: { title: 'Content', widget: 'slate' },\n                    } },\n                },\n            } },\n        },\n    } },\n}"
         }
       ]
     },
-    "h-32": {
+    "h-46": {
       "@type": "slate",
       "plaintext": "Empty Blocks",
       "value": [
@@ -1243,7 +2321,7 @@
         }
       ]
     },
-    "p-33": {
+    "p-47": {
       "@type": "slate",
       "plaintext": "A container region can never be truly empty. When its last child is deleted, Hydra fills it back in — but *what* it inserts depends on the region's config:",
       "value": [
@@ -1268,7 +2346,7 @@
         }
       ]
     },
-    "ul-34": {
+    "ul-48": {
       "@type": "slate",
       "plaintext": "If the region has a defaultBlockType, that type is added. If the region allows exactly one allowedBlocks type, that type is added. Only when the region has no defaultBlockType and more than one allowedBlocks is the choice ambiguous — so Hydra inserts a placeholder child with @type: \"empty\" and shows a '+' for the user to pick a type in place.",
       "value": [
@@ -1358,7 +2436,7 @@
         }
       ]
     },
-    "p-35": {
+    "p-49": {
       "@type": "slate",
       "plaintext": "So the simplest way to never deal with empty placeholders in a region is to give it a `defaultBlockType` (or a single-entry `allowedBlocks`). Otherwise your frontend must render `empty`.",
       "value": [
@@ -1405,7 +2483,7 @@
         }
       ]
     },
-    "p-36": {
+    "p-50": {
       "@type": "slate",
       "plaintext": "Empty blocks are stripped before saving. Render them as empty space; Hydra puts a '+' button in the middle for the user to pick a real type in place. You can override the look of that '+' by rendering something inside the empty block and adding `data-block-add=\"button\"` to it.",
       "value": [
@@ -1430,7 +2508,7 @@
         }
       ]
     },
-    "h-37": {
+    "h-51": {
       "@type": "slate",
       "plaintext": "empty is a universal placeholder — renderers must tolerate it",
       "value": [
@@ -1452,7 +2530,7 @@
         }
       ]
     },
-    "p-38": {
+    "p-52": {
       "@type": "slate",
       "plaintext": "In a no-default, multi-allowed region, `@type: \"empty\"` can appear in **any** container — including transiently, the moment a child is deleted and before the user picks a replacement. You never list `\"empty\"` in `allowedBlocks`; it isn't a type you opt into. So every container renderer has to render an `empty` child without erroring.",
       "value": [
@@ -1521,7 +2599,7 @@
         }
       ]
     },
-    "p-39": {
+    "p-53": {
       "@type": "slate",
       "plaintext": "If your container renders its children by delegating each one to your central block dispatch (the function or component that switches on `@type`), you get this for free — just give that dispatch an `empty` case that renders a selectable placeholder.",
       "value": [
@@ -1557,7 +2635,7 @@
         }
       ]
     },
-    "p-40": {
+    "p-54": {
       "@type": "slate",
       "plaintext": "The trap is a **custom** container renderer that only expects specific child types — a `contextNavigation` that walks `navItem`/`listing` children, say. Don't hand-roll an allow-list that rejects anything else, or a seeded `empty` will throw and break the whole container. Route non-special children through your central dispatch instead of throwing:",
       "value": [
@@ -1626,18 +2704,18 @@
         }
       ]
     },
-    "ce-41": {
+    "ce-55": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-41-javascript-85a3e1",
+          "@id": "ce-55-javascript-423feb",
           "label": "Javascript",
           "language": "javascript",
           "code": "for (const childId of items) {\n    const child = blocks[childId];\n    if (child['@type'] === 'navItem') { /* nav-specific rendering */ }\n    else if (child['@type'] === 'listing') { /* expand listing */ }\n    else renderBlock(childId, child);   // empty (or anything else) → central dispatch, never throw\n}"
         }
       ]
     },
-    "p-42": {
+    "p-56": {
       "@type": "slate",
       "plaintext": "Two more things a renderer must survive once the user picks a type for a seeded empty:",
       "value": [
@@ -1651,7 +2729,7 @@
         }
       ]
     },
-    "ul-43": {
+    "ul-57": {
       "@type": "slate",
       "plaintext": "Re-render on the type change. The child's @type flips from empty to the picked type in place (same data-block-uid). If your renderer memoises or does its work once (e.g. an async setup), make sure it re-runs when a child's type changes — otherwise it keeps showing the stale empty. Tolerate a freshly-typed child with no data yet. A just-picked navItem has no href; a just-picked form field has no value — render a placeholder, don't crash on the missing field.",
       "value": [
@@ -1760,7 +2838,7 @@
         }
       ]
     },
-    "h-44": {
+    "h-58": {
       "@type": "slate",
       "plaintext": "Synchronised Block Types in a Container",
       "value": [
@@ -1774,7 +2852,7 @@
         }
       ]
     },
-    "p-45": {
+    "p-59": {
       "@type": "slate",
       "plaintext": "You can have one container type whose children are all kept the same `@type`, with the editor picking that type once on the parent. When the type changes, every child is converted (using each child's `fieldMappings`); when a new child is added it gets the selected type.",
       "value": [
@@ -1810,7 +2888,7 @@
         }
       ]
     },
-    "p-46": {
+    "p-60": {
       "@type": "slate",
       "plaintext": "Declare `itemTypeField` on the *blocks field* — its value names a sibling field on the same schema whose value drives every child's `@type`. The sibling field is typically rendered with `widget: 'blockTypeSelect'`, which computes its `choices` from the blocks field's `allowedBlocks` at render time:",
       "value": [
@@ -1890,18 +2968,18 @@
         }
       ]
     },
-    "ce-47": {
+    "ce-61": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-47-javascript-20930c",
+          "@id": "ce-61-javascript-4bce71",
           "label": "Javascript",
           "language": "javascript",
           "code": "blocks: {\n    gridBlock: {\n        blockSchema: {\n            properties: {\n                slides: {\n                    widget: 'blocks_layout',\n                    itemTypeField: 'variation',         // sync trigger\n                    allowedBlocks: ['teaser', 'image'],\n                },\n                variation: {\n                    widget: 'blockTypeSelect',          // dropdown\n                },\n            },\n        },\n    },\n    teaser: {\n        fieldMappings: {\n            '@default': { '@id': 'href', 'title': 'title', 'image': 'preview_image' },\n        },\n    },\n    image: {\n        fieldMappings: {\n            '@default': { '@id': 'href', 'title': 'alt', 'image': 'url' },\n        },\n    },\n}"
         }
       ]
     },
-    "p-48": {
+    "p-62": {
       "@type": "slate",
       "plaintext": "The relationship is local: read the schema and you can see \"the children of `slides` get their `@type` from `variation`\" right next to the field declaration. Works the same for `widget: 'blocks_layout'` and `widget: 'object_list'` children.",
       "value": [
@@ -1970,7 +3048,7 @@
         }
       ]
     },
-    "h-49": {
+    "h-63": {
       "@type": "slate",
       "plaintext": "Field-value syncing",
       "value": [
@@ -1984,7 +3062,7 @@
         }
       ]
     },
-    "p-50": {
+    "p-64": {
       "@type": "slate",
       "plaintext": "On top of type syncing you can also have field _values_ centrally controlled at the parent — set once on the parent, applied to every child. Add ONE enhancer on the parent:",
       "value": [
@@ -1998,18 +3076,18 @@
         }
       ]
     },
-    "ce-51": {
+    "ce-65": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-51-javascript-fd2f5c",
+          "@id": "ce-65-javascript-5f8f27",
           "label": "Javascript",
           "language": "javascript",
           "code": "gridBlock: {\n    blockSchema: {\n        properties: {\n            slides: { widget: 'blocks_layout', itemTypeField: 'variation', allowedBlocks: ['teaser', 'image'] },\n            variation: { widget: 'blockTypeSelect' },\n        },\n    },\n    schemaEnhancer: { inheritSchemaFrom: {} },\n}"
         }
       ]
     },
-    "p-52": {
+    "p-66": {
       "@type": "slate",
       "plaintext": "`inheritSchemaFrom` does two things automatically:",
       "value": [
@@ -2031,7 +3109,7 @@
         }
       ]
     },
-    "ol-53": {
+    "ol-67": {
       "@type": "slate",
       "plaintext": "Surfaces the parent-claimed fields on the parent's sidebar under an \"Item Defaults\" fieldset. Auto-hides the same fields on every child's sidebar (via a hideParentOwnedFields enhancer that's applied to every block at INIT — no per-child opt-in).",
       "value": [
@@ -2080,7 +3158,7 @@
         }
       ]
     },
-    "p-54": {
+    "p-68": {
       "@type": "slate",
       "plaintext": "The parent declares **what it claims** per child block type via `parentControlled`. If absent, the default is: parent claims everything _not_ listed in the child's `fieldMappings['@default']` mapping. The default works for typical cases; set `parentControlled` only when you want a different split (e.g. keep a meta-toggle field editable per-child):",
       "value": [
@@ -2138,18 +3216,18 @@
         }
       ]
     },
-    "ce-55": {
+    "ce-69": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-55-javascript-423feb",
+          "@id": "ce-69-javascript-17bbd6",
           "label": "Javascript",
           "language": "javascript",
           "code": "listing: {\n    schemaEnhancer: {\n        inheritSchemaFrom: {\n            typeField: 'variation',\n            mappingField: 'fieldMapping',\n            // Only these fields are claimed by listing for teaser children.\n            // The rest (including teaser's `overwrite` toggle) stay editable.\n            parentControlled: {\n                teaser: ['head_title', 'openLinkInNewTab', 'styles'],\n            },\n        },\n    },\n}"
         }
       ]
     },
-    "p-56": {
+    "p-70": {
       "@type": "slate",
       "plaintext": "When `parentControlled[childType]` is set, it **replaces** the `@default` fallback for that child type. Both sides — the parent's \"Item Defaults\" fieldset and the child's hidden fields — are computed from the same single rule, so they can never get out of sync.",
       "value": [
@@ -2196,7 +3274,7 @@
         }
       ]
     },
-    "h-57": {
+    "h-71": {
       "@type": "slate",
       "plaintext": "Recipe options",
       "value": [
@@ -2210,7 +3288,7 @@
         }
       ]
     },
-    "ul-58": {
+    "ul-72": {
       "@type": "slate",
       "plaintext": "inheritSchemaFrom — schemaEnhancer recipe; surfaces parent-claimed fields on the parent and hides them on children. itemTypeField — declared on a blocks_layout/object_list field; names the sibling field whose value drives every child's @type. typeField — names the sibling field directly on inheritSchemaFrom. Use this when there is no blocks field to declare itemTypeField on (e.g. listings — see Listings). mappingField — name of the field where a per-block fieldMapping override is stored. Required for the FieldMappingWidget to appear. parentControlled — { childType: [fieldName, ...] } per-child-type override. Replaces the fieldMappings['@default'] fallback. defaultsField — prefix for the inherited fields on the parent's \"Item Defaults\" fieldset (default: 'itemDefaults'). blockTypeSelect widget options:",
       "value": [
@@ -2457,7 +3535,7 @@
         }
       ]
     },
-    "p-59": {
+    "p-73": {
       "@type": "slate",
       "plaintext": "- **`blocksField`** — which sub-blocks field's `allowedBlocks` to use for the choices. Auto-discovers if omitted. Set to `'..'` when the choices should come from the *enclosing parent's* `allowedSiblingTypes`.   - **`filterConvertibleFrom`** — only offer types whose `fieldMappings` accept the named source. Typically `'@default'` for listings (every item type must be populatable from canonical content fields).",
       "value": [
@@ -2572,56 +3650,70 @@
       "p-7",
       "ce-8",
       "p-9",
-      "h-10",
-      "p-11",
+      "p-10",
+      "h-11",
       "p-12",
-      "ce-13",
-      "p-14",
-      "h-15",
-      "p-16",
+      "p-13",
+      "ce-14",
+      "p-15",
+      "h-16",
       "p-17",
-      "h-18",
-      "p-19",
-      "ce-20",
-      "h-21",
-      "p-22",
-      "ce-23",
-      "p-24",
-      "h-25",
-      "p-26",
-      "ce-27",
-      "ul-28",
-      "h-29",
+      "p-18",
+      "h-19",
+      "p-20",
+      "ce-21",
+      "h-22",
+      "p-23",
+      "ce-24",
+      "p-25",
+      "h-26",
+      "p-27",
+      "p-28",
+      "ce-29",
       "p-30",
       "ce-31",
-      "h-32",
+      "p-32",
       "p-33",
-      "ul-34",
-      "p-35",
+      "p-34",
+      "h-35",
       "p-36",
-      "h-37",
+      "tbl-37",
       "p-38",
-      "p-39",
+      "h-39",
       "p-40",
       "ce-41",
-      "p-42",
-      "ul-43",
-      "h-44",
-      "p-45",
-      "p-46",
-      "ce-47",
-      "p-48",
-      "h-49",
+      "ul-42",
+      "h-43",
+      "p-44",
+      "ce-45",
+      "h-46",
+      "p-47",
+      "ul-48",
+      "p-49",
       "p-50",
-      "ce-51",
+      "h-51",
       "p-52",
-      "ol-53",
+      "p-53",
       "p-54",
       "ce-55",
       "p-56",
-      "h-57",
-      "ul-58",
-      "p-59"
+      "ul-57",
+      "h-58",
+      "p-59",
+      "p-60",
+      "ce-61",
+      "p-62",
+      "h-63",
+      "p-64",
+      "ce-65",
+      "p-66",
+      "ol-67",
+      "p-68",
+      "ce-69",
+      "p-70",
+      "h-71",
+      "ul-72",
+      "p-73"
     ]
   }
 }

--- a/docs/content/content/content/docs/examples/table/data.json
+++ b/docs/content/content/content/docs/examples/table/data.json
@@ -4213,7 +4213,7 @@
           "@id": "ref-table-schema-javascript-237d52",
           "label": "Schema",
           "language": "javascript",
-          "code": "{\n  \"slateTable\": {\n    \"blockSchema\": {\n      \"properties\": {\n        \"table\": {\n          \"title\": \"Table\"\n        }\n      }\n    }\n  }\n}"
+          "code": "{\n  \"slateTable\": {\n    \"addMode\": \"table\",\n    \"blockSchema\": {\n      \"properties\": {\n        \"table\": {\n          \"title\": \"Table\",\n          \"widget\": \"object\",\n          \"schema\": {\n            \"properties\": {\n              \"rows\": {\n                \"widget\": \"object_list\",\n                \"idField\": \"key\",\n                \"addMode\": \"table\",\n                \"schema\": {\n                  \"properties\": {\n                    \"cells\": {\n                      \"widget\": \"object_list\",\n                      \"idField\": \"key\",\n                      \"schema\": {\n                        \"properties\": {\n                          \"value\": {\n                            \"widget\": \"slate\"\n                          }\n                        }\n                      }\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}"
         }
       ]
     },

--- a/docs/content/content/content/docs/visual-editing/data.json
+++ b/docs/content/content/content/docs/visual-editing/data.json
@@ -434,13 +434,13 @@
     },
     "h-14": {
       "@type": "slate",
-      "plaintext": "Path Syntax for Parent/Page Fields",
+      "plaintext": "Field Path Syntax",
       "value": [
         {
           "type": "h2",
           "children": [
             {
-              "text": "Path Syntax for Parent/Page Fields"
+              "text": "Field Path Syntax"
             }
           ]
         }
@@ -448,32 +448,98 @@
     },
     "p-15": {
       "@type": "slate",
-      "plaintext": "The `data-edit-text|edit-media|edit-link` attributes support Unix-style paths to edit fields outside the current block:",
+      "plaintext": "Every `data-edit-*` attribute — `data-edit-text`, `data-edit-link`, `data-edit-media` — takes a Unix-style **field path**, resolved the same way for all three. A path has two independent axes:",
       "value": [
         {
           "type": "p",
           "children": [
             {
-              "text": "The "
+              "text": "Every "
             },
             {
               "type": "code",
               "children": [
                 {
-                  "text": "data-edit-text|edit-media|edit-link"
+                  "text": "data-edit-*"
                 }
               ]
             },
             {
-              "text": " attributes support Unix-style paths to edit fields outside the current block:"
+              "text": " attribute — "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "data-edit-text"
+                }
+              ]
+            },
+            {
+              "text": ", "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "data-edit-link"
+                }
+              ]
+            },
+            {
+              "text": ", "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "data-edit-media"
+                }
+              ]
+            },
+            {
+              "text": " — takes a Unix-style "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "field path"
+                }
+              ]
+            },
+            {
+              "text": ", resolved the same way for all three. A path has two independent axes:"
             }
           ]
         }
       ]
     },
-    "ul-16": {
+    "p-16": {
       "@type": "slate",
-      "plaintext": "fieldName — edit the block's own field (default) ../fieldName — edit the parent block's field ../../fieldName — edit the grandparent's field /fieldName — edit the page metadata field",
+      "plaintext": "**Which block** (the leading part):",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "Which block"
+                }
+              ]
+            },
+            {
+              "text": " (the leading part):"
+            }
+          ]
+        }
+      ]
+    },
+    "ul-17": {
+      "@type": "slate",
+      "plaintext": "fieldName — this block's own field (default) ../fieldName — the parent block's field ../../fieldName — the grandparent block's field /fieldName — a page/root field",
       "value": [
         {
           "type": "ul",
@@ -490,7 +556,7 @@
                   ]
                 },
                 {
-                  "text": " — edit the block's own field (default)"
+                  "text": " — this block's own field (default)"
                 }
               ]
             },
@@ -506,7 +572,18 @@
                   ]
                 },
                 {
-                  "text": " — edit the parent block's field"
+                  "text": " — the parent "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "text": "block"
+                    }
+                  ]
+                },
+                {
+                  "text": "'s field"
                 }
               ]
             },
@@ -522,7 +599,7 @@
                   ]
                 },
                 {
-                  "text": " — edit the grandparent's field"
+                  "text": " — the grandparent block's field"
                 }
               ]
             },
@@ -538,7 +615,7 @@
                   ]
                 },
                 {
-                  "text": " — edit the page metadata field"
+                  "text": " — a page/root field"
                 }
               ]
             }
@@ -546,32 +623,241 @@
         }
       ]
     },
-    "ce-17": {
-      "@type": "codeExample",
-      "tabs": [
-        {
-          "@id": "ce-17-html-621a4c",
-          "label": "Html",
-          "language": "html",
-          "code": "<!-- Edit the page title (not inside any block) -->\n<h1 data-edit-text=\"/title\">My Page Title</h1>\n\n<!-- Edit the page description -->\n<p data-edit-text=\"/description\">Page description here</p>\n\n<!-- Inside a nested block, edit the parent container's title -->\n<h3 data-edit-text=\"../title\">Column Title</h3>"
-        }
-      ]
-    },
     "p-18": {
       "@type": "slate",
-      "plaintext": "This allows fixed parts of the page (like headers) to be editable without being inside a block.",
+      "plaintext": "`..` always steps up one **block** — never an object or region level (see below).",
       "value": [
         {
           "type": "p",
           "children": [
             {
-              "text": "This allows fixed parts of the page (like headers) to be editable without being inside a block."
+              "type": "code",
+              "children": [
+                {
+                  "text": ".."
+                }
+              ]
+            },
+            {
+              "text": " always steps up one "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "block"
+                }
+              ]
+            },
+            {
+              "text": " — never an object or region level (see below)."
             }
           ]
         }
       ]
     },
-    "h-19": {
+    "p-19": {
+      "@type": "slate",
+      "plaintext": "**Where inside the block** (`/` descends objects):",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "Where inside the block"
+                }
+              ]
+            },
+            {
+              "text": " ("
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "/"
+                }
+              ]
+            },
+            {
+              "text": " descends objects):"
+            }
+          ]
+        }
+      ]
+    },
+    "ul-20": {
+      "@type": "slate",
+      "plaintext": "content/headline — descend a widget: 'object'",
+      "value": [
+        {
+          "type": "ul",
+          "children": [
+            {
+              "type": "li",
+              "children": [
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "text": "`content/headline`"
+                    }
+                  ]
+                },
+                {
+                  "text": " — descend a "
+                },
+                {
+                  "type": "link",
+                  "data": {
+                    "url": "container-blocks.md#widget-object-nesting-fields-and-containers-inside-a-block-field"
+                  },
+                  "children": [
+                    {
+                      "text": "`widget: 'object'`"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "p-21": {
+      "@type": "slate",
+      "plaintext": "field to a nested field (the key mirrors the storage path, `block.content.headline`)",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "field to a nested field (the key mirrors the storage path, "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "block.content.headline"
+                }
+              ]
+            },
+            {
+              "text": ")"
+            }
+          ]
+        }
+      ]
+    },
+    "p-22": {
+      "@type": "slate",
+      "plaintext": "The two compose: `../content/headline` is \"the parent block, its `content.headline`\". `/` descends objects only — a region (`object_list` / `blocks_layout`) or a value is the end of a path (a region's children are separate blocks with their own `data-block-uid`).",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "The two compose: "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "../content/headline"
+                }
+              ]
+            },
+            {
+              "text": " is \"the parent block, its "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "content.headline"
+                }
+              ]
+            },
+            {
+              "text": "\". "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "/"
+                }
+              ]
+            },
+            {
+              "text": " descends objects only — a region ("
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "object_list"
+                }
+              ]
+            },
+            {
+              "text": " / "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "blocks_layout"
+                }
+              ]
+            },
+            {
+              "text": ") or a value is the end of a path (a region's children are separate blocks with their own "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "data-block-uid"
+                }
+              ]
+            },
+            {
+              "text": ")."
+            }
+          ]
+        }
+      ]
+    },
+    "ce-23": {
+      "@type": "codeExample",
+      "tabs": [
+        {
+          "@id": "ce-23-html-1a4c34",
+          "label": "Html",
+          "language": "html",
+          "code": "<!-- page fields (not inside any block) -->\n<h1 data-edit-text=\"/title\">My Page Title</h1>\n<p  data-edit-text=\"/description\">Page description here</p>\n\n<!-- inside a nested block, edit the parent container's title -->\n<h3 data-edit-text=\"../title\">Column Title</h3>\n\n<!-- fields nested on a widget:'object' — text, link and media all use the same path -->\n<h3 data-edit-text=\"content/headline\">…</h3>\n<a  data-edit-link=\"content/href\">…</a>\n<img data-edit-media=\"content/image\" />"
+        }
+      ]
+    },
+    "p-24": {
+      "@type": "slate",
+      "plaintext": "This lets fixed parts of the page (headers), parent-block fields, and fields grouped inside an object all be edited in place, with one addressing model.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This lets fixed parts of the page (headers), parent-block fields, and fields grouped inside an object all be edited in place, with one addressing model."
+            }
+          ]
+        }
+      ]
+    },
+    "h-25": {
       "@type": "slate",
       "plaintext": "Readonly Regions",
       "value": [
@@ -585,7 +871,7 @@
         }
       ]
     },
-    "p-20": {
+    "p-26": {
       "@type": "slate",
       "plaintext": "Add `data-block-readonly` (or `<!-- hydra block-readonly -->` comment) to disable inline editing for all fields inside an element:",
       "value": [
@@ -621,18 +907,18 @@
         }
       ]
     },
-    "ce-21": {
+    "ce-27": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-21-html-01cf34",
+          "@id": "ce-27-html-13c090",
           "label": "Html",
           "language": "html",
           "code": "<div class=\"teaser\" data-block-uid=\"teaser-1\">\n  <div data-block-readonly>\n    <h2 data-edit-text=\"title\">Target Page Title</h2>\n  </div>\n  <a data-edit-link=\"href\" href=\"/target\">Read more</a>\n</div>"
         }
       ]
     },
-    "p-22": {
+    "p-28": {
       "@type": "slate",
       "plaintext": "Or using comment syntax:",
       "value": [
@@ -646,18 +932,18 @@
         }
       ]
     },
-    "ce-23": {
+    "ce-29": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-23-html-1a4c34",
+          "@id": "ce-29-html-57107f",
           "label": "Html",
           "language": "html",
           "code": "<!-- hydra block-readonly -->\n<div class=\"listing-item\" data-block-uid=\"item-1\">...</div>"
         }
       ]
     },
-    "h-24": {
+    "h-30": {
       "@type": "slate",
       "plaintext": "Renderer Node-ID Rules",
       "value": [
@@ -671,7 +957,7 @@
         }
       ]
     },
-    "p-25": {
+    "p-31": {
       "@type": "slate",
       "plaintext": "When rendering Slate nodes to DOM, your renderer must follow these rules for `data-node-id`:",
       "value": [
@@ -696,7 +982,7 @@
         }
       ]
     },
-    "ol-26": {
+    "ol-32": {
       "@type": "slate",
       "plaintext": "Element nodes (p, strong, em, etc.) must have data-node-id matching the Slate node's nodeId Wrapper elements — If you add extra wrapper elements around a Slate node, ALL wrappers must have the same data-node-id as the inner element",
       "value": [
@@ -786,7 +1072,7 @@
         }
       ]
     },
-    "p-27": {
+    "p-33": {
       "@type": "slate",
       "plaintext": "hydra.js uses node-ids to map between Slate's data model and your DOM. When restoring cursor position after formatting changes, it walks your DOM counting Slate children.",
       "value": [
@@ -800,18 +1086,18 @@
         }
       ]
     },
-    "ce-28": {
+    "ce-34": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-28-html-ee6bed",
+          "@id": "ce-34-html-708bb2",
           "label": "Html",
           "language": "html",
           "code": "Valid wrapper pattern:\n<strong data-node-id=\"0.1\"><b data-node-id=\"0.1\">bold</b></strong>\nBoth elements have the same node-id, so they count as one Slate child.\n\nInvalid (missing node-id on wrapper):\n<span class=\"my-style\"><strong data-node-id=\"0.1\">bold</strong></span>\nThis breaks cursor positioning because hydra.js can't correlate DOM structure to Slate structure."
         }
       ]
     },
-    "h-29": {
+    "h-35": {
       "@type": "slate",
       "plaintext": "One top-level node per slate field",
       "value": [
@@ -825,7 +1111,7 @@
         }
       ]
     },
-    "p-30": {
+    "p-36": {
       "@type": "slate",
       "plaintext": "A slate field's `value` is an array, but it always holds exactly **one top-level node** — a single paragraph, heading, list, or blockquote. Inline content (bold, links, …) lives in that node's `children`.",
       "value": [
@@ -872,7 +1158,7 @@
         }
       ]
     },
-    "p-31": {
+    "p-37": {
       "@type": "slate",
       "plaintext": "Editing can transiently produce more than one top-level node — pasting multiple paragraphs, pressing Enter, or a Backspace that demotes a list item to a paragraph (`[ul, p]`). Hydra normalizes that immediately:",
       "value": [
@@ -897,7 +1183,7 @@
         }
       ]
     },
-    "ul-32": {
+    "ul-38": {
       "@type": "slate",
       "plaintext": "Split — when the field is the value of a slate block, each extra",
       "value": [
@@ -946,7 +1232,7 @@
         }
       ]
     },
-    "p-33": {
+    "p-39": {
       "@type": "slate",
       "plaintext": "node becomes its own `slate` block, inserted after the original in the   same container (`blocks_layout` or `object_list`). This is how pressing   Enter in a text block produces a new block.",
       "value": [
@@ -993,7 +1279,7 @@
         }
       ]
     },
-    "ul-34": {
+    "ul-40": {
       "@type": "slate",
       "plaintext": "Flatten — when the field can't be split — a slate field of a",
       "value": [
@@ -1031,9 +1317,9 @@
         }
       ]
     },
-    "p-35": {
+    "p-41": {
       "@type": "slate",
-      "plaintext": "non-slate block (e.g. a `slateTable` cell's `value`), or a container   that's full or in table mode — the extra nodes' content merges back into   the first node. No text is lost.",
+      "plaintext": "non-slate block (e.g. a `slateTable` cell's `value`), a slate field nested   on a `widget: 'object'` (`content/headline`), or a container that's full or   in table mode — the extra nodes' content merges back into the first node.   No text is lost.",
       "value": [
         {
           "type": "p",
@@ -1061,13 +1347,35 @@
               ]
             },
             {
-              "text": "), or a container   that's full or in table mode — the extra nodes' content merges back into   the first node. No text is lost."
+              "text": "), a slate field nested   on a "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "widget: 'object'"
+                }
+              ]
+            },
+            {
+              "text": " ("
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "content/headline"
+                }
+              ]
+            },
+            {
+              "text": "), or a container that's full or   in table mode — the extra nodes' content merges back into the first node.   No text is lost."
             }
           ]
         }
       ]
     },
-    "p-36": {
+    "p-42": {
       "@type": "slate",
       "plaintext": "A frontend renderer can therefore always assume one top-level node per slate field; it never has to handle a multi-node `value`.",
       "value": [
@@ -1092,7 +1400,7 @@
         }
       ]
     },
-    "h-37": {
+    "h-43": {
       "@type": "slate",
       "plaintext": "Complete Slate Rendering Example",
       "value": [
@@ -1106,7 +1414,7 @@
         }
       ]
     },
-    "p-38": {
+    "p-44": {
       "@type": "slate",
       "plaintext": "Slate data structure (value is an array but always contains a single root node):",
       "value": [
@@ -1120,18 +1428,18 @@
         }
       ]
     },
-    "ce-39": {
+    "ce-45": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-39-json-5d264e",
+          "@id": "ce-45-json-6a84b8",
           "label": "Json",
           "language": "json",
           "code": "{\n  \"value\": [\n    {\n      \"type\": \"p\", \"nodeId\": \"0\",\n      \"children\": [\n        { \"text\": \"Hello \" },\n        { \"type\": \"strong\", \"nodeId\": \"0.1\",\n          \"children\": [{ \"text\": \"world\" }] },\n        { \"text\": \"! Visit \" },\n        { \"type\": \"link\", \"nodeId\": \"0.3\",\n          \"data\": { \"url\": \"/about\" },\n          \"children\": [{ \"text\": \"our page\" }] }\n      ]\n    }\n  ]\n}"
         }
       ]
     },
-    "p-40": {
+    "p-46": {
       "@type": "slate",
       "plaintext": "Renderer:",
       "value": [
@@ -1145,18 +1453,18 @@
         }
       ]
     },
-    "ce-41": {
+    "ce-47": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-41-javascript-925664",
+          "@id": "ce-47-javascript-5e9bf2",
           "label": "Javascript",
           "language": "javascript",
           "code": "function renderSlate(nodes) {\n  return (nodes || []).map(node => {\n    if (node.text !== undefined) return escapeHtml(node.text);\n    const tag = { p:'p', h1:'h1', h2:'h2', strong:'strong',\n                  em:'em', link:'a' }[node.type] || 'span';\n    const attrs = node.type === 'link'\n      ? ` href=\"${node.data?.url || '#'}\"` : '';\n    return `<${tag} data-node-id=\"${node.nodeId}\"${attrs}>${renderSlate(node.children)}</${tag}>`;\n  }).join('');\n}"
         }
       ]
     },
-    "p-42": {
+    "p-48": {
       "@type": "slate",
       "plaintext": "Usage:",
       "value": [
@@ -1170,11 +1478,11 @@
         }
       ]
     },
-    "ce-43": {
+    "ce-49": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-43-html-79ffcf",
+          "@id": "ce-49-html-9b3b7f",
           "label": "Html",
           "language": "html",
           "code": "<div data-block-uid=\"block-1\" data-edit-text=\"value\">\n  <!-- renderSlate(block.value) output goes here -->\n</div>"
@@ -1200,34 +1508,40 @@
       "ce-13",
       "h-14",
       "p-15",
-      "ul-16",
-      "ce-17",
+      "p-16",
+      "ul-17",
       "p-18",
-      "h-19",
-      "p-20",
-      "ce-21",
+      "p-19",
+      "ul-20",
+      "p-21",
       "p-22",
       "ce-23",
-      "h-24",
-      "p-25",
-      "ol-26",
-      "p-27",
-      "ce-28",
-      "h-29",
-      "p-30",
+      "p-24",
+      "h-25",
+      "p-26",
+      "ce-27",
+      "p-28",
+      "ce-29",
+      "h-30",
       "p-31",
-      "ul-32",
+      "ol-32",
       "p-33",
-      "ul-34",
-      "p-35",
+      "ce-34",
+      "h-35",
       "p-36",
-      "h-37",
-      "p-38",
-      "ce-39",
-      "p-40",
-      "ce-41",
+      "p-37",
+      "ul-38",
+      "p-39",
+      "ul-40",
+      "p-41",
       "p-42",
-      "ce-43"
+      "h-43",
+      "p-44",
+      "ce-45",
+      "p-46",
+      "ce-47",
+      "p-48",
+      "ce-49"
     ]
   }
 }

--- a/docs/examples/block-definitions.json
+++ b/docs/examples/block-definitions.json
@@ -281,10 +281,36 @@
   "table": {
     "blocks": {
       "slateTable": {
+        "addMode": "table",
         "blockSchema": {
           "properties": {
             "table": {
-              "title": "Table"
+              "title": "Table",
+              "widget": "object",
+              "schema": {
+                "properties": {
+                  "rows": {
+                    "widget": "object_list",
+                    "idField": "key",
+                    "addMode": "table",
+                    "schema": {
+                      "properties": {
+                        "cells": {
+                          "widget": "object_list",
+                          "idField": "key",
+                          "schema": {
+                            "properties": {
+                              "value": {
+                                "widget": "slate"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/docs/examples/table.md
+++ b/docs/examples/table.md
@@ -9,10 +9,36 @@ This is a **built-in** block (registered as `slateTable`).
 ```json
 {
   "slateTable": {
+    "addMode": "table",
     "blockSchema": {
       "properties": {
         "table": {
-          "title": "Table"
+          "title": "Table",
+          "widget": "object",
+          "schema": {
+            "properties": {
+              "rows": {
+                "widget": "object_list",
+                "idField": "key",
+                "addMode": "table",
+                "schema": {
+                  "properties": {
+                    "cells": {
+                      "widget": "object_list",
+                      "idField": "key",
+                      "schema": {
+                        "properties": {
+                          "value": {
+                            "widget": "slate"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/docs/visual-editing.md
+++ b/docs/visual-editing.md
@@ -60,28 +60,48 @@ Add `data-linkable-allow` to elements that should navigate during edit mode (pag
 <select data-linkable-allow @change="handleFilter">...</select>
 ```
 
-## Path Syntax for Parent/Page Fields
+## Field Path Syntax
 
-The `data-edit-text|edit-media|edit-link` attributes support Unix-style paths to edit fields outside the current block:
+Every `data-edit-*` attribute — `data-edit-text`, `data-edit-link`,
+`data-edit-media` — takes a Unix-style **field path**, resolved the same way for
+all three. A path has two independent axes:
 
-- **`fieldName`** — edit the block's own field (default)
-- **`../fieldName`** — edit the parent block's field
-- **`../../fieldName`** — edit the grandparent's field
-- **`/fieldName`** — edit the page metadata field
+**Which block** (the leading part):
+
+- **`fieldName`** — this block's own field (default)
+- **`../fieldName`** — the parent **block**'s field
+- **`../../fieldName`** — the grandparent block's field
+- **`/fieldName`** — a page/root field
+
+`..` always steps up one **block** — never an object or region level (see below).
+
+**Where inside the block** (`/` descends objects):
+
+- **`content/headline`** — descend a [`widget: 'object'`](container-blocks.md#widget-object-nesting-fields-and-containers-inside-a-block-field)
+  field to a nested field (the key mirrors the storage path, `block.content.headline`)
+
+The two compose: `../content/headline` is "the parent block, its `content.headline`".
+`/` descends objects only — a region (`object_list` / `blocks_layout`) or a value
+is the end of a path (a region's children are separate blocks with their own
+`data-block-uid`).
 
 <!-- codeExample: html -->
 ```html
-<!-- Edit the page title (not inside any block) -->
+<!-- page fields (not inside any block) -->
 <h1 data-edit-text="/title">My Page Title</h1>
+<p  data-edit-text="/description">Page description here</p>
 
-<!-- Edit the page description -->
-<p data-edit-text="/description">Page description here</p>
-
-<!-- Inside a nested block, edit the parent container's title -->
+<!-- inside a nested block, edit the parent container's title -->
 <h3 data-edit-text="../title">Column Title</h3>
+
+<!-- fields nested on a widget:'object' — text, link and media all use the same path -->
+<h3 data-edit-text="content/headline">…</h3>
+<a  data-edit-link="content/href">…</a>
+<img data-edit-media="content/image" />
 ```
 
-This allows fixed parts of the page (like headers) to be editable without being inside a block.
+This lets fixed parts of the page (headers), parent-block fields, and fields
+grouped inside an object all be edited in place, with one addressing model.
 
 ## Readonly Regions
 
@@ -140,9 +160,10 @@ item to a paragraph (`[ul, p]`). Hydra normalizes that immediately:
   same container (`blocks_layout` or `object_list`). This is how pressing
   Enter in a text block produces a new block.
 - **Flatten** — when the field *can't* be split — a slate field of a
-  non-slate block (e.g. a `slateTable` cell's `value`), or a container
-  that's full or in table mode — the extra nodes' content merges back into
-  the first node. No text is lost.
+  non-slate block (e.g. a `slateTable` cell's `value`), a slate field nested
+  on a `widget: 'object'` (`content/headline`), or a container that's full or
+  in table mode — the extra nodes' content merges back into the first node.
+  No text is lost.
 
 A frontend renderer can therefore always assume one top-level node per
 slate field; it never has to handle a multi-node `value`.

--- a/examples/nuxt-blog-starter/components/block.vue
+++ b/examples/nuxt-blog-starter/components/block.vue
@@ -528,6 +528,24 @@
     </table>
   </div>
 
+  <!-- objectBlocks: fields grouped under a widget:'object' (#245). The headline
+       (slate) and href (link) live directly on block.content; the body is a
+       blocks_layout region nested at block.content.blocks_layout.body over the
+       object's own blocks dict (block.content.blocks). Field paths use the
+       `content/...` object-descent form. -->
+  <div v-else-if="block['@type'] == 'objectBlocks'" :data-block-uid="block_uid" class="object-blocks-block my-4">
+    <h3 v-if="(block.content?.headline || []).length" class="ob-headline" data-edit-text="content/headline">
+      <RichText v-for="node in block.content?.headline || []" :key="node" :node="node" />
+    </h3>
+    <a v-if="block.content?.href !== undefined" class="ob-link"
+       data-edit-link="content/href" :href="block.content?.href || '#'">Object link</a>
+    <div class="object-blocks-body">
+      <Block v-for="item in expand(block.content?.blocks_layout?.body || [], block.content?.blocks || {})"
+             :key="item['@uid']" :block_uid="item['@uid']" :block="item" :data="data"
+             :contained="true" data-block-add="bottom" />
+    </div>
+  </div>
+
   <div v-else-if="block['@type'] == 'button'" :data-block-uid="block_uid"
        :class="['my-4', {
            'text-center': block.inneralign === 'center',

--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -1743,6 +1743,131 @@ export function isPlaceholderContent(block) {
 }
 
 /**
+ * Read the value at an array path (e.g. ['table','rows'] or ['content','headline']).
+ * Empty path returns `obj` itself. Missing segment returns undefined.
+ */
+export function getAtPath(obj, path) {
+  return (path || []).reduce((cur, key) => cur?.[key], obj);
+}
+
+/**
+ * Immutably descend `path` on `obj`, replacing each visited node with a shallow
+ * clone (so callers can mutate the returned node / its properties without
+ * touching the original references — INITIAL_DATA arrives deep-frozen). Returns
+ * the node at `path`. To set a leaf value: `ensureMutablePath(obj,
+ * path.slice(0, -1))[path.at(-1)] = value`.
+ */
+export function ensureMutablePath(obj, path) {
+  let cur = obj;
+  for (const key of path || []) {
+    cur[key] = { ...(cur[key] || {}) };
+    cur = cur[key];
+  }
+  return cur;
+}
+
+/**
+ * Resolve a field's schema def by an object-descent `path` (e.g.
+ * ['content','headline']). Descends ONLY through `widget:'object'` wrappers — a
+ * transparent grouping of fields. A REGION (`object_list` / `blocks_layout`) or
+ * a plain value is TERMINAL: you cannot path *through* it, because a region's
+ * children are separate blocks addressed by their own UID, not by continuing
+ * the field path (and a value has no sub-fields). Note object_list/blocks_layout
+ * ALSO carry a `.schema`, so the gate is on the widget, not on `.schema`.
+ * Returns the fieldDef at `path`, or undefined if a segment is missing or an
+ * intermediate segment is not an object wrapper.
+ */
+export function getFieldDefByPath(schema, path) {
+  let props = schema?.properties;
+  let def;
+  for (let i = 0; i < (path || []).length; i++) {
+    if (!props) return undefined;
+    def = props[path[i]];
+    if (!def) return undefined;
+    if (i < path.length - 1) {
+      if (def.widget !== 'object' || !def.schema?.properties) return undefined;
+      props = def.schema.properties;
+    }
+  }
+  return def;
+}
+
+// ── Central field access ──────────────────────────────────────────────────
+// The ONE API every inline-edit path (text / link / media) and the sidebar/
+// validation should use to read or write a block field by its `/`-path (the
+// object-descent grammar; #245). Never index `block[fieldName]` /
+// `schema.properties[fieldName]` directly — a nested field like `content/image`
+// would read undefined and write a stray flat key. `/`-scope and `..` (which
+// BLOCK) are resolved separately (DOM-relative, hydra-side) before these run.
+
+/** Read a block field value by `/`-path. "content/headline" → block.content.headline. */
+export function getFieldValue(block, fieldPath) {
+  return getAtPath(block, String(fieldPath).split('/'));
+}
+
+/**
+ * Return a NEW block with the field at `/`-path set (immutable — input untouched;
+ * intermediate object wrappers are cloned). Callers that want in-place mutation
+ * (hydra's live formData) reassign / Object.assign the result.
+ */
+export function setFieldValue(block, fieldPath, value) {
+  const parts = String(fieldPath).split('/');
+  const result = { ...block };
+  ensureMutablePath(result, parts.slice(0, -1))[parts[parts.length - 1]] = value;
+  return result;
+}
+
+/** Resolve a block field's schema def by `/`-path (descends `widget:'object'` only). */
+export function getFieldDef(schema, fieldPath) {
+  return getFieldDefByPath(schema, String(fieldPath).split('/'));
+}
+
+// Same value as hydra.js / buildBlockPathMap — inlined so this module stays
+// free of hydra-js deps.
+const PAGE_BLOCK_UID = '_page';
+
+/**
+ * The BLOCK-SCOPE half of the path grammar: resolve a `data-edit-*` path's
+ * leading `/` / `..` against the block hierarchy, returning `{ blockId,
+ * fieldName }` where `fieldName` is the remaining WITHIN-block object-descent
+ * path (feed it to getFieldDef / getFieldValue / setFieldValue). Pure — the
+ * pathMap is passed in, not read off a bridge.
+ *
+ *   'field'    → { blockId, 'field' }         this block's field
+ *   'a/b'      → { blockId, 'a/b' }           descend the block's objects
+ *   '/field'   → { _page, 'field' }           page/root field
+ *   '../field' → { parent block, 'field' }    up one BLOCK per `../`
+ *   '../a/b'   → { parent block, 'a/b' }       then descend objects
+ *
+ * `..` only ever crosses a BLOCK boundary (never an object/region level); past
+ * the top block it lands on the page.
+ *
+ * @param {string} fieldPath
+ * @param {string} blockId - current block (PAGE_BLOCK_UID for page-level)
+ * @param {Object} blockPathMap - blockId → { parentId } (for `../`)
+ * @returns {{ blockId: string, fieldName: string }}
+ */
+export function resolveFieldPath(fieldPath, blockId, blockPathMap) {
+  if (fieldPath.startsWith('/')) {
+    return { blockId: PAGE_BLOCK_UID, fieldName: fieldPath.slice(1) };
+  }
+  if (!blockId || blockId === PAGE_BLOCK_UID) {
+    return { blockId: PAGE_BLOCK_UID, fieldName: fieldPath };
+  }
+  let currentBlockId = blockId;
+  let remainingPath = fieldPath;
+  while (remainingPath.startsWith('../')) {
+    const pathInfo = blockPathMap?.[currentBlockId];
+    if (!pathInfo?.parentId || pathInfo.parentId === PAGE_BLOCK_UID) {
+      return { blockId: PAGE_BLOCK_UID, fieldName: remainingPath.slice(3) };
+    }
+    currentBlockId = pathInfo.parentId;
+    remainingPath = remainingPath.slice(3);
+  }
+  return { blockId: currentBlockId, fieldName: remainingPath };
+}
+
+/**
  * The child blocks at a container's region, as ordered {id, block} entries — uniform
  * across BOTH storages. blocks_layout and object_list are just two ways to lay out the
  * same thing (a container's ordered region of child blocks); any caller that needs the
@@ -1753,29 +1878,34 @@ export function isPlaceholderContent(block) {
  * (the admin derives it from the schema, the merge data-drivenly), but the read shape
  * is shared here so it isn't duplicated.
  *
+ * A descriptor's `regionPath` is the object-key prefix to where the region
+ * lives (e.g. ['table'] for a `table` object wrapper, [] for the block root) —
+ * the `/`-path grammar's object hops. For object_list the array is at
+ * `[...regionPath, region]`; for blocks_layout the shared dict + layout live on
+ * the node at `regionPath`. Same prefix, one representation, no `dataPath`.
+ *
  * @param {Object} parentBlock - the container block
- * @param {Object} descriptor - { isObjectList, dataPath, region='items', idField='@id' }
+ * @param {Object} descriptor - { isObjectList, regionPath, region='items', idField='@id' }
  * @returns {Array<{id: string, block: Object}>}
  */
 export function getChildBlockEntries(parentBlock, descriptor = {}) {
   const {
     isObjectList,
-    dataPath,
+    regionPath = [],
     region = 'items',
     idField = '@id',
   } = descriptor;
   if (isObjectList) {
-    // object_list: an array of block objects, possibly at a nested dataPath.
-    let arr = parentBlock;
-    for (const key of dataPath || [region]) {
-      arr = arr?.[key];
-    }
+    // object_list: an inline array at [...regionPath, region].
+    const arr = getAtPath(parentBlock, [...regionPath, region]);
     return [...(arr || [])].map((block) => ({ id: block[idField], block }));
   }
-  // blocks_layout: the region lists ids into the shared parent.blocks dict.
-  const ids = parentBlock?.blocks_layout?.[region] || [];
+  // blocks_layout: the region lists ids into a shared blocks dict on the node at
+  // regionPath (block root when empty, e.g. a `table` object wrapper otherwise).
+  const container = getAtPath(parentBlock, regionPath);
+  const ids = container?.blocks_layout?.[region] || [];
   return ids
-    .map((id) => ({ id, block: parentBlock?.blocks?.[id] }))
+    .map((id) => ({ id, block: container?.blocks?.[id] }))
     .filter((entry) => entry.block);
 }
 
@@ -1787,7 +1917,7 @@ export function getChildBlockEntries(parentBlock, descriptor = {}) {
  * field so callers iterate uniformly and never branch on storage.
  *
  * @param {Object} block - the container block
- * @returns {Array<{ region?: string, isObjectList?: boolean, dataPath?: string[] }>}
+ * @returns {Array<{ region?: string, isObjectList?: boolean, regionPath?: string[] }>}
  */
 export function getChildFields(block, idFieldMap = null) {
   const fields = [];
@@ -1807,7 +1937,7 @@ export function getChildFields(block, idFieldMap = null) {
     if (Array.isArray(val) && val.length > 0 && val[0]?.templateId) {
       fields.push({
         isObjectList: true,
-        dataPath: [key],
+        region: key, // top-level array field; regionPath defaults to []
         idField: typeIds?.[key] || '@id',
       });
     }
@@ -1820,44 +1950,43 @@ export function getChildFields(block, idFieldMap = null) {
  * paired with getChildBlockEntries, uniform across BOTH storages (the public mutator the
  * merge and the admin can share). For blocks_layout it ADDS the blocks to the shared
  * dict and sets the region's id list (call once per region — regions accumulate in the
- * one dict). For object_list it writes the array at the (possibly nested) dataPath,
+ * one dict). For object_list it writes the array at `[...regionPath, region]`,
  * cloning each level (INITIAL_DATA arrives deep-frozen).
  *
  * @param {Object} parentBlock - the container block to mutate
- * @param {Object} descriptor - { isObjectList, dataPath, region='items', idField='@id' }
+ * @param {Object} descriptor - { isObjectList, regionPath, region='items', idField='@id' }
  * @param {Array<{id: string, block: Object}>} entries
  */
 export function setChildBlockEntries(parentBlock, descriptor, entries) {
   const {
     isObjectList,
-    dataPath,
+    regionPath = [],
     region = 'items',
     idField = '@id',
   } = descriptor;
   if (isObjectList) {
-    const path = dataPath || [region];
-    let target = parentBlock;
-    for (let i = 0; i < path.length - 1; i++) {
-      target[path[i]] = { ...(target[path[i]] || {}) };
-      target = target[path[i]];
-    }
-    target[path[path.length - 1]] = entries.map((e) => ({
+    const parent = ensureMutablePath(parentBlock, regionPath);
+    parent[region] = entries.map((e) => ({
       ...e.block,
       [idField]: e.id,
     }));
     return;
   }
+  // blocks_layout: the shared blocks dict + blocks_layout may live under a
+  // widget:'object' wrapper (regionPath). Clone each level so the object's own
+  // dict is written (never the block root) and sibling object fields survive.
+  const container = ensureMutablePath(parentBlock, regionPath);
   for (const { id, block } of entries) {
     // Callers that manage the shared blocks dict themselves (e.g. the admin's
     // full-dict setContainerItems, whose blocksObj already reflects adds/deletes)
     // omit `block` — only write into the dict when a block is actually provided.
     if (block !== undefined) {
-      if (!parentBlock.blocks) parentBlock.blocks = {};
-      parentBlock.blocks[id] = block;
+      if (!container.blocks) container.blocks = {};
+      container.blocks[id] = block;
     }
   }
-  parentBlock.blocks_layout = {
-    ...(parentBlock.blocks_layout || {}),
+  container.blocks_layout = {
+    ...(container.blocks_layout || {}),
     [region]: entries.map((e) => e.id),
   };
 }
@@ -3260,7 +3389,7 @@ export function expandTemplatesSync(inputItems, options = {}) {
       let childSlotIds = undefined;
       for (const field of getChildFields(tplBlock)) {
         const key = field.isObjectList
-          ? field.dataPath[field.dataPath.length - 1]
+          ? field.region
           : 'blocks';
         for (const { block: child } of getChildBlockEntries(tplBlock, field)) {
           if (child && !child.fixed && child.slotId) {

--- a/packages/hydra-js/blocksLayoutInObject.test.js
+++ b/packages/hydra-js/blocksLayoutInObject.test.js
@@ -1,0 +1,138 @@
+import { getChildBlockEntries, setChildBlockEntries } from '@volto-hydra/helpers';
+import { buildBlockPathMap } from './buildBlockPathMap.js';
+
+/**
+ * A blocks_layout region can live INSIDE a widget:'object' wrapper (#245): the
+ * object holds its OWN `blocks` dict + `blocks_layout`, one level deeper than the
+ * block root (e.g. block.table.blocks / block.table.blocks_layout.body). The
+ * funnel navigates there via `regionPath` (the object-path prefix), the same
+ * field object_list uses (its array is at [...regionPath, region]). regionPath
+ * omitted / [] means the region lives directly on the parent block (the
+ * ordinary case).
+ */
+describe('blocks_layout nested in a widget:object (regionPath)', () => {
+  const nested = () => ({
+    '@type': 'objectBlocks',
+    table: {
+      hideHeaders: true,
+      blocks: {
+        b1: { '@type': 'slate', value: 'One' },
+        b2: { '@type': 'slate', value: 'Two' },
+      },
+      blocks_layout: { body: ['b1', 'b2'] },
+    },
+  });
+
+  test('read: getChildBlockEntries resolves ids from the object-nested blocks dict', () => {
+    expect(
+      getChildBlockEntries(nested(), { region: 'body', regionPath: ['table'] }),
+    ).toEqual([
+      { id: 'b1', block: { '@type': 'slate', value: 'One' } },
+      { id: 'b2', block: { '@type': 'slate', value: 'Two' } },
+    ]);
+  });
+
+  test('write: setChildBlockEntries writes into the object, preserving sibling object keys', () => {
+    const parent = nested();
+    setChildBlockEntries(
+      parent,
+      { region: 'body', regionPath: ['table'] },
+      [
+        { id: 'b2', block: { '@type': 'slate', value: 'Two' } },
+        { id: 'b3', block: { '@type': 'image' } },
+      ],
+    );
+    // Ordering updated inside the object's own blocks_layout.
+    expect(parent.table.blocks_layout.body).toEqual(['b2', 'b3']);
+    // New block added to the object's own blocks dict.
+    expect(parent.table.blocks.b3).toEqual({ '@type': 'image' });
+    // Sibling object field untouched; nothing leaked to the block root.
+    expect(parent.table.hideHeaders).toBe(true);
+    expect(parent.blocks).toBeUndefined();
+    expect(parent.blocks_layout).toBeUndefined();
+  });
+
+  test('write: preserves a sibling region inside the same object', () => {
+    const parent = {
+      '@type': 'objectBlocks',
+      table: {
+        blocks: { a: { '@type': 'slate' }, z: { '@type': 'slate' } },
+        blocks_layout: { header: ['z'], body: ['a'] },
+      },
+    };
+    setChildBlockEntries(
+      parent,
+      { region: 'body', regionPath: ['table'] },
+      [{ id: 'a', block: { '@type': 'slate' } }, { id: 'n', block: { '@type': 'image' } }],
+    );
+    expect(parent.table.blocks_layout.header).toEqual(['z']); // untouched
+    expect(parent.table.blocks_layout.body).toEqual(['a', 'n']);
+  });
+
+  test('regionPath omitted behaves exactly like the block-root case', () => {
+    const parent = { blocks: { a: { '@type': 'slate' } }, blocks_layout: { items: ['a'] } };
+    expect(getChildBlockEntries(parent, {}).map((e) => e.id)).toEqual(['a']);
+  });
+});
+
+describe('buildBlockPathMap records regionPath for blocks-in-object', () => {
+  const blocksConfig = {
+    Document: {
+      id: 'Document',
+      blockSchema: { properties: { items: { widget: 'blocks_layout' } } },
+    },
+    objectBlocks: {
+      id: 'objectBlocks',
+      blockSchema: {
+        properties: {
+          table: {
+            widget: 'object',
+            schema: {
+              properties: {
+                body: { widget: 'blocks_layout', allowedBlocks: ['slate'] },
+              },
+            },
+          },
+        },
+      },
+    },
+    slate: { id: 'slate' },
+  };
+
+  const formData = {
+    '@type': 'Document',
+    blocks: {
+      'ob-1': {
+        '@type': 'objectBlocks',
+        table: {
+          blocks: { c1: { '@type': 'slate' }, c2: { '@type': 'slate' } },
+          blocks_layout: { body: ['c1', 'c2'] },
+        },
+      },
+    },
+    blocks_layout: { items: ['ob-1'] },
+  };
+
+  test('child path points at the object-nested blocks dict', () => {
+    const map = buildBlockPathMap(formData, blocksConfig);
+    expect(map['c1'].path).toEqual(['blocks', 'ob-1', 'table', 'blocks', 'c1']);
+    expect(map['c2'].path).toEqual(['blocks', 'ob-1', 'table', 'blocks', 'c2']);
+  });
+
+  test('child parentId is the enclosing block; region is the field name', () => {
+    const map = buildBlockPathMap(formData, blocksConfig);
+    expect(map['c1'].parentId).toBe('ob-1');
+    expect(map['c1'].region).toBe('body');
+  });
+
+  test('child carries regionPath = the object prefix (block-relative)', () => {
+    const map = buildBlockPathMap(formData, blocksConfig);
+    expect(map['c1'].regionPath).toEqual(['table']);
+  });
+
+  test('a top-level blocks field carries no regionPath (block-root)', () => {
+    const map = buildBlockPathMap(formData, blocksConfig);
+    // ob-1 lives directly in the page items region — no object nesting.
+    expect(map['ob-1'].regionPath ?? []).toEqual([]);
+  });
+});

--- a/packages/hydra-js/buildBlockPathMap.js
+++ b/packages/hydra-js/buildBlockPathMap.js
@@ -459,6 +459,14 @@ export function buildBlockPathMap(formData, blocksConfig, intl = {}) {
     const layout = parent.blocks_layout?.[region];
     if (!blocks || !Array.isArray(layout) || layout.length === 0) return;
 
+    // Block-relative object prefix to the shared blocks dict + blocks_layout.
+    // Empty when the blocks live directly on the owning block (the ordinary
+    // case); [table] etc. when the blocks_layout is nested inside a
+    // widget:'object' wrapper (#245). The ops navigate here via regionPath —
+    // the blocks_layout analogue of object_list's dataPath.
+    const ownerPath = pathMap[parentId]?.path || [];
+    const regionPath = parentPath.slice(ownerPath.length);
+
     // Constraints come from the blocks field's own def, falling back to the
     // block-level config (the existing convention for Volto built-ins).
     const parentBlockConfig = blocksConfig?.[parent?.['@type']];
@@ -571,6 +579,7 @@ export function buildBlockPathMap(formData, blocksConfig, intl = {}) {
         path: blockPath,
         parentId: effectiveParentId,
         region, // The container field (region) this block lives in
+        ...(regionPath.length > 0 && { regionPath }), // object prefix to the blocks dict (#245)
         blockType, // Block type for uniform lookups (single source of truth)
         _schemaRef: storeSchema(blockSchema), // Deduplicated schema reference
         // A field's own allowedBlocks is authoritative at every level (same as the object_list
@@ -649,6 +658,16 @@ export function buildBlockPathMap(formData, blocksConfig, intl = {}) {
       addMode = blockConfig?.addMode || null;
     }
 
+    // Block-relative path from the enclosing block to this array — what the mutation
+    // ops navigate. The region's object-key PREFIX (the `/`-path object hops):
+    // [] when the array is directly on the parent, ['table'] when it's inside a
+    // `table` object wrapper (#245). Uniform with the blocks_layout regionPath —
+    // the array itself is at [...regionPath, region]. A nested object_list item
+    // (cells inside a row) is parent-relative, so its prefix is [].
+    const regionPath = parentPathInfo?.isObjectListItem
+      ? []
+      : parentPath.slice((parentPathInfo?.path || []).length);
+
     itemsArray.forEach((item, index) => {
       const itemId = item[idField];
       if (!itemId) return;
@@ -724,7 +743,7 @@ export function buildBlockPathMap(formData, blocksConfig, intl = {}) {
         ...(!canInsertAfter && { canInsertAfter: false }),
         _schemaRef: storeSchema(blockSchema), // Deduplicated schema reference
         itemSchema: effectiveItemSchema, // null for typed items (schema from blocksConfig)
-        dataPath: effectiveDataPath, // Store for later use
+        ...(regionPath.length > 0 && { regionPath }), // object prefix to the array (#245); array at [...regionPath, region]
         allowedSiblingTypes: hasAllowedBlocks ? fieldDef.allowedBlocks : [virtualType],
         maxSiblings: fieldDef.maxLength || null,
         siblingCount: itemsArray.length,

--- a/packages/hydra-js/getChildBlockEntries.test.js
+++ b/packages/hydra-js/getChildBlockEntries.test.js
@@ -36,10 +36,10 @@ describe('getChildBlockEntries — uniform child access across blocks_layout & o
     ]);
   });
 
-  test('object_list: reads the array at a nested dataPath (e.g. table.rows)', () => {
+  test('object_list: reads the array at a nested regionPath (e.g. table/rows)', () => {
     const parent = { table: { rows: [{ '@id': 'r1' }, { '@id': 'r2' }] } };
     expect(
-      getChildBlockEntries(parent, { isObjectList: true, dataPath: ['table', 'rows'] }).map((e) => e.id),
+      getChildBlockEntries(parent, { isObjectList: true, regionPath: ['table'], region: 'rows' }).map((e) => e.id),
     ).toEqual(['r1', 'r2']);
   });
 

--- a/packages/hydra-js/hydra.src.js
+++ b/packages/hydra-js/hydra.src.js
@@ -21,6 +21,12 @@ import {
   isTextOnlyBlockChange,
   findBlockInForm,
   slateNodesText,
+  getAtPath,
+  ensureMutablePath,
+  getFieldValue,
+  setFieldValue,
+  getFieldDef,
+  resolveFieldPath as resolveFieldPathHelper,
 } from '@volto-hydra/helpers';
 import { expelAllowedTypes, findOnlyEmptyChildUid } from './containerOps.js';
 
@@ -680,43 +686,13 @@ export class Bridge {
   }
 
   /**
-   * Resolve a field path to determine the target block and field name.
-   * Supports:
-   * - "fieldName" -> block's own field (or page if no block context)
-   * - "../fieldName" -> parent block's field (or page if at top level)
-   * - "/fieldName" -> page-level field
-   *
-   * @param {string} fieldPath - The field path from data-edit-text
-   * @param {string|null} blockId - Current block ID (PAGE_BLOCK_UID for page-level)
-   * @returns {Object} { blockId: string, fieldName: string }
+   * Resolve a data-edit path's block scope (`/`, `..`) to { blockId, fieldName }.
+   * Thin wrapper over the pure `resolveFieldPath` helper, passing this bridge's
+   * blockPathMap. The whole path grammar (block scope + object descent) lives in
+   * @volto-hydra/helpers.
    */
   resolveFieldPath(fieldPath, blockId) {
-    // Handle absolute path (page-level)
-    if (fieldPath.startsWith('/')) {
-      return { blockId: PAGE_BLOCK_UID, fieldName: fieldPath.slice(1) };
-    }
-
-    // If no block context or PAGE_BLOCK_UID, treat as page-level
-    if (!blockId || blockId === PAGE_BLOCK_UID) {
-      return { blockId: PAGE_BLOCK_UID, fieldName: fieldPath };
-    }
-
-    // Handle relative path with ../
-    let currentBlockId = blockId;
-    let remainingPath = fieldPath;
-
-    while (remainingPath.startsWith('../')) {
-      const pathInfo = this.blockPathMap?.[currentBlockId];
-      if (!pathInfo?.parentId || pathInfo.parentId === PAGE_BLOCK_UID) {
-        // Already at top level, next ../ goes to page
-        return { blockId: PAGE_BLOCK_UID, fieldName: remainingPath.slice(3) };
-      }
-      currentBlockId = pathInfo.parentId;
-      remainingPath = remainingPath.slice(3);
-    }
-
-    // Block field
-    return { blockId: currentBlockId, fieldName: remainingPath };
+    return resolveFieldPathHelper(fieldPath, blockId, this.blockPathMap);
   }
 
   /**
@@ -5649,11 +5625,11 @@ export class Bridge {
     const fieldName = editableField.getAttribute('data-edit-text');
     const blockData = this.getBlockData(blockUid);
 
-    if (!blockData || !blockData[fieldName]) {
+    if (!blockData || !getFieldValue(blockData, fieldName)) {
       return { valid: true }; // Can't validate without Slate value
     }
 
-    const slateValue = blockData[fieldName];
+    const slateValue = getFieldValue(blockData, fieldName);
     if (!Array.isArray(slateValue)) {
       return { valid: true }; // Not a Slate field
     }
@@ -7236,7 +7212,7 @@ export class Bridge {
       if (!fieldEl) continue;
 
       if (this.fieldTypeIsSlate(fieldType)) {
-        const slateValue = blockData[fieldName];
+        const slateValue = getFieldValue(blockData, fieldName);
         if (!slateValue || !Array.isArray(slateValue)) continue;
         const domValue = this.readSlateValueFromDOM(fieldEl, slateValue, { matchMetadataFromDom: true });
         if (!this._deepEqual(domValue, slateValue)) {
@@ -7250,7 +7226,7 @@ export class Bridge {
         // Non-slate text fields: compare using same read as handleTextChange
         const resolved = this.resolveFieldPath(fieldName, blockUid);
         const targetData = this.getBlockData(resolved.blockId);
-        const expected = targetData?.[resolved.fieldName] ?? '';
+        const expected = getFieldValue(targetData, resolved.fieldName) ?? '';
         const domText = this.stripZeroWidthSpaces(fieldEl.innerText || '');
         if (domText !== String(expected)) return false;
       }
@@ -7266,7 +7242,7 @@ export class Bridge {
     const editableFields = this.getEditableFields(blockElement);
     for (const [fieldName, fieldType] of Object.entries(editableFields)) {
       if (!this.fieldTypeIsSlate(fieldType)) continue;
-      const slateValue = blockData[fieldName];
+      const slateValue = getFieldValue(blockData, fieldName);
       if (!slateValue || !Array.isArray(slateValue)) continue;
 
       const fieldEl = blockElement.querySelector(`[data-edit-text="${fieldName}"]`)
@@ -10609,12 +10585,23 @@ export class Bridge {
       const schema = this.getBlockSchema(blockId);
       if (!schema?.properties) return;
 
-      Object.entries(schema.properties).forEach(([fieldName, fieldDef]) => {
-        if (isSlateFieldType(getFieldTypeString(fieldDef)) && block[fieldName]) {
-          block[fieldName] = this.addNodeIds(block[fieldName]);
-          slateCalls++;
-        }
-      });
+      // Walk the block's fields, descending into widget:'object' wrappers so a
+      // slate field nested on an object (e.g. content.headline, #245) also gets
+      // nodeIds — otherwise inline-editing it fails with "missing data-node-id".
+      const addToFields = (obj, props) => {
+        if (!obj || !props) return;
+        Object.entries(props).forEach(([fieldName, fieldDef]) => {
+          if (fieldDef.widget === 'object' && fieldDef.schema?.properties) {
+            addToFields(obj[fieldName], fieldDef.schema.properties);
+            return;
+          }
+          if (isSlateFieldType(getFieldTypeString(fieldDef)) && obj[fieldName]) {
+            obj[fieldName] = this.addNodeIds(obj[fieldName]);
+            slateCalls++;
+          }
+        });
+      };
+      addToFields(block, schema.properties);
     });
     log('addNodeIdsToAllSlateFields took', (performance.now() - t0).toFixed(1) + 'ms, slate fields:', slateCalls);
   }
@@ -10788,7 +10775,7 @@ export class Bridge {
       const resolved = this.resolveFieldPath(this.focusedFieldName, this.selectedBlockUid);
       const fieldData = this.getBlockData(resolved.blockId);
       const fieldType = this.getFieldType(this.selectedBlockUid, this.focusedFieldName);
-      const fieldValue = fieldData?.[resolved.fieldName];
+      const fieldValue = getFieldValue(fieldData, resolved.fieldName);
 
       // Find the block element for locating editable fields
       const blockElement = this.queryBlockElement(this.selectedBlockUid);
@@ -11323,11 +11310,22 @@ export class Bridge {
         const block = blocks[blockId];
         const schema = this.getBlockSchema(blockId);
         if (block && schema?.properties) {
-          for (const [fieldName, fieldDef] of Object.entries(schema.properties)) {
-            if (isSlateFieldType(getFieldTypeString(fieldDef)) && block[fieldName]) {
-              this.resetJsonNodeIds(block[fieldName]);
+          // Descend widget:'object' wrappers so a slate field nested on an
+          // object (content/headline, #245) is stripped too — top-level is just
+          // the depth-0 case of the same walk.
+          const stripFields = (obj, props) => {
+            if (!obj || !props) return;
+            for (const [fieldName, fieldDef] of Object.entries(props)) {
+              if (fieldDef.widget === 'object' && fieldDef.schema?.properties) {
+                stripFields(obj[fieldName], fieldDef.schema.properties);
+                continue;
+              }
+              if (isSlateFieldType(getFieldTypeString(fieldDef)) && obj[fieldName]) {
+                this.resetJsonNodeIds(obj[fieldName]);
+              }
             }
-          }
+          };
+          stripFields(block, schema.properties);
           // Also check nested blocks in container fields
           if (block.blocks) {
             stripNodeIdsFromSlateFields(block.blocks);
@@ -11360,8 +11358,8 @@ export class Bridge {
     let fieldA, fieldB;
     if (resolved.blockId === PAGE_BLOCK_UID) {
       // Page-level field - compare directly on formData
-      fieldA = formDataA?.[resolved.fieldName];
-      fieldB = formDataB?.[resolved.fieldName];
+      fieldA = getFieldValue(formDataA, resolved.fieldName);
+      fieldB = getFieldValue(formDataB, resolved.fieldName);
       log('focusedFieldValuesEqual (page-level):', fieldA === fieldB, 'field:', resolved.fieldName, 'A:', fieldA, 'B:', fieldB);
       return fieldA === fieldB;
     }
@@ -11386,8 +11384,8 @@ export class Bridge {
       return false; // Can't find block - assume not equal (safe default)
     }
     // Deep copy and strip nodeIds before comparing (old formData has nodeIds, incoming doesn't)
-    fieldA = blockA[resolved.fieldName];
-    fieldB = blockB[resolved.fieldName];
+    fieldA = getFieldValue(blockA, resolved.fieldName);
+    fieldB = getFieldValue(blockB, resolved.fieldName);
     if (fieldA === undefined || fieldB === undefined) {
       return fieldA === fieldB;
     }
@@ -11409,9 +11407,40 @@ export class Bridge {
   getFieldType(blockUid, fieldName) {
     const resolved = this.resolveFieldPath(fieldName, blockUid);
     const schema = this.getBlockSchema(resolved.blockId);
-    const fieldDef = schema?.properties?.[resolved.fieldName];
+    const fieldDef = this.getNestedFieldDef(schema, resolved.fieldName);
     if (!fieldDef) return undefined;
     return getFieldTypeString(fieldDef);
+  }
+
+  /**
+   * Resolve a `/`-path field name to its schema fieldDef, descending through
+   * widget:'object' wrappers (#245). "headline" reads schema.properties.headline;
+   * "content/headline" descends schema.properties.content.schema.properties.headline
+   * — the object key(s) mirror the storage path. The block-scope prefix (`/`, `..`)
+   * is consumed by resolveFieldPath before this; the remainder is `/`-separated
+   * object hops. Returns undefined if any segment is missing.
+   */
+  getNestedFieldDef(schema, fieldName) {
+    if (!fieldName) return undefined;
+    return getFieldDef(schema, fieldName);
+  }
+
+  /**
+   * Read a `/`-path field value from a block (central field-access API).
+   */
+  getFieldValueByPath(obj, fieldName) {
+    if (!obj || !fieldName) return undefined;
+    return getFieldValue(obj, fieldName);
+  }
+
+  /**
+   * Write a `/`-path field value into a block IN PLACE (hydra's `obj` is a live
+   * formData ref). Routes through the shared immutable setFieldValue, then
+   * Object.assign's the result back so the ref reflects the change.
+   */
+  setFieldValueByPath(obj, fieldName, value) {
+    if (!obj || !fieldName) return;
+    Object.assign(obj, setFieldValue(obj, fieldName, value));
   }
 
   /**
@@ -11444,7 +11473,7 @@ export class Bridge {
       }
     }
     // 2. Schema-level placeholder
-    const fieldDef = this.getBlockSchema(resolved.blockId)?.properties?.[resolved.fieldName];
+    const fieldDef = this.getNestedFieldDef(this.getBlockSchema(resolved.blockId), resolved.fieldName);
     if (fieldDef?.placeholder) return fieldDef.placeholder;
     // 3. Universal fallback
     return 'Click to edit';
@@ -11607,16 +11636,22 @@ export class Bridge {
       // The DOM is the source of truth for structure (which children exist,
       // their order, their text). Metadata (type, data, marks) comes from
       // the existing JSON via a nodeId → metadata map.
-      const block = this.getBlockData(blockUid);
-      if (!block || !block[editableField]) {
+      // Resolve blockId (../ , /) then read/write the field at its storage path,
+      // which may be nested inside a widget:'object' (dotted, e.g.
+      // content.headline, #245). getFieldValueByPath/setFieldValueByPath walk
+      // the dotted path so a bare "value" behaves exactly as before.
+      const resolved = this.resolveFieldPath(editableField, blockUid);
+      const block = this.getBlockData(resolved.blockId);
+      const currentValue = this.getFieldValueByPath(block, resolved.fieldName);
+      if (!block || !currentValue) {
         log('handleTextChange: block or field not found for', blockUid, editableField);
         return;
       }
 
-      const freshValue = this.readSlateValueFromDOM(target, block[editableField]);
+      const freshValue = this.readSlateValueFromDOM(target, currentValue);
 
       const freshStr = JSON.stringify(freshValue);
-      const currentStr = JSON.stringify(block[editableField]);
+      const currentStr = JSON.stringify(currentValue);
 
       if (freshStr === currentStr) {
         log('handleTextChange: DOM matches formData, skipping');
@@ -11627,7 +11662,7 @@ export class Bridge {
       log('handleTextChange: DIFF fresh=', freshStr);
       log('handleTextChange: DIFF current=', currentStr);
 
-      block[editableField] = freshValue;
+      this.setFieldValueByPath(block, resolved.fieldName, freshValue);
       log('handleTextChange: updated', editableField);
     } else {
       // Non-Slate field - update field directly with text content
@@ -11635,7 +11670,7 @@ export class Bridge {
       const resolved = this.resolveFieldPath(editableField, blockUid);
       const targetData = this.getBlockData(resolved.blockId);
       if (targetData) {
-        targetData[resolved.fieldName] = this.stripZeroWidthSpaces(target.innerText);
+        this.setFieldValueByPath(targetData, resolved.fieldName, this.stripZeroWidthSpaces(target.innerText));
         log('handleTextChange: updated field:', resolved.fieldName);
       }
     }

--- a/packages/hydra-js/pathHelpers.test.js
+++ b/packages/hydra-js/pathHelpers.test.js
@@ -1,0 +1,282 @@
+import {
+  getAtPath,
+  ensureMutablePath,
+  getFieldDefByPath,
+  getFieldValue,
+  setFieldValue,
+  getFieldDef,
+  resolveFieldPath,
+} from '@volto-hydra/helpers';
+
+/**
+ * getAtPath / ensureMutablePath are the shared object-path primitives behind
+ * every container read/write (object_list dataPath, blocks_layout regionPath,
+ * dotted object fields like content.headline). The clone-along-path write is
+ * subtle — these guard it directly.
+ */
+describe('getAtPath', () => {
+  const obj = { table: { rows: [1, 2], hideHeaders: true }, top: 'x' };
+
+  test('reads a nested value at an array path', () => {
+    expect(getAtPath(obj, ['table', 'rows'])).toEqual([1, 2]);
+    expect(getAtPath(obj, ['table', 'hideHeaders'])).toBe(true);
+    expect(getAtPath(obj, ['top'])).toBe('x');
+  });
+
+  test('empty (or missing) path returns the object itself', () => {
+    expect(getAtPath(obj, [])).toBe(obj);
+    expect(getAtPath(obj, undefined)).toBe(obj);
+  });
+
+  test('a missing segment short-circuits to undefined (no throw)', () => {
+    expect(getAtPath(obj, ['table', 'nope', 'deep'])).toBeUndefined();
+    expect(getAtPath(undefined, ['a'])).toBeUndefined();
+  });
+});
+
+describe('ensureMutablePath', () => {
+  test('returns the node at path and clones every visited level', () => {
+    const original = { content: { headline: [{ text: 'a' }], blocks: { b1: {} } } };
+    const contentBefore = original.content;
+    const node = ensureMutablePath(original, ['content']);
+
+    expect(node).toBe(original.content); // returns the (now cloned) node
+    expect(original.content).not.toBe(contentBefore); // level was cloned
+    expect(original.content.blocks).toBe(contentBefore.blocks); // untouched siblings kept by ref
+  });
+
+  test('set-a-leaf idiom writes nested without mutating shared refs', () => {
+    const shared = { content: { headline: [{ text: 'old' }], keep: 1 } };
+    const snapshot = shared.content.headline; // pretend this is frozen/shared
+    const path = ['content', 'headline'];
+    ensureMutablePath(shared, path.slice(0, -1))[path[path.length - 1]] = [{ text: 'new' }];
+
+    expect(shared.content.headline).toEqual([{ text: 'new' }]);
+    expect(snapshot).toEqual([{ text: 'old' }]); // original array object untouched
+    expect(shared.content.keep).toBe(1); // sibling field survives
+  });
+
+  test('empty path returns the object unchanged', () => {
+    const o = { a: 1 };
+    expect(ensureMutablePath(o, [])).toBe(o);
+  });
+
+  test('creates intermediate objects for a missing path', () => {
+    const o = {};
+    ensureMutablePath(o, ['x', 'y']).z = 3;
+    expect(o).toEqual({ x: { y: { z: 3 } } });
+  });
+});
+
+describe('getFieldDefByPath — descend only through widget:object', () => {
+  const headline = { title: 'Headline', widget: 'slate' };
+  const cells = { widget: 'object_list', schema: { properties: { value: { widget: 'slate' } } } };
+  const schema = {
+    properties: {
+      value: { widget: 'slate' },
+      content: {
+        widget: 'object',
+        schema: {
+          properties: {
+            headline,
+            body: { widget: 'blocks_layout' },
+            rows: { widget: 'object_list', schema: { properties: { cells } } },
+          },
+        },
+      },
+    },
+  };
+
+  test('resolves a top-level field and one nested in an object', () => {
+    expect(getFieldDefByPath(schema, ['value'])).toBe(schema.properties.value);
+    expect(getFieldDefByPath(schema, ['content', 'headline'])).toBe(headline);
+  });
+
+  test('a region field is reachable as a LEAF (its own def)', () => {
+    expect(getFieldDefByPath(schema, ['content', 'body']).widget).toBe('blocks_layout');
+    expect(getFieldDefByPath(schema, ['content', 'rows']).widget).toBe('object_list');
+  });
+
+  test('cannot descend PAST a region (object_list/blocks_layout) — terminal', () => {
+    // rows is an array of items; "content.rows.cells" is meaningless (which row?)
+    expect(getFieldDefByPath(schema, ['content', 'rows', 'cells'])).toBeUndefined();
+    // blocks_layout region: its children are separate blocks, not path segments
+    expect(getFieldDefByPath(schema, ['content', 'body', 'anything'])).toBeUndefined();
+  });
+
+  test('cannot descend PAST a value, and missing segments → undefined', () => {
+    expect(getFieldDefByPath(schema, ['value', 'deeper'])).toBeUndefined();
+    expect(getFieldDefByPath(schema, ['content', 'nope'])).toBeUndefined();
+    expect(getFieldDefByPath(schema, ['nope'])).toBeUndefined();
+  });
+});
+
+describe('central field-access API (getFieldValue / setFieldValue / getFieldDef)', () => {
+  // The ONE API text/link/media inline editing all route through, so a nested
+  // object field like content/image works uniformly (was flat block[field]).
+  test('getFieldValue reads a `/`-path (flat and nested)', () => {
+    const block = { value: [{ text: 'x' }], content: { image: '/img.png' } };
+    expect(getFieldValue(block, 'value')).toEqual([{ text: 'x' }]);
+    expect(getFieldValue(block, 'content/image')).toBe('/img.png');
+    expect(getFieldValue(block, 'content/nope')).toBeUndefined();
+  });
+
+  test('setFieldValue writes a `/`-path immutably (input untouched, siblings kept)', () => {
+    const block = { '@type': 't', content: { image: 'old', keep: 1 } };
+    const out = setFieldValue(block, 'content/image', 'new');
+    expect(out.content.image).toBe('new');
+    expect(out.content.keep).toBe(1); // sibling field preserved
+    expect(out['@type']).toBe('t'); // top-level field preserved
+    expect(block.content.image).toBe('old'); // input NOT mutated
+    expect(out.content).not.toBe(block.content); // object wrapper cloned
+  });
+
+  test('setFieldValue on a flat field behaves like a normal set', () => {
+    const block = { href: 'a', title: 'T' };
+    const out = setFieldValue(block, 'href', 'b');
+    expect(out).toEqual({ href: 'b', title: 'T' });
+    expect(block.href).toBe('a');
+  });
+
+  test('getFieldDef resolves a `/`-path through object wrappers only', () => {
+    const schema = {
+      properties: {
+        href: { widget: 'object_browser' },
+        content: { widget: 'object', schema: { properties: { image: { widget: 'image' } } } },
+      },
+    };
+    expect(getFieldDef(schema, 'href').widget).toBe('object_browser');
+    expect(getFieldDef(schema, 'content/image').widget).toBe('image');
+    expect(getFieldDef(schema, 'content/nope')).toBeUndefined();
+  });
+});
+
+describe('getFieldDef across a variety of schema shapes', () => {
+  // Deep object nesting, mixed object/region, typed object_list, malformed —
+  // this resolver is load-bearing for text/link/media/validation, so cover the
+  // shapes it must handle (and refuse).
+  const leaf = (widget) => ({ widget });
+  const obj = (properties) => ({ widget: 'object', schema: { properties } });
+  const schema = {
+    properties: {
+      title: leaf('slate'),
+      a: obj({
+        b: obj({
+          c: leaf('image'), // 3-level deep object nesting: a/b/c
+          title: leaf('text'), // same field name as the top-level `title`
+        }),
+        rows: { widget: 'object_list', schema: { properties: { cell: leaf('slate') } } },
+        panels: {
+          widget: 'object_list',
+          typeField: 'type', // typed object_list
+          schema: { properties: {} },
+        },
+        body: { widget: 'blocks_layout' },
+      }),
+      broken: { widget: 'object' }, // object wrapper WITHOUT schema.properties
+    },
+  };
+
+  test('top-level leaf', () => {
+    expect(getFieldDef(schema, 'title').widget).toBe('slate');
+  });
+
+  test('deep 3-level object nesting (a/b/c)', () => {
+    expect(getFieldDef(schema, 'a/b/c').widget).toBe('image');
+  });
+
+  test('same field name at different depths resolves per path', () => {
+    expect(getFieldDef(schema, 'title').widget).toBe('slate'); // top
+    expect(getFieldDef(schema, 'a/b/title').widget).toBe('text'); // nested
+  });
+
+  test('a region (object_list, incl. typed; blocks_layout) is reachable as a leaf', () => {
+    expect(getFieldDef(schema, 'a/rows').widget).toBe('object_list');
+    expect(getFieldDef(schema, 'a/panels').widget).toBe('object_list');
+    expect(getFieldDef(schema, 'a/body').widget).toBe('blocks_layout');
+  });
+
+  test('cannot descend past a region — object_list item / typed / blocks_layout', () => {
+    expect(getFieldDef(schema, 'a/rows/cell')).toBeUndefined();
+    expect(getFieldDef(schema, 'a/panels/anything')).toBeUndefined();
+    expect(getFieldDef(schema, 'a/body/anything')).toBeUndefined();
+  });
+
+  test('malformed / empty schemas never throw, return undefined', () => {
+    expect(getFieldDef(schema, 'broken/x')).toBeUndefined(); // object with no schema.properties
+    expect(getFieldDef(schema, 'a/missing/c')).toBeUndefined();
+    expect(getFieldDef({ properties: {} }, 'a')).toBeUndefined();
+    expect(getFieldDef(undefined, 'a')).toBeUndefined();
+    expect(getFieldDef(schema, '')).toBeUndefined();
+  });
+
+  test('the matching data path round-trips through getFieldValue/setFieldValue', () => {
+    const data = { a: { b: { c: 'old' } } };
+    expect(getFieldValue(data, 'a/b/c')).toBe('old');
+    const out = setFieldValue(data, 'a/b/c', 'new');
+    expect(out.a.b.c).toBe('new');
+    expect(data.a.b.c).toBe('old'); // immutable
+  });
+});
+
+describe('resolveFieldPath — the block-scope half of the grammar', () => {
+  // pathMap: child → col → PAGE
+  const pathMap = {
+    child: { parentId: 'col' },
+    col: { parentId: '_page' },
+  };
+
+  test('bare path stays on the current block', () => {
+    expect(resolveFieldPath('value', 'child', pathMap)).toEqual({ blockId: 'child', fieldName: 'value' });
+  });
+
+  test('object-descent remainder is preserved untouched', () => {
+    expect(resolveFieldPath('content/headline', 'child', pathMap)).toEqual({
+      blockId: 'child',
+      fieldName: 'content/headline',
+    });
+  });
+
+  test('leading / is page/root (remainder kept for further descent)', () => {
+    expect(resolveFieldPath('/title', 'child', pathMap)).toEqual({ blockId: '_page', fieldName: 'title' });
+    expect(resolveFieldPath('/a/b', 'child', pathMap)).toEqual({ blockId: '_page', fieldName: 'a/b' });
+  });
+
+  test('.. goes up one BLOCK per ../ (not an object level)', () => {
+    expect(resolveFieldPath('../x', 'child', pathMap)).toEqual({ blockId: 'col', fieldName: 'x' });
+    expect(resolveFieldPath('../../x', 'child', pathMap)).toEqual({ blockId: '_page', fieldName: 'x' });
+  });
+
+  test('.. composes with object descent on the resolved block', () => {
+    expect(resolveFieldPath('../content/headline', 'child', pathMap)).toEqual({
+      blockId: 'col',
+      fieldName: 'content/headline',
+    });
+  });
+
+  test('.. up to the page, then stops (exactly-to-root collapses cleanly)', () => {
+    // child (depth 2: child→col→page): two `..` reach the page and consume cleanly.
+    expect(resolveFieldPath('../../x', 'child', pathMap)).toEqual({ blockId: '_page', fieldName: 'x' });
+  });
+
+  test('EXCESS .. beyond the root is left as a remnant (malformed path, degrades safely)', () => {
+    // A third `..` can't go above the page; the surplus stays in fieldName (which
+    // then simply won't resolve to a field). Authors shouldn't over-`..`.
+    expect(resolveFieldPath('../../../x', 'child', pathMap)).toEqual({ blockId: '_page', fieldName: '../x' });
+  });
+
+  test('no block context → page-level', () => {
+    expect(resolveFieldPath('title', null, pathMap)).toEqual({ blockId: '_page', fieldName: 'title' });
+    expect(resolveFieldPath('title', '_page', pathMap)).toEqual({ blockId: '_page', fieldName: 'title' });
+  });
+
+  test('full grammar end-to-end: block scope THEN object descent to a fieldDef', () => {
+    const colSchema = {
+      properties: { content: { widget: 'object', schema: { properties: { headline: { widget: 'slate' } } } } },
+    };
+    // "../content/headline" from `child` → block `col`, field path "content/headline"
+    const { blockId, fieldName } = resolveFieldPath('../content/headline', 'child', pathMap);
+    expect(blockId).toBe('col');
+    expect(getFieldDef(colSchema, fieldName).widget).toBe('slate');
+  });
+});

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -17,6 +17,8 @@ import {
   getBlockType,
   isBlockReadonly,
   isBlockPositionLocked,
+  getFieldValue,
+  setFieldValue,
 } from '@volto-hydra/helpers';
 import Api from '@plone/volto/helpers/Api/Api';
 
@@ -70,7 +72,7 @@ function countContainerItems(formData, blockPathMap, containerConfig) {
     getBlockById(formData, blockPathMap, containerConfig.parentId) || formData;
   if (containerConfig.isObjectList) {
     let arr = parent;
-    for (const key of containerConfig.dataPath || [containerConfig.region]) {
+    for (const key of [...(containerConfig.regionPath || []), containerConfig.region]) {
       arr = arr?.[key];
     }
     return Array.isArray(arr) ? arr.length : 0;
@@ -115,19 +117,37 @@ function splitMultiNodeSlateBlocks(formData, blockPathMap, blocksConfig, uuidGen
     const schema = getResolvedSchema(pathInfo, blockPathMap);
     if (!schema?.properties) continue;
 
-    for (const [fieldName, fieldDef] of Object.entries(schema.properties)) {
-      if (!isSlateFieldType(getFieldTypeString(fieldDef))) continue;
-      const value = block[fieldName];
+    // Slate field PATHS, descending widget:'object' so a nested slate field
+    // (content/headline) is enforced too — not just top-level fields.
+    const slateFieldPaths = [];
+    const collectSlate = (props, prefix) => {
+      for (const [fn, fd] of Object.entries(props)) {
+        if (fd.widget === 'object' && fd.schema?.properties) {
+          collectSlate(fd.schema.properties, `${prefix}${fn}/`);
+          continue;
+        }
+        if (isSlateFieldType(getFieldTypeString(fd))) {
+          slateFieldPaths.push(`${prefix}${fn}`);
+        }
+      }
+    };
+    collectSlate(schema.properties, '');
+
+    for (const fieldName of slateFieldPaths) {
+      const value = getFieldValue(block, fieldName);
       if (!Array.isArray(value) || value.length <= 1) continue;
 
       const restNodes = value.slice(1);
 
-      // Can this multi-node value be split into sibling slate blocks?
-      const containerConfig = blockType === 'slate'
+      // Can this multi-node value be split into sibling slate blocks? Only a
+      // TOP-LEVEL field of a slate block can (a nested object field has no
+      // region to add siblings to — it flattens instead).
+      const containerConfig = blockType === 'slate' && !fieldName.includes('/')
         ? getContainerFieldConfig(blockId, blockPathMap, result, blocksConfig)
         : null;
       const splittable =
         blockType === 'slate' &&
+        !fieldName.includes('/') &&
         !!containerConfig &&
         containerConfig.addMode !== 'table' &&
         (containerConfig.allowedBlocks == null ||
@@ -147,20 +167,19 @@ function splitMultiNodeSlateBlocks(formData, blockPathMap, blocksConfig, uuidGen
           ),
         };
         if (merged.children.length === 0) merged.children = [{ text: '' }];
-        result = updateBlockById(result, blockPathMap, blockId, {
-          ...block,
-          [fieldName]: [merged],
-        });
+        result = updateBlockById(result, blockPathMap, blockId,
+          setFieldValue(block, fieldName, [merged]),
+        );
         flattenedAny = true;
         continue;
       }
 
       // Split: keep the first node, each remaining node becomes a new
       // sibling slate block. Chain inserts so each goes after the previous.
-      result = updateBlockById(result, blockPathMap, blockId, {
-        ...block,
-        [fieldName]: [value[0]],
-      });
+      // (fieldName here is a top-level slate-block field, never nested.)
+      result = updateBlockById(result, blockPathMap, blockId,
+        setFieldValue(block, fieldName, [value[0]]),
+      );
       let afterBlockId = blockId;
       for (let i = 0; i < restNodes.length; i++) {
         const newBlockId = uuidGenerator();
@@ -346,50 +365,46 @@ const extractBlockFieldTypes = (intl, contentTypeSchema = null) => {
       if (!blockFieldTypes[blockType]) {
         blockFieldTypes[blockType] = {};
       }
-      Object.keys(schema.properties).forEach((fieldName) => {
-        const field = schema.properties[fieldName];
-        blockFieldTypes[blockType][fieldName] = getFieldTypeString(field);
+      // Walk a schema's properties, recording each field's type under `typeKey`
+      // and registering a virtual block type for every object_list field
+      // (`typeKey:fieldName`) so getBlockTypeSchema / getAllContainerFields can
+      // resolve object_list items (e.g. table rows/cells) by their virtual type.
+      //
+      // widget:'object' wrappers: the VIRTUAL TYPE key stays transparent (a
+      // container nested in an object, e.g. `rows` inside the `table` object,
+      // still registers as `slateTable:rows` — the object name never enters the
+      // key, matching buildBlockPathMap's processItem). But a field's TYPE is
+      // recorded under its `/`-path storage key (`content/headline`), so the map
+      // matches how object sub-fields are addressed for inline editing (#245).
+      // Arbitrary depth, both nesting kinds.
+      const registerFieldTypes = (typeKey, properties, fieldPrefix = '') => {
+        if (!blockFieldTypes[typeKey]) blockFieldTypes[typeKey] = {};
+        Object.keys(properties).forEach((fieldName) => {
+          const field = properties[fieldName];
 
-        // Handle object_list widgets (e.g., slides in slider block)
-        if (field.widget === 'object_list' && field.schema?.properties) {
-          // object_list widget: extract field types from itemSchema
-          // Store under virtual type key: blockType:fieldName
-          const itemTypeKey = `${blockType}:${fieldName}`;
-          blockFieldTypes[itemTypeKey] = {};
-
-          // Also register virtual type in blocksConfig so getAllContainerFields works
-          if (!config.blocks.blocksConfig[itemTypeKey]) {
-            config.blocks.blocksConfig[itemTypeKey] = {
-              blockSchema: field.schema,
-              disableCustomSidebarEditForm: true, // Virtual types use schema form in sidebar
-            };
+          // Object wrapper — descend with a `/`-path prefix, same typeKey.
+          if (field.widget === 'object' && field.schema?.properties) {
+            registerFieldTypes(typeKey, field.schema.properties, `${fieldPrefix}${fieldName}/`);
+            return;
           }
 
-          Object.keys(field.schema.properties).forEach((itemFieldName) => {
-            const itemField = field.schema.properties[itemFieldName];
-            blockFieldTypes[itemTypeKey][itemFieldName] = getFieldTypeString(itemField);
+          blockFieldTypes[typeKey][`${fieldPrefix}${fieldName}`] = getFieldTypeString(field);
 
-            // Handle nested object_list (e.g., rows containing cells)
-            if (itemField.widget === 'object_list' && itemField.schema?.properties) {
-              const nestedItemTypeKey = `${itemTypeKey}:${itemFieldName}`;
-              blockFieldTypes[nestedItemTypeKey] = {};
-
-              // Register nested virtual type in blocksConfig
-              if (!config.blocks.blocksConfig[nestedItemTypeKey]) {
-                config.blocks.blocksConfig[nestedItemTypeKey] = {
-                  blockSchema: itemField.schema,
-                  disableCustomSidebarEditForm: true,
-                };
-              }
-
-              Object.keys(itemField.schema.properties).forEach((nestedFieldName) => {
-                const nestedField = itemField.schema.properties[nestedFieldName];
-                blockFieldTypes[nestedItemTypeKey][nestedFieldName] = getFieldTypeString(nestedField);
-              });
+          if (field.widget === 'object_list' && field.schema?.properties) {
+            // Virtual type key is object-transparent (no prefix).
+            const itemTypeKey = `${typeKey}:${fieldName}`;
+            if (!config.blocks.blocksConfig[itemTypeKey]) {
+              config.blocks.blocksConfig[itemTypeKey] = {
+                blockSchema: field.schema,
+                disableCustomSidebarEditForm: true, // Virtual types use schema form in sidebar
+              };
             }
-          });
-        }
-      });
+            // Item fields are addressed relative to the item — reset the prefix.
+            registerFieldTypes(itemTypeKey, field.schema.properties);
+          }
+        });
+      };
+      registerFieldTypes(blockType, schema.properties);
 
       // Debug: Log what was added for hero
       if (blockType === 'hero') {
@@ -1640,19 +1655,15 @@ const Iframe = (props) => {
         let dataPath;
         if (action === 'inside') {
           tableBlock = getBlockById(formData, blockPathMap, blockId);
-          dataPath = fieldDef?.dataPath || [fieldName];
+          dataPath = [...(containerConfig?.regionPath || []), fieldName];
         } else {
-          // For before/after on a row, get the parent table
+          // For before/after on a row, get the parent table. The row's pathInfo
+          // carries the object prefix (regionPath, e.g. [table]) to the rows
+          // array — array is at [...regionPath, region].
           const rowPathInfo = blockPathMap?.[blockId];
           const parentId = rowPathInfo?.parentId;
           tableBlock = getBlockById(formData, blockPathMap, parentId);
-          // Get dataPath from the row's container field definition
-          const tableType = blockPathMap[parentId]?.blockType;
-          const tableBlockSchema = typeof mergedBlocksConfig?.[tableType]?.blockSchema === 'function'
-            ? mergedBlocksConfig[tableType].blockSchema({ formData, intl: { formatMessage: (m) => m.defaultMessage } })
-            : mergedBlocksConfig?.[tableType]?.blockSchema;
-          const rowsFieldDef = tableBlockSchema?.properties?.[rowPathInfo.region];
-          dataPath = rowsFieldDef?.dataPath || [rowPathInfo.region];
+          dataPath = [...(rowPathInfo?.regionPath || []), rowPathInfo?.region];
         }
         let rowsData = tableBlock;
         for (const key of dataPath) {
@@ -4792,7 +4803,7 @@ const Iframe = (props) => {
                       // Find the previous row and its corresponding cell
                       const newBlockPathMap = buildBlockPathMap(newFormData, blocksConfig, intl);
                       const tableBlock = getBlockByPath(newFormData, newBlockPathMap[rowPathInfo.parentId]?.path);
-                      const dataPath = containerConfig.dataPath || ['rows'];
+                      const dataPath = [...(containerConfig.regionPath || []), containerConfig.region || 'rows'];
                       let rows = tableBlock;
                       for (const key of dataPath) {
                         rows = rows?.[key];
@@ -4871,10 +4882,13 @@ const Iframe = (props) => {
                 const block = getBlockById(properties, iframeSyncState.blockPathMap, selectedBlock);
                 if (!block) return;
 
-                // For blocks, store url and image_scales separately (like Image block does)
-                const updatedBlock = metadata?.image_scales
-                  ? { ...block, [fieldName]: url, image_field: metadata.image_field, image_scales: metadata.image_scales }
-                  : { ...block, [fieldName]: url };
+                // For blocks, store url and image_scales separately (like Image block does).
+                // setFieldValue writes the url at its (possibly object-nested) /-path;
+                // image_field/image_scales stay at the block top level (Image-block shape).
+                let updatedBlock = setFieldValue(block, fieldName, url);
+                if (metadata?.image_scales) {
+                  updatedBlock = { ...updatedBlock, image_field: metadata.image_field, image_scales: metadata.image_scales };
+                }
                 // Use updateBlockById to handle both top-level and container blocks
                 updatedProperties = updateBlockById(properties, iframeSyncState.blockPathMap, selectedBlock, updatedBlock);
               }
@@ -5319,7 +5333,7 @@ const Iframe = (props) => {
                 if (cellIndex != null && rowIndex > 0) {
                   const newBlockPathMap = buildBlockPathMap(newFormData, blocksConfig, intl);
                   const tableBlock = getBlockByPath(newFormData, newBlockPathMap[rowPathInfo.parentId]?.path);
-                  const dataPath = containerConfig.dataPath || ['rows'];
+                  const dataPath = [...(containerConfig.regionPath || []), containerConfig.region || 'rows'];
                   let rows = tableBlock;
                   for (const key of dataPath) {
                     rows = rows?.[key];

--- a/packages/volto-hydra/src/components/Toolbar/SyncedSlateToolbar.jsx
+++ b/packages/volto-hydra/src/components/Toolbar/SyncedSlateToolbar.jsx
@@ -10,7 +10,7 @@ import slateTransforms, { withEmptyInlineRemoval } from '../../utils/slateTransf
 import { syncCreateSlateBlock } from '@plone/volto-slate/utils/volto-blocks';
 import { getBlockById, updateBlockById } from '../../utils/blockPath';
 import { calculateDragHandlePosition, PAGE_BLOCK_UID } from '@volto-hydra/hydra-js';
-import { isSlateFieldType, isBlockPositionLocked, isBlockReadonly } from '@volto-hydra/helpers';
+import { isSlateFieldType, isBlockPositionLocked, isBlockReadonly, getFieldValue, getFieldDef } from '@volto-hydra/helpers';
 import { useDispatch, useSelector } from 'react-redux';
 import FormatDropdown from './FormatDropdown';
 import DropdownMenu from './DropdownMenu';
@@ -611,7 +611,7 @@ const SyncedSlateToolbar = ({
     if (!selectedBlock || !block) return;
 
     const fieldName = blockUI?.focusedFieldName || 'value';
-    const fieldValue = block[fieldName];
+    const fieldValue = getFieldValue(block, fieldName);
 
     // Only sync for slate fields
     const blockType = block?.['@type'];
@@ -1017,7 +1017,7 @@ const SyncedSlateToolbar = ({
       // Only call onChange if value actually changed (like Volto line 108)
       const block = getBlock(selectedBlock);
       const fieldName = blockUI?.focusedFieldName || 'value';
-      const currentFieldValue = block?.[fieldName];
+      const currentFieldValue = getFieldValue(block, fieldName);
       const currentText = currentFieldValue?.[0]?.children?.[0]?.text?.substring(0, 40);
 
       if (isEqual(newValue, currentFieldValue)) {
@@ -1165,7 +1165,7 @@ const SyncedSlateToolbar = ({
   }
 
   const fieldName = blockUI?.focusedFieldName || 'value';
-  const fieldValue = block[fieldName];
+  const fieldValue = getFieldValue(block, fieldName);
 
   // Determine if we should show format buttons based on field type
   // Also hide for readonly blocks (e.g., fixed template blocks, or blocks outside template in edit mode)
@@ -1703,7 +1703,7 @@ const SyncedSlateToolbar = ({
 
     {/* Field Link Editor Popup - fixed position at toolbar */}
     {fieldLinkEditorOpen && fieldLinkEditorField && (() => {
-      const fieldDef = blockPathMap?.[selectedBlock]?.schema?.properties?.[fieldLinkEditorField];
+      const fieldDef = getFieldDef(blockPathMap?.[selectedBlock]?.schema, fieldLinkEditorField);
       const isObjectBrowserLink = fieldDef?.widget === 'object_browser' && fieldDef?.mode === 'link';
       return (
         <div
@@ -1717,7 +1717,7 @@ const SyncedSlateToolbar = ({
           }}
         >
           <AddLinkForm
-            data={{ url: getBlock(selectedBlock)?.[fieldLinkEditorField] || '' }}
+            data={{ url: getFieldValue(getBlock(selectedBlock), fieldLinkEditorField) || '' }}
             theme={{}}
             onChangeValue={(url) => {
               if (onFieldLinkChange) {
@@ -1759,7 +1759,7 @@ const SyncedSlateToolbar = ({
     {/* Media Field Overlays - show when block is selected, for each media field */}
     {/* Skip for readonly blocks - they shouldn't show media editing UI */}
     {blockUI?.mediaFields && !isBlockReadonly(getBlock(selectedBlock), templateEditMode) && Object.entries(blockUI.mediaFields).map(([fieldName, fieldData]) => {
-      const mediaValue = getBlock(selectedBlock)?.[fieldName];
+      const mediaValue = getFieldValue(getBlock(selectedBlock), fieldName);
       const hasMediaValue = mediaValue && (
         (Array.isArray(mediaValue) && mediaValue.length > 0) ||
         (typeof mediaValue === 'string' && mediaValue !== '')

--- a/packages/volto-hydra/src/index.js
+++ b/packages/volto-hydra/src/index.js
@@ -342,24 +342,34 @@ const applyConfig = (config) => {
         ...baseSchema,
         properties: {
           ...baseSchema.properties,
-          // Rows for container traversal - uses dataPath to avoid nesting inside widget: 'object'
-          rows: {
-            widget: 'object_list',
-            idField: 'key',
-            dataPath: ['table', 'rows'], // Where to find data in block
+          // #245: rows nest inside the `table` object (block.table.rows) as a
+          // first-class widget:'object' — no dataPath. The pathMap recurses into
+          // the object and resolves the object_list relative to it.
+          table: {
+            widget: 'object',
             schema: {
-              fieldsets: [{ id: 'default', title: 'Default', fields: [] }],
+              fieldsets: [{ id: 'default', title: 'Table', fields: ['rows'] }],
               properties: {
-                cells: {
+                rows: {
                   widget: 'object_list',
                   idField: 'key',
+                  addMode: 'table',
                   schema: {
-                    fieldsets: [{ id: 'default', title: 'Default', fields: ['value'] }],
+                    fieldsets: [{ id: 'default', title: 'Default', fields: [] }],
                     properties: {
-                      value: {
-                        title: 'Content',
-                        widget: 'slate',
-                        default: [{ type: 'p', children: [{ text: '' }] }],
+                      cells: {
+                        widget: 'object_list',
+                        idField: 'key',
+                        schema: {
+                          fieldsets: [{ id: 'default', title: 'Default', fields: ['value'] }],
+                          properties: {
+                            value: {
+                              title: 'Content',
+                              widget: 'slate',
+                              default: [{ type: 'p', children: [{ text: '' }] }],
+                            },
+                          },
+                        },
                       },
                     },
                   },

--- a/packages/volto-hydra/src/utils/blockPath.js
+++ b/packages/volto-hydra/src/utils/blockPath.js
@@ -15,6 +15,8 @@ import {
   getBlockType,
   setBlockType,
   clearBlockType,
+  getAtPath,
+  ensureMutablePath,
 } from '@volto-hydra/helpers';
 import {
   buildBlockPathMap as _buildBlockPathMap,
@@ -188,17 +190,31 @@ function reorderContainerItems(items, newOrder, containerConfig) {
  * @param {Object} [blocksObj] - For blocks containers, the blocks object to set
  * @returns {Object} Updated parent block
  */
+/**
+ * Navigate to the object that actually holds a blocks_layout region's shared
+ * `blocks` dict + `blocks_layout`. Usually the parent block itself; for a
+ * blocks_layout nested inside a widget:'object' wrapper (#245) it's the object
+ * at `regionPath` (e.g. parentBlock.table). Read-only — returns the live node.
+ */
+function getRegionContainer(parentBlock, regionPath) {
+  return getAtPath(parentBlock, regionPath) || parentBlock;
+}
+
 function setContainerItems(
   parentBlock,
   containerConfig,
   items,
   blocksObj = null,
 ) {
-  const { isObjectList, idField = '@id' } = containerConfig;
+  const { isObjectList, idField = '@id', regionPath } = containerConfig;
   const updatedParent = { ...parentBlock };
   if (!isObjectList) {
-    // Full-dict replace; setChildBlockEntries leaves it alone (block omitted below).
-    updatedParent.blocks = blocksObj || parentBlock.blocks;
+    // Full-dict replace at the region's blocks dict, which may live under a
+    // widget:'object' wrapper (regionPath, e.g. [table]). Clone each level;
+    // setChildBlockEntries below re-navigates the same path and spreads this
+    // clone, so the dict written here survives alongside the blocks_layout.
+    const container = ensureMutablePath(updatedParent, regionPath);
+    container.blocks = blocksObj || container.blocks;
   }
   const entries = isObjectList
     ? items.map((block) => ({ id: block[idField], block }))
@@ -421,6 +437,9 @@ export function getContainerFieldConfig(
   // The container field (region) this block lives in — same concept for blocks
   // and object_list. It is the schema property name.
   const region = pathInfo.region || 'items';
+  // Object prefix to the region's blocks dict when the blocks_layout is nested
+  // inside a widget:'object' wrapper (#245); [] for the ordinary block-root case.
+  const regionPath = pathInfo.regionPath || [];
 
   // If parent is a virtual template instance, use the instance's parent for storage operations
   // Template blocks are stored flat, so the actual container is the instance's parent
@@ -441,11 +460,11 @@ export function getContainerFieldConfig(
       defaultBlockType: pathInfo.blockType,
       maxLength: pathInfo.maxSiblings,
       isObjectList: true,
-      itemSchema: pathInfo.typeField ? null : fieldDef?.schema, // null for typed items
+      itemSchema: pathInfo.typeField ? null : pathInfo.itemSchema, // stored on pathInfo (nesting-safe); null for typed items
       itemIndex: pathInfo.path[pathInfo.path.length - 1], // Last element is index
       idField: pathInfo.idField,
       typeField: pathInfo.typeField || null, // Attribute name for item type (typed object_list)
-      dataPath: pathInfo.dataPath || fieldDef?.dataPath || null, // Path to actual data location
+      regionPath: pathInfo.regionPath || [], // object prefix; array at [...regionPath, region]
       addMode: pathInfo.addMode || null, // Table mode for this container
       parentAddMode: pathInfo.parentAddMode || null, // Inherited from parent
     };
@@ -468,13 +487,21 @@ export function getContainerFieldConfig(
   const parentType = blockPathMap[parentId]?.blockType;
   const parentConfig = blocksConfig?.[parentType];
 
-  // Check schema-defined blocks field (looked up by region = schema field name)
+  // Check schema-defined blocks field (looked up by region = schema field name).
+  // For a blocks_layout nested in a widget:'object', walk the schema through the
+  // object wrappers (regionPath) before the region lookup, and carry regionPath
+  // so the ops navigate to the object's own blocks dict.
   if (schema?.properties) {
-    const regionFieldDef = schema.properties[region];
+    let regionSchema = schema;
+    for (const key of regionPath) {
+      regionSchema = regionSchema?.properties?.[key]?.schema;
+    }
+    const regionFieldDef = regionSchema?.properties?.[region];
     if (regionFieldDef?.widget === 'blocks_layout') {
       return {
         region,
         parentId,
+        ...(regionPath.length > 0 && { regionPath }),
         ...resolveRegionConstraints(
           regionFieldDef,
           parentConfig,
@@ -631,18 +658,15 @@ export function getAllContainerFields(
   const pageDefaultBlockType = config.settings.defaultBlockType || null;
 
   // Helper to get current count for a container field
-  const getFieldCount = (region, isObjectList = false, dataPath = null) => {
+  const getFieldCount = (region, isObjectList = false, regionPath = []) => {
     if (isObjectList) {
-      // object_list: navigate via dataPath or the region (field name)
-      const path = dataPath || [region];
-      let data = block;
-      for (const key of path) {
-        data = data?.[key];
-      }
+      // object_list: the array lives at [...regionPath, region]
+      const data = getAtPath(block, [...regionPath, region]);
       return Array.isArray(data) ? data.length : 0;
     }
     // blocks container: the region is a key in the shared blocks_layout dict
-    return block.blocks_layout?.[region]?.length || 0;
+    // on the node at regionPath (block root when empty).
+    return getAtPath(block, regionPath)?.blocks_layout?.[region]?.length || 0;
   };
 
   const containerFields = [];
@@ -652,25 +676,61 @@ export function getAllContainerFields(
   // carries allowedBlocks/defaultBlockType), the default region is a blocks_layout named 'items'.
   // Synthesize that single field so it flows through the SAME loop below — the implicit case is
   // a default region, not a different code path.
-  let fieldEntries = Object.entries(schema?.properties || {}).filter(
-    ([, fd]) => fd.widget === 'blocks_layout' || fd.widget === 'object_list',
-  );
+  // Collect container fields, descending transparently through widget:'object'
+  // wrappers (the same way buildBlockPathMap's processItem does). A container
+  // nested inside an object — e.g. `rows` inside a `table` object — is block-
+  // relative at [...objectPath, fieldName], exactly the dataPath the pathMap
+  // stores, so the ops navigate it without any config-level dataPath.
+  // Title-case a schema field name for display (the object wrapper's own label
+  // when it declares no title): 'table' → 'Table'.
+  const titleize = (name) =>
+    name ? name.charAt(0).toUpperCase() + name.slice(1) : name;
+  const collectContainerFields = (properties, objectPath, titlePath) => {
+    const out = [];
+    for (const [fieldName, fd] of Object.entries(properties || {})) {
+      if (fd.widget === 'object' && fd.schema?.properties) {
+        out.push(
+          ...collectContainerFields(
+            fd.schema.properties,
+            [...objectPath, fieldName],
+            [...titlePath, fd.title || titleize(fieldName)],
+          ),
+        );
+      } else if (fd.widget === 'blocks_layout' || fd.widget === 'object_list') {
+        out.push([fieldName, fd, objectPath, titlePath]);
+      }
+    }
+    return out;
+  };
+  let fieldEntries = collectContainerFields(schema?.properties, [], []);
   if (fieldEntries.length === 0) {
     const isImplicitContainer =
       (block.blocks && block.blocks_layout?.items) ||
       blockConfig?.allowedBlocks ||
       blockConfig?.defaultBlockType;
     if (isImplicitContainer)
-      fieldEntries = [['items', { widget: 'blocks_layout' }]];
+      fieldEntries = [['items', { widget: 'blocks_layout' }, [], []]];
   }
 
-  for (const [fieldName, fieldDef] of fieldEntries) {
+  // Prefix a nested container's display title with its object path so the
+  // sidebar shows the nesting (e.g. "Table / Rows", "Content / Body"). Top-level
+  // fields (empty titlePath) are shown as-is.
+  const prefixTitle = (baseTitle, titlePath) =>
+    titlePath.length > 0 ? [...titlePath, baseTitle].join(' / ') : baseTitle;
+
+  for (const [fieldName, fieldDef, objectPath, titlePath] of fieldEntries) {
     if (fieldDef.widget === 'blocks_layout') {
       // A blocks field. Its name IS the region key inside the shared
       // blocks_layout dict; the data container field is always 'blocks_layout'.
       // Each blocks field has its own allowedBlocks / maxLength.
       const region = fieldName;
-      const layoutList = block.blocks_layout?.[region];
+      // The blocks dict + blocks_layout live under the object wrapper when this
+      // region is nested (objectPath, e.g. [table]); [] for the block-root case.
+      const regionContainer = objectPath.reduce(
+        (node, key) => node?.[key],
+        block,
+      );
+      const layoutList = regionContainer?.blocks_layout?.[region];
       const currentCount = Array.isArray(layoutList) ? layoutList.length : 0;
       // Same field → block → page precedence as getContainerFieldConfig (a container that
       // restricts nothing inherits the page's allowed list + default block type).
@@ -681,7 +741,11 @@ export function getAllContainerFields(
       const maxLengthOk = !rc.maxLength || currentCount < rc.maxLength;
       containerFields.push({
         region,
-        title: fieldDef.title || (region === 'items' ? 'Blocks' : region),
+        ...(objectPath.length > 0 && { regionPath: objectPath }),
+        title: prefixTitle(
+          fieldDef.title || (region === 'items' ? 'Blocks' : region),
+          titlePath,
+        ),
         allowedBlocks: rc.allowedBlocks,
         allowedTemplates: fieldDef.allowedTemplates || null,
         allowedLayouts: fieldDef.allowedLayouts || null,
@@ -697,13 +761,16 @@ export function getAllContainerFields(
       //   2. schema set (no allowedBlocks): single-schema items, virtual type blockType:fieldName
       const hasAllowedBlocks = !!fieldDef.allowedBlocks;
       const itemType = `${blockType}:${fieldName}`;
-      const dataPath = fieldDef.dataPath || null;
+      // Object prefix to the array (the `/`-path object hops): [] at the block
+      // root, [table] when nested in a `table` object. The array is at
+      // [...regionPath, fieldName].
       const maxLength = fieldDef.maxLength || null;
-      const currentCount = getFieldCount(fieldName, true, dataPath);
+      const currentCount = getFieldCount(fieldName, true, objectPath);
       const maxLengthOk = !maxLength || currentCount < maxLength;
       containerFields.push({
         region: fieldName,
-        title: fieldDef.title || fieldName,
+        ...(objectPath.length > 0 && { regionPath: objectPath }),
+        title: prefixTitle(fieldDef.title || fieldName, titlePath),
         allowedBlocks: hasAllowedBlocks ? fieldDef.allowedBlocks : [itemType],
         allowedTemplates: fieldDef.allowedTemplates || null,
         defaultBlockType:
@@ -715,7 +782,6 @@ export function getAllContainerFields(
         itemSchema: hasAllowedBlocks ? null : fieldDef.schema, // null for typed (schema from blocksConfig)
         idField: fieldDef.idField || '@id', // ID field name for items
         typeField: fieldDef.typeField || null, // Attribute name for item type (e.g., '@type')
-        dataPath,
       });
     }
   }
@@ -790,13 +856,21 @@ export function insertBlockInContainer(
     items.splice(insertIndex, 0, { [idField]: newBlockId, ...stamped });
     updatedParentBlock = setContainerItems(parentBlock, containerConfig, items);
   } else {
-    // Standard container: shared blocks dict + layout field
+    // Standard container: shared blocks dict + layout field. The dict may live
+    // under an object wrapper (regionPath) — read + rebuild it there.
+    const regionContainer = getRegionContainer(
+      parentBlock,
+      containerConfig.regionPath,
+    );
     const stamped = inheritTemplateMembership(
       newBlockData,
-      parentBlock.blocks?.[refBlockId] || parentBlock,
+      regionContainer.blocks?.[refBlockId] || parentBlock,
       { inheritFixed: !!parentBlock?.templateInstanceId },
     );
-    const newContainerBlocks = { ...parentBlock.blocks, [newBlockId]: stamped };
+    const newContainerBlocks = {
+      ...regionContainer.blocks,
+      [newBlockId]: stamped,
+    };
     const refIndex = items.indexOf(refBlockId);
     const insertIndex = getInsertIndex(items, refIndex);
     items.splice(insertIndex, 0, newBlockId);
@@ -1267,8 +1341,13 @@ export function deleteBlockFromContainer(
       filteredItems,
     );
   } else {
-    // Standard container: remove from shared blocks dict and layout
-    const { [blockId]: removed, ...remainingBlocks } = parentBlock.blocks;
+    // Standard container: remove from shared blocks dict and layout. The dict
+    // may live under an object wrapper (regionPath).
+    const regionContainer = getRegionContainer(
+      parentBlock,
+      containerConfig.regionPath,
+    );
+    const { [blockId]: removed, ...remainingBlocks } = regionContainer.blocks;
     const filteredItems = items.filter((id) => id !== blockId);
     updatedParentBlock = setContainerItems(
       parentBlock,
@@ -1503,7 +1582,7 @@ export function insertTableColumn(
   }
 
   // Get rows using dataPath
-  const dataPath = rowPathInfo.dataPath || ['rows'];
+  const dataPath = [...(rowPathInfo.regionPath || []), rowPathInfo.region || 'rows'];
   let rows = tableBlock;
   for (const key of dataPath) {
     rows = rows?.[key];
@@ -1607,7 +1686,7 @@ export function deleteTableColumn(formData, blockPathMap, cellId) {
   }
 
   // Get rows using dataPath
-  const dataPath = rowPathInfo.dataPath || ['rows'];
+  const dataPath = [...(rowPathInfo.regionPath || []), rowPathInfo.region || 'rows'];
   let rows = tableBlock;
   for (const key of dataPath) {
     rows = rows?.[key];
@@ -2300,21 +2379,18 @@ export function reorderBlocksInContainer(
     return formData;
   }
 
-  // Detect if this region is an object_list field (the region is the schema
-  // property name).
-  const schema = getResolvedSchema(
-    blockPathMap[effectiveParentId],
-    blockPathMap,
-  );
-  const fieldDef = schema?.properties?.[region];
-  const isObjectList = fieldDef?.widget === 'object_list';
-
-  // Build containerConfig from fieldDef for the funnel.
+  // Build containerConfig from a child's pathInfo, not the parent schema:
+  // an object_list nested inside a widget:'object' is not at
+  // schema.properties[region], and its object prefix (regionPath, e.g. [table])
+  // only lives on the child's pathInfo. Any child in the reordered set carries
+  // region/regionPath/idField for the whole container.
+  const sampleChild = blockPathMap[newOrder[0]];
+  const isObjectList = !!sampleChild?.isObjectListItem;
   const containerConfig = {
     region,
     isObjectList,
-    dataPath: fieldDef?.dataPath,
-    idField: fieldDef?.idField,
+    regionPath: sampleChild?.regionPath || [],
+    idField: sampleChild?.idField || '@id',
   };
 
   const items = getContainerItems(parentBlock, containerConfig);

--- a/packages/volto-hydra/src/utils/formDataValidation.js
+++ b/packages/volto-hydra/src/utils/formDataValidation.js
@@ -12,6 +12,7 @@ import {
   isSlateFieldType,
   getChildFields,
   getChildBlockEntries,
+  getFieldValue,
 } from '@volto-hydra/helpers';
 
 // Re-export for convenience
@@ -182,7 +183,7 @@ export function validateBlock(blockId, blockData, blockFieldTypes = {}) {
   const slateFields = getSlateFieldsForBlockType(blockType, blockFieldTypes);
 
   for (const fieldName of slateFields) {
-    const fieldValue = blockData[fieldName];
+    const fieldValue = getFieldValue(blockData, fieldName);
     if (fieldValue && Array.isArray(fieldValue)) {
       errors.push(...validateSlateValue(fieldValue, blockId, fieldName));
     }

--- a/packages/volto-hydra/src/utils/schemaValidation.mjs
+++ b/packages/volto-hydra/src/utils/schemaValidation.mjs
@@ -87,6 +87,22 @@ export function applySchemaDefaultsToBlock(blockData, schema) {
   const newData = { ...blockData };
 
   for (const [fieldName, fieldDef] of Object.entries(schema.properties)) {
+    // widget:'object' — recurse so the object's OWN fields (block.content.*)
+    // get their defaults/validation too. Descend objects only; a region
+    // (object_list/blocks_layout) is a container handled elsewhere and must NOT
+    // be walked here.
+    if (fieldDef.widget === 'object' && fieldDef.schema?.properties) {
+      const current = newData[fieldName];
+      if (current && typeof current === 'object' && !Array.isArray(current)) {
+        const nested = applySchemaDefaultsToBlock(current, fieldDef.schema);
+        if (nested !== current) {
+          newData[fieldName] = nested;
+          modified = true;
+        }
+      }
+      continue;
+    }
+
     const currentValue = blockData[fieldName];
 
     // First: validate current value - clear if invalid
@@ -100,6 +116,7 @@ export function applySchemaDefaultsToBlock(blockData, schema) {
 
   // Second pass: apply defaults to empty/null fields
   for (const [fieldName, fieldDef] of Object.entries(schema.properties)) {
+    if (fieldDef.widget === 'object') continue; // handled by recursion above
     if (fieldDef.default === undefined) continue;
 
     const currentValue = newData[fieldName];
@@ -137,6 +154,20 @@ export function applySchemaDefaultsToBlockWithContext(blockData, schema, context
   const newData = { ...blockData };
 
   for (const [fieldName, fieldDef] of Object.entries(schema.properties)) {
+    // widget:'object' — recurse (with context, for function defaults on nested
+    // fields). Descend objects only, never a region.
+    if (fieldDef.widget === 'object' && fieldDef.schema?.properties) {
+      const current = newData[fieldName];
+      if (current && typeof current === 'object' && !Array.isArray(current)) {
+        const nested = applySchemaDefaultsToBlockWithContext(current, fieldDef.schema, context);
+        if (nested !== current) {
+          newData[fieldName] = nested;
+          modified = true;
+        }
+      }
+      continue;
+    }
+
     const currentValue = blockData[fieldName];
     if (currentValue !== undefined && currentValue !== null) {
       if (!isValidValue(currentValue, fieldDef)) {
@@ -147,6 +178,7 @@ export function applySchemaDefaultsToBlockWithContext(blockData, schema, context
   }
 
   for (const [fieldName, fieldDef] of Object.entries(schema.properties)) {
+    if (fieldDef.widget === 'object') continue; // handled by recursion above
     if (fieldDef.default === undefined) continue;
 
     const currentValue = newData[fieldName];

--- a/packages/volto-hydra/src/utils/schemaValidation.test.js
+++ b/packages/volto-hydra/src/utils/schemaValidation.test.js
@@ -1,0 +1,74 @@
+import { describe, test, expect } from 'vitest';
+import {
+  applySchemaDefaultsToBlock,
+  applySchemaDefaultsToBlockWithContext,
+} from './schemaValidation.mjs';
+
+/**
+ * Schema defaults must reach fields nested inside a `widget:'object'` (#245) —
+ * a default declared on `content.inneralign` is applied just like a top-level
+ * field's. The walk descends objects only; it must NOT recurse into a region
+ * (object_list/blocks_layout), whose items are handled elsewhere.
+ */
+describe('applySchemaDefaultsToBlock — object-nested defaults', () => {
+  const schema = {
+    properties: {
+      align: { default: 'left' },
+      content: {
+        widget: 'object',
+        schema: {
+          properties: {
+            inneralign: { default: 'center' },
+            deep: { widget: 'object', schema: { properties: { size: { default: 'md' } } } },
+            // a region nested in the object — must be left untouched
+            rows: { widget: 'object_list', schema: { properties: { x: { default: 'NO' } } } },
+          },
+        },
+      },
+    },
+  };
+
+  test('applies a default to a field inside an object', () => {
+    const out = applySchemaDefaultsToBlock({ content: {} }, schema);
+    expect(out.content.inneralign).toBe('center');
+    expect(out.align).toBe('left'); // top-level still works
+  });
+
+  test('applies defaults at arbitrary object depth (content.deep.size)', () => {
+    const out = applySchemaDefaultsToBlock({ content: { deep: {} } }, schema);
+    expect(out.content.deep.size).toBe('md');
+  });
+
+  test('does NOT recurse into a region nested in the object', () => {
+    const out = applySchemaDefaultsToBlock(
+      { content: { rows: [{ '@id': 'r1' }] } },
+      schema,
+    );
+    // The region's items are containers — defaults must not be stamped into them.
+    expect(out.content.rows).toEqual([{ '@id': 'r1' }]);
+    expect(out.content.rows[0].x).toBeUndefined();
+  });
+
+  test('leaves an already-set nested value alone', () => {
+    const out = applySchemaDefaultsToBlock({ content: { inneralign: 'right' } }, schema);
+    expect(out.content.inneralign).toBe('right');
+  });
+
+  test('unchanged input is returned by identity (no spurious modification)', () => {
+    const block = { align: 'left', content: { inneralign: 'center' } };
+    expect(applySchemaDefaultsToBlock(block, schema)).toBe(block);
+  });
+
+  test('WithContext resolves a function default on a nested field', () => {
+    const ctxSchema = {
+      properties: {
+        content: {
+          widget: 'object',
+          schema: { properties: { id: { default: (ctx) => ctx.seed } } },
+        },
+      },
+    };
+    const out = applySchemaDefaultsToBlockWithContext({ content: {} }, ctxSchema, { seed: 'X1' });
+    expect(out.content.id).toBe('X1');
+  });
+});

--- a/proposals/unified-block-path.md
+++ b/proposals/unified-block-path.md
@@ -1,0 +1,116 @@
+# Unified block/field path grammar — Design Proposal
+
+> **Status: §5 steps 1–2 IMPLEMENTED; step 3 not.** `data-edit-text` uses the
+> `/` grammar (object hops descend `widget:'object'`), and the container funnel
+> addresses regions by `regionPath` (object prefix) + `region` — the internal
+> `dataPath`/`regionPath` split is gone (one representation). Region-by-**id** in
+> a path (`content/body/<id>`) and the physical `pathInfo.path` collapse (step 3)
+> are not done. The tables below still show the *old* split in the "Today" column
+> for contrast; the "Unified path" column is what now ships (minus region-by-id).
+
+## 1. Problem
+
+"Address a piece of content" is expressed **three different ways** today:
+
+- **Block scope** — `data-edit-text` strings: `field` (this block), `../field`
+  (parent block), `/field` (page root). Already a filesystem-style path.
+- **Field-within-object** — a `.`-dotted tail added for #245: `content.headline`
+  descends a `widget:'object'` wrapper to a field.
+- **Container region** — an internal **array** descriptor on each block's
+  `pathInfo`: `dataPath: ['table','rows']` (object_list array) and
+  `regionPath: ['content']` + `region: 'body'` (blocks_layout dict).
+
+Three grammars for the same idea ("go deeper into nested content"). The dotted
+tail and the array descriptors both walk objects; they just look different and
+can't address the same things. We want **one** path grammar.
+
+## 2. The grammar
+
+A path is a `/`-separated list of segments, resolved **left to right against the
+schema**, starting **at the current block** (the `data-block-uid` element that
+carries the `data-edit-text`, or the block a container op targets).
+
+```
+path        := ['/'] segment ('/' segment)*        // leading '/' = page root
+segment     := '..'                                // up one BLOCK (see §3)
+             | <name>                              // field name (in an object)
+             | <id>                                // child id (in a region)
+```
+
+Resolution — at each hop, look at the **current node's schema**:
+
+| current node          | next segment is… | descends to                          |
+|-----------------------|------------------|--------------------------------------|
+| block / `widget:'object'` | a **field name** | that field (its `schema.properties[name]`) |
+| region (`object_list`)    | a **child id**   | the item whose `idField` == id       |
+| region (`blocks_layout`)  | a **child id**   | the block with that id in the shared dict |
+| value (slate/string/…)    | — (terminal)     | nothing — a value has no sub-path    |
+
+The schema at the node — not the separator — decides whether a segment is a
+name or an id, so there is no ambiguity and no second separator. A region is
+never traversed by *name* (which item? there are many); an object is never
+traversed by *id* (it has named fields). A value is terminal.
+
+## 3. The `..` rule (agreed)
+
+`..` **always means "up to the parent BLOCK"** — never up an object or region
+level. Rationale:
+
+- It matches what `..` means **today** (`schemaInheritance` fieldRules,
+  `resolveFieldPath`), so **no migration** of existing `../field` references.
+- It keeps the axes asymmetric but simple: `/` descends *down* through objects
+  and regions; `..` only ever crosses *block* boundaries going up. Within-block
+  object nesting has **no "up"** — to reach a sibling field of `content/headline`
+  you re-address from the block root (`content/subtitle`), not `../subtitle`.
+
+So: **objects and regions are down-only (via `/`); the block hierarchy is the
+up axis (`..`) and the absolute root (`/`).**
+
+## 4. What this replaces
+
+| Today | Unified path |
+|-------|--------------|
+| `data-edit-text="value"` | `value` (unchanged) |
+| `data-edit-text="/title"` | `/title` (unchanged) |
+| `data-edit-text="../subtitle"` | `../subtitle` (unchanged) |
+| `data-edit-text="content.headline"` (#245 dotted) | `content/headline` |
+| container descriptor `dataPath:['table','rows']` | path `table/rows` |
+| container descriptor `regionPath:['content'], region:'body'` | path `content/body` |
+| a specific child block in a region | `content/body/<block-id>` |
+
+The array `dataPath`/`regionPath` descriptors stop being a separate thing: they
+are just the parsed segments of a `/`-path. The walk is already implemented —
+`getFieldDefByPath` (schema) and `getAtPath`/`ensureMutablePath` (data) in
+`@volto-hydra/helpers` — they'd take the parsed path instead of a pre-baked
+array, plus a region hop that resolves a child by id.
+
+## 5. Migration
+
+1. **`data-edit-text` grammar** — ✅ **DONE.** Object-field descent switched from
+   `.` to `/`. Renderers emit `content/headline`; `getFieldType`/placeholder/
+   nodeId/writeback all split the post-block-scope remainder on `/` via
+   `getFieldDefByPath`/`getAtPath` (descend `widget:'object'` only). `..`/`/`
+   (block scope) unchanged.
+2. **Funnel region-addressing** — ✅ **DONE (minus region-by-id).** The container
+   funnel addresses a region by `regionPath` (object prefix) + `region`; the
+   object_list array is at `[...regionPath, region]`, blocks_layout on the node at
+   `regionPath`. The old `dataPath` field is removed everywhere
+   (`buildBlockPathMap`, `getContainerFieldConfig`, `getAllContainerFields`,
+   `getChildFields`, the ops, and the shared `getChildBlockEntries`/
+   `setChildBlockEntries`). Kept as arrays internally (not stringified) — the
+   `/`-grammar is the interface, arrays the impl. The region→**child-by-id** hop
+   is **not** added yet (no funnel consumer needs it; see §6).
+3. **Physical `pathInfo.path` collapse** — ⬜ **NOT DONE.** Derive the physical
+   formData location from a logical path on demand and drop the stored `path`
+   arrays. Only worth it if the uniformity beats re-resolving vs array-indexing.
+
+## 6. Constraints / notes
+
+- **Separator is `/`.** A schema field key or a block id must not contain `/`
+  (block ids are uuids; schema keys are identifiers — neither does).
+- **Region-by-id in `data-edit-text` is rarely needed** — a child block already
+  carries its own `data-block-uid` in the DOM, so inline editing addresses it
+  directly. Region-by-id mainly pays off in step 2 (unifying the funnel) and for
+  template/fieldRules that reference a specific nested block's field.
+- **Values stay terminal** on both halves (schema descent stops at non-object;
+  data descent naturally returns `undefined` past a value).

--- a/tests-playwright/fixtures/content/object-blocks-multinode/data.json
+++ b/tests-playwright/fixtures/content/object-blocks-multinode/data.json
@@ -1,0 +1,27 @@
+{
+  "@id": "http://localhost:8888/object-blocks-multinode",
+  "@type": "Document",
+  "UID": "object-blocks-multinode-uid",
+  "id": "object-blocks-multinode",
+  "title": "Object Blocks Multinode",
+  "blocks": {
+    "title-block": { "@type": "title" },
+    "obm-1": {
+      "@type": "objectBlocks",
+      "content": {
+        "headline": [
+          { "type": "h2", "children": [{ "text": "First para" }] },
+          { "type": "p", "children": [{ "text": "Second para" }] }
+        ],
+        "blocks": {
+          "obm-c1": {
+            "@type": "slate",
+            "value": [{ "type": "p", "children": [{ "text": "body block" }] }]
+          }
+        },
+        "blocks_layout": { "body": ["obm-c1"] }
+      }
+    }
+  },
+  "blocks_layout": { "items": ["title-block", "obm-1"] }
+}

--- a/tests-playwright/fixtures/content/object-blocks-page/data.json
+++ b/tests-playwright/fixtures/content/object-blocks-page/data.json
@@ -1,0 +1,35 @@
+{
+  "@id": "http://localhost:8888/object-blocks-page",
+  "@type": "Document",
+  "UID": "object-blocks-page-uid",
+  "id": "object-blocks-page",
+  "title": "Object Blocks Page",
+  "blocks": {
+    "title-block": {
+      "@type": "title"
+    },
+    "ob-1": {
+      "@type": "objectBlocks",
+      "content": {
+        "headline": [{ "type": "p", "children": [{ "text": "Original headline" }] }],
+        "href": "https://old.example.com",
+        "blocks": {
+          "child-1": {
+            "@type": "slate",
+            "value": [{ "type": "p", "children": [{ "text": "First body block" }] }]
+          },
+          "child-2": {
+            "@type": "slate",
+            "value": [{ "type": "p", "children": [{ "text": "Second body block" }] }]
+          }
+        },
+        "blocks_layout": {
+          "body": ["child-1", "child-2"]
+        }
+      }
+    }
+  },
+  "blocks_layout": {
+    "items": ["title-block", "ob-1"]
+  }
+}

--- a/tests-playwright/fixtures/mock-api-server.test.cjs
+++ b/tests-playwright/fixtures/mock-api-server.test.cjs
@@ -57,7 +57,7 @@ describe('@querystring-search', () => {
         },
       ],
       b_start: 0,
-      b_size: 50,
+      b_size: 1000,
     });
 
     assert.ok(data.items_total > 0, 'should return items');
@@ -87,7 +87,7 @@ describe('@querystring-search', () => {
       sort_on: 'getObjPositionInParent',
       sort_order: 'ascending',
       b_start: 0,
-      b_size: 50,
+      b_size: 1000,
     });
 
     // Filter to direct children only (not nested template items etc.)
@@ -121,7 +121,7 @@ describe('@querystring-search', () => {
       sort_on: 'getObjPositionInParent',
       sort_order: 'ascending',
       b_start: 0,
-      b_size: 50,
+      b_size: 1000,
     });
     const desc = await querystringSearch('/_test_data', {
       query: [
@@ -134,7 +134,7 @@ describe('@querystring-search', () => {
       sort_on: 'getObjPositionInParent',
       sort_order: 'descending',
       b_start: 0,
-      b_size: 50,
+      b_size: 1000,
     });
 
     const ascIds = asc.items.map((i) => i.id);

--- a/tests-playwright/fixtures/shared-block-schemas.js
+++ b/tests-playwright/fixtures/shared-block-schemas.js
@@ -458,7 +458,48 @@ export const sharedBlocksConfig = {
     // valid page blocks; the frontend still owns their rendering.
     search: { id: 'search', title: 'Search', group: 'common', blockSchema: { properties: {} } },
     heading: { id: 'heading', title: 'Heading', group: 'common', blockSchema: { properties: {} } },
-    slateTable: { id: 'slateTable', title: 'Table', group: 'common', blockSchema: { properties: {} } },
+    // slateTable has inline-editable cells, so it MUST declare its nested
+    // structure — table (object) → rows (object_list) → cells (object_list) →
+    // value (slate). A frontend's registered schema OVERRIDES the admin's
+    // baseline (mock-parent + View.jsx), so an empty schema here erases the
+    // table's rows/cells from the pathMap: they lose their pathInfo, cells
+    // resolve as plain-string fields, and table-mode 2D cursor navigation never
+    // engages (parentAddMode is undefined). Mirror the admin baseline exactly.
+    slateTable: {
+        id: 'slateTable',
+        title: 'Table',
+        group: 'common',
+        addMode: 'table',
+        blockSchema: {
+            properties: {
+                table: {
+                    widget: 'object',
+                    schema: {
+                        properties: {
+                            rows: {
+                                widget: 'object_list',
+                                idField: 'key',
+                                addMode: 'table',
+                                schema: {
+                                    properties: {
+                                        cells: {
+                                            widget: 'object_list',
+                                            idField: 'key',
+                                            schema: {
+                                                properties: {
+                                                    value: { widget: 'slate' },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
     maps: { id: 'maps', title: 'Map', group: 'common', blockSchema: { properties: {} } },
     video: { id: 'video', title: 'Video', group: 'common', blockSchema: { properties: {} } },
     // Code example block: tabbed code display with syntax highlighting

--- a/tests-playwright/fixtures/shared-block-schemas.js
+++ b/tests-playwright/fixtures/shared-block-schemas.js
@@ -402,6 +402,46 @@ export const sharedBlocksConfig = {
             },
         },
     },
+    // Object-nested blocks_layout (#245): a `content` widget:'object' wrapper
+    // whose `body` region is a blocks_layout. The object holds its OWN shared
+    // `blocks` dict + `blocks_layout` — one level deeper than the block root
+    // (data: block.content.blocks / block.content.blocks_layout.body). Exercises
+    // the regionPath funnel path end-to-end.
+    objectBlocks: {
+        id: 'objectBlocks',
+        title: 'Object Blocks',
+        group: 'common',
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: ['content'] }],
+            properties: {
+                content: {
+                    widget: 'object',
+                    schema: {
+                        fieldsets: [{ id: 'default', title: 'Content', fields: ['headline', 'body'] }],
+                        properties: {
+                            // An inline-editable text field living directly on the
+                            // object — written to block.content.headline.
+                            headline: {
+                                title: 'Headline',
+                                widget: 'slate',
+                                default: [{ type: 'p', children: [{ text: '' }] }],
+                            },
+                            // An inline-editable LINK field on the object — proves
+                            // link editing routes through the central /-path API
+                            // (writes block.content.href, not a flat key).
+                            href: { title: 'Link', widget: 'object_browser', mode: 'link' },
+                            body: {
+                                title: 'Body',
+                                widget: 'blocks_layout',
+                                allowedBlocks: ['slate', 'image'],
+                                defaultBlockType: 'slate',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
     // Separator (horizontal rule) — a simple leaf block with no editable fields.
     // Registered so it's a valid page-level block (it's used across the docs
     // content and inside accordions); without this it isn't in the page's

--- a/tests-playwright/fixtures/test-frontend/index.html
+++ b/tests-playwright/fixtures/test-frontend/index.html
@@ -455,7 +455,7 @@
                                 properties: {
                                     items: {
                                         title: 'Blocks',
-                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample'],
+                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample', 'objectBlocks'],
                                         allowedTemplates: ['/_test_data/templates/test-layout'],
                                         allowedLayouts: contextNavLayoutForced
                                             || [null, '/_test_data/templates/test-layout', '/_test_data/templates/header-footer-layout', '/_test_data/templates/header-only-layout', '/_test_data/templates/editable-fixed-layout'],

--- a/tests-playwright/fixtures/test-frontend/renderer.js
+++ b/tests-playwright/fixtures/test-frontend/renderer.js
@@ -283,6 +283,9 @@ async function renderBlock(blockId, block) {
         case 'slateTable':
             wrapper.innerHTML = renderSlateTableBlock(block);
             break;
+        case 'objectBlocks':
+            wrapper.innerHTML = await renderObjectBlocksBlock(block);
+            break;
         case 'search':
             wrapper.innerHTML = await renderSearchBlock(block, blockId);
             break;
@@ -1092,6 +1095,55 @@ function attachFormValidation(formEl, block) {
             formEl.appendChild(successDiv);
         }
     });
+}
+
+/**
+ * Object-nested blocks_layout (#245). The `content` object holds its OWN shared
+ * blocks dict + blocks_layout; the `body` region lists ids into content.blocks.
+ * Renders each child with data-block-uid so the bridge can select/edit them.
+ * @param {Object} block - objectBlocks data with block.content.{blocks,blocks_layout}
+ * @returns {Promise<string>} HTML string
+ */
+async function renderObjectBlocksBlock(block) {
+    const content = block.content || {};
+    const blocks = content.blocks || {};
+    const bodyItems = content.blocks_layout?.body || [];
+
+    // Inline-editable text field living directly on the object
+    // (block.content.headline) — a slate field, marked data-edit-text so hydra
+    // sets it contenteditable, exactly like a top-level slate field.
+    let html = '';
+    const headline = content.headline;
+    if (Array.isArray(headline) && headline[0]) {
+        const node = headline[0];
+        const nodeIdAttr = node.nodeId !== undefined ? ` data-node-id="${node.nodeId}"` : '';
+        const text = renderChildren(node.children);
+        html += `<h3 class="ob-headline" data-edit-text="content/headline"${nodeIdAttr}>${text}</h3>`;
+    }
+    // Inline-editable LINK field on the object (block.content.href) — addressed
+    // by its /-path, edited via the central field-access API.
+    if (content.href !== undefined) {
+        html += `<a class="ob-link" data-edit-link="content/href" href="${content.href || '#'}">Object link</a>`;
+    }
+    html += '<div class="object-blocks-body">';
+    for (const childId of bodyItems) {
+        const child = blocks[childId];
+        if (!child || !child['@type']) continue;
+        html += `<div data-block-uid="${childId}" data-block-add="bottom">`;
+        switch (child['@type']) {
+            case 'slate':
+                html += renderSlateBlock(child);
+                break;
+            case 'image':
+                html += renderImageBlock(child);
+                break;
+            default:
+                html += `<p data-unknown-block-type="${child['@type']}">[not implemented]</p>`;
+        }
+        html += '</div>';
+    }
+    html += '</div>';
+    return html;
 }
 
 /**

--- a/tests-playwright/helpers/AdminUIHelper.ts
+++ b/tests-playwright/helpers/AdminUIHelper.ts
@@ -3516,14 +3516,24 @@ export class AdminUIHelper {
     // For insertBefore: indicator at TOP edge (within tolerance above block)
     const tolerance = 30; // Should be close to the edge
     const expectedEdge = insertAfter ? targetBottom : targetTop;
+    // The INNER bound (toward the block's centre) must never reach past the
+    // midpoint: for a block shorter than 2*tolerance the opposite edge would
+    // otherwise fall inside the window, so an indicator at the TOP edge
+    // (insertBefore) would satisfy an insertAfter check — and the drop then
+    // lands on the wrong side (the placeholder-region flake: tightly packed
+    // ~18px paragraphs). Keep the full tolerance on the OUTER side (the gap to
+    // the neighbouring block). Tall blocks are unaffected (min → tolerance).
+    const innerTol = Math.min(tolerance, (targetBottom - targetTop) / 2);
     let isNearTarget: boolean;
 
     if (insertAfter) {
-      // Indicator should be near bottom edge of target
-      isNearTarget = dropY >= targetBottom - tolerance && dropY <= targetBottom + tolerance;
+      // Indicator should be near bottom edge of target, on the after-side of
+      // the midpoint.
+      isNearTarget = dropY >= targetBottom - innerTol && dropY <= targetBottom + tolerance;
     } else {
-      // Indicator should be near top edge of target
-      isNearTarget = dropY >= targetTop - tolerance && dropY <= targetTop + tolerance;
+      // Indicator should be near top edge of target, on the before-side of
+      // the midpoint.
+      isNearTarget = dropY >= targetTop - tolerance && dropY <= targetTop + innerTol;
     }
 
     if (!isNearTarget) {

--- a/tests-playwright/helpers/BlockVerificationHelper.ts
+++ b/tests-playwright/helpers/BlockVerificationHelper.ts
@@ -393,6 +393,79 @@ export interface VerifyBlockRenderingOptions {
 }
 
 /**
+ * Schema-INDEPENDENT coverage check: every block/field the frontend actually
+ * renders as editable must be known to the bridge's blockPathMap.
+ *
+ * `checkSubBlocks` walks the OTHER direction (pathMap → DOM: "is every block
+ * the pathMap knows about rendered?"). That direction is blind to an
+ * incomplete schema: if a frontend registers e.g. `slateTable` with an empty
+ * schema, buildBlockPathMap can't see `table → rows → cells`, so the cells are
+ * simply ABSENT from the pathMap — yet the frontend still renders them from
+ * data. pathMap → DOM then iterates nothing and passes, while the cells are
+ * un-selectable / un-editable / un-navigable (no pathInfo → parentAddMode
+ * undefined, field type unresolved). That is precisely how an incomplete
+ * schema slipped through to a silent table-navigation failure.
+ *
+ * This check closes the gap by walking DOM → pathMap: for the rendered block
+ * subtree, assert every nested `[data-block-uid]` has a pathMap entry. It needs
+ * no blocksConfig — it reads the live bridge — so it runs in CI unconditionally
+ * (unlike the schema-driven discovery checks, which are gated on MOCK_PARENT_URL
+ * and traverse schema-first, so they can't see missing nested structure).
+ *
+ * Scope, to stay false-positive-free:
+ *  - Only rendered `[data-block-uid]`s are checked (a concrete "this is an
+ *    editable block" signal). We deliberately do NOT flag unresolved
+ *    `data-edit-*` fields: page-level fields (`/title`) and listing-projected
+ *    block fields (a teaser inside a grid) legitimately render edit
+ *    annotations that aren't in THIS block's editable pathMap.
+ *  - Read-only subtrees (`data-block-readonly` — listing results, teasers) are
+ *    skipped: their inner markup is projected content, not editable blocks.
+ *  - Items that reuse the parent's uid (listing expansion) are skipped.
+ */
+export async function verifyPathMapCoverage(
+  iframe: FrameLocator,
+  blockId: string,
+): Promise<void> {
+  const block = iframe.locator(`[data-block-uid="${blockId}"]`).first();
+  const orphans = await block.evaluate((el, parentUid) => {
+    const b = (window as any).__hydraBridge;
+    // No bridge (e.g. a pure render harness) → nothing to assert against.
+    if (!b?.blockPathMap) return null;
+    const pathMap = b.blockPathMap;
+
+    // Dynamic-container block types render interactive `data-block-uid`
+    // children that are intentionally NOT part of the editable pathMap:
+    // `search` (facets widget + results listing) and `listing`/
+    // `contextNavigation` (async-fetched results). Those are a different
+    // editability model, not the static-nested-editable-block class this
+    // guardrail targets — skip them wholesale to stay false-positive-free.
+    const DYNAMIC = new Set(['search', 'listing', 'contextNavigation']);
+    if (DYNAMIC.has(pathMap[parentUid]?.blockType)) return [];
+
+    const found: string[] = [];
+    el.querySelectorAll('[data-block-uid]').forEach((child: Element) => {
+      const uid = child.getAttribute('data-block-uid');
+      // Skip self, listing-expanded items reusing the parent uid, and read-only
+      // (projected) subtrees.
+      if (!uid || uid === parentUid) return;
+      if (child.closest('[data-block-readonly]')) return;
+      if (!pathMap[uid]) found.push(uid);
+    });
+    return Array.from(new Set(found));
+  }, blockId);
+
+  if (orphans === null) return; // no bridge
+
+  expect(
+    orphans,
+    `Blocks rendered inside "${blockId}" but ABSENT from the pathMap — they can't be ` +
+      `selected, edited, moved or navigated. This means their container field isn't ` +
+      `declared (or is incompletely declared) in the frontend's block schema, so ` +
+      `buildBlockPathMap never descended into it: ${orphans.join(', ')}`,
+  ).toEqual([]);
+}
+
+/**
  * Full block rendering verification: locate block, check text, check edit
  * annotations, verify sub-blocks, and click data-edit-text elements.
  *
@@ -494,6 +567,13 @@ export async function verifyBlockRendering(
   // Schema-driven slate check — checkSlateAnnotations pulls the schema
   // from the bridge itself (authoritative, schemaEnhancer-resolved).
   await checkSlateAnnotations(block, blockData);
+
+  // Schema-INDEPENDENT coverage: every rendered nested block + editable field
+  // must be known to the pathMap. Catches incomplete frontend schemas that the
+  // schema-driven checks (disabled in CI, and blind to gaps they have no
+  // schema path into) can't — e.g. a slateTable whose cells render but are
+  // absent from the pathMap. Runs off the live bridge, so it needs no config.
+  await verifyPathMapCoverage(iframe, blockId);
 
   // Verify sub-blocks (before clicking, which may toggle interactive
   // containers like accordions closed). Sub-blocks come from the bridge's

--- a/tests-playwright/integration/object-blocks.spec.ts
+++ b/tests-playwright/integration/object-blocks.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * blocks_layout nested inside a widget:'object' (#245).
+ *
+ * The `objectBlocks` test block declares a `content` object whose `body` region
+ * is a blocks_layout. The object holds its OWN shared blocks dict + blocks_layout
+ * (data: block.content.blocks / block.content.blocks_layout.body) — one level
+ * deeper than the block root. These tests drive the full editing path (select,
+ * add, delete, reorder) through the regionPath funnel.
+ */
+import { test, expect } from '../fixtures';
+import { AdminUIHelper } from '../helpers/AdminUIHelper';
+
+test.describe('blocks_layout nested in a widget:object', () => {
+  test('renders the object-nested body blocks, each selectable', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/object-blocks-page');
+
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="ob-1"]').waitFor();
+
+    const body = iframe.locator('[data-block-uid="ob-1"] .object-blocks-body');
+    await expect(body.locator('[data-block-uid]')).toHaveCount(2);
+    await expect(iframe.locator('[data-block-uid="child-1"]')).toContainText('First body block');
+
+    // Selecting a nested body block works (sidebar opens on it).
+    await helper.clickBlockInIframe('child-1');
+    await helper.waitForSidebarOpen();
+    await helper.waitForIframeBlockHandle('child-1');
+  });
+
+  test('sidebar prefixes the nested container title with the object path', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/object-blocks-page');
+
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="ob-1"]').waitFor();
+
+    // Select ob-1 (the object block) to see its child container sections.
+    await helper.clickBlockInIframe('child-1');
+    await helper.waitForSidebarOpen();
+    await helper.escapeToParent();
+    await helper.waitForIframeBlockHandle('ob-1');
+
+    // The `body` region lives under the `content` object, so its sidebar title
+    // is prefixed with the object path: "Content / Body".
+    const sidebar = page.locator('.sidebar-container');
+    await expect(
+      sidebar.locator('.widget-title', { hasText: 'Content / Body' }),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test('adds a block into the object-nested body region', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/object-blocks-page');
+
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="ob-1"]').waitFor();
+
+    const body = iframe.locator('[data-block-uid="ob-1"] .object-blocks-body');
+    await expect(body.locator('[data-block-uid]')).toHaveCount(2);
+
+    // Select the first body block and add a sibling via the iframe [+].
+    // The body region allows slate + image, so the chooser opens — pick slate.
+    await helper.clickBlockInIframe('child-1');
+    await helper.waitForSidebarOpen();
+    await helper.clickAddBlockButton();
+    await helper.selectBlockType('slate');
+
+    // A new body block is added inside the SAME object region (count 2 → 3),
+    // proving the insert wrote to content.blocks_layout.body, not the block root.
+    await expect(body.locator('[data-block-uid]')).toHaveCount(3);
+  });
+
+  test('deletes a body block via the sidebar hierarchy', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/object-blocks-page');
+
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="ob-1"]').waitFor();
+
+    const body = iframe.locator('[data-block-uid="ob-1"] .object-blocks-body');
+    await expect(body.locator('[data-block-uid]')).toHaveCount(2);
+
+    // Select child-2, delete it via the current block's sidebar dropdown.
+    await helper.clickBlockInIframe('child-2');
+    await helper.waitForSidebarOpen();
+    await helper.waitForIframeBlockHandle('child-2');
+
+    const sidebar = page.locator('.sidebar-container');
+    const currentBlockHeader = sidebar.locator('[data-is-current="true"]');
+    await currentBlockHeader.locator('.menu-trigger').click();
+    const removeOption = page
+      .locator('.volto-hydra-dropdown-item')
+      .filter({ hasText: 'Remove' });
+    await expect(removeOption).toBeVisible({ timeout: 3000 });
+    await removeOption.click();
+
+    // Only child-1 remains in the object's body region.
+    await expect(body.locator('[data-block-uid]')).toHaveCount(1);
+    await expect(iframe.locator('[data-block-uid="child-1"]')).toBeVisible();
+    await expect(iframe.locator('[data-block-uid="child-2"]')).toHaveCount(0);
+  });
+
+  test('inline-edits a slate field of a block inside the object region', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/object-blocks-page');
+
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="ob-1"]').waitFor();
+
+    // Type into the first body block. The block's value lives at
+    // content.blocks['child-1'].value — inline editing must reach it through the
+    // object nesting (getBlockById resolves the block-relative path).
+    await helper.editBlockTextInIframe('child-1', 'Edited inside the object');
+
+    // The rendered block reflects the new text.
+    await expect(iframe.locator('[data-block-uid="child-1"]')).toContainText(
+      'Edited inside the object',
+    );
+  });
+
+  test('inline-edits a field that lives directly on the object', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/object-blocks-page');
+
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="ob-1"]').waitFor();
+    const headline = iframe.locator('[data-block-uid="ob-1"] .ob-headline');
+    await expect(headline).toHaveText('Original headline');
+
+    // Click the headline itself (it belongs to ob-1, not a child block) to
+    // select ob-1 and focus the field, then retype. The value lives at
+    // block.content.headline — editing it in the canvas must write there.
+    await headline.click();
+    await expect(headline).toHaveAttribute('contenteditable', 'true', { timeout: 5000 });
+    await headline.press('ControlOrMeta+a');
+    await headline.pressSequentially('Edited object field', { delay: 10 });
+
+    await expect(headline).toHaveText('Edited object field');
+
+    // Force a re-render FROM formData: edit a body block, which sends FORM_DATA
+    // and re-renders ob-1 (headline included) from stored data. If the headline
+    // edit only lived in the DOM (writeback missed the nested content.headline
+    // storage path), the headline would revert to "Original headline" here.
+    await helper.editBlockTextInIframe('child-1', 'Body edit forces rerender');
+    await expect(iframe.locator('[data-block-uid="child-1"]')).toContainText(
+      'Body edit forces rerender',
+    );
+    await expect(headline).toHaveText('Edited object field');
+  });
+
+  test('inline-edits a LINK field that lives directly on the object', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/object-blocks-page');
+
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="ob-1"]').waitFor();
+    const link = iframe.locator('[data-block-uid="ob-1"] .ob-link');
+    await expect(link).toHaveAttribute('href', 'https://old.example.com');
+
+    // Select the object block via its link, open the link editor, change the URL.
+    // The link field is at block.content.href — the central /-path API must read
+    // and write it there (not a flat block['content/href'] key).
+    await link.click();
+    await helper.waitForBlockSelectedInAdmin('ob-1');
+
+    const toolbar = page.locator('.quanta-toolbar');
+    const linkButton = toolbar.locator('button[title*="Edit link"]');
+    await expect(linkButton).toBeVisible({ timeout: 5000 });
+    await linkButton.click();
+
+    const linkForm = page.locator('.field-link-editor .link-form-container');
+    await expect(linkForm).toBeVisible({ timeout: 5000 });
+    const urlInput = linkForm.locator('input[name="link"]');
+    await urlInput.fill('https://new.example.com');
+    await linkForm.locator('button[aria-label="Submit"]').click();
+
+    // The rendered link reflects the new href (written to content.href).
+    await expect(link).toHaveAttribute('href', 'https://new.example.com', { timeout: 5000 });
+
+    // Force a re-render from formData (edit a body block) — the link must
+    // survive, proving it persisted to content.href, not a stray flat key.
+    await helper.editBlockTextInIframe('child-1', 'Body edit for link rerender');
+    await expect(link).toHaveAttribute('href', 'https://new.example.com');
+  });
+
+  test('a multi-node slate field on an object is flattened on load (not left multi-node)', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/object-blocks-multinode');
+
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="obm-1"]').waitFor();
+
+    // content.headline started as [h2 "First para", p "Second para"] — two top-level
+    // nodes. A slate field must hold ONE node; a field on an object can't split into
+    // sibling blocks, so it FLATTENS (merges both nodes' children into one). The
+    // enforcement must reach the nested field (content/headline), so both texts
+    // survive in the single rendered node. If it were left multi-node, the renderer
+    // (which shows headline[0]) would show only "First para".
+    const headline = iframe.locator('[data-block-uid="obm-1"] .ob-headline');
+    await expect(headline).toContainText('First para');
+    await expect(headline).toContainText('Second para');
+  });
+
+  test('reorders blocks within the object region', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/object-blocks-page');
+
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="ob-1"]').waitFor();
+
+    const body = iframe.locator('[data-block-uid="ob-1"] .object-blocks-body');
+    // Initial order: child-1, child-2.
+    await expect(body.locator('[data-block-uid]').nth(0)).toHaveAttribute(
+      'data-block-uid',
+      'child-1',
+    );
+
+    // Drag child-1 below child-2 — the reorder must rewrite
+    // content.blocks_layout.body, not the block root.
+    await helper.dragBlockAfter('child-1', 'child-2');
+
+    // New order: child-2, child-1.
+    await expect(body.locator('[data-block-uid]').nth(0)).toHaveAttribute(
+      'data-block-uid',
+      'child-2',
+    );
+    await expect(body.locator('[data-block-uid]').nth(1)).toHaveAttribute(
+      'data-block-uid',
+      'child-1',
+    );
+  });
+});


### PR DESCRIPTION
## Object widget #245 — `widget:'object'` nesting replaces the `dataPath` workaround

Makes `widget:'object'` a first-class field-grouping container so nested editable
content (object_list rows/cells, blocks_layout regions, scalar/link/media fields)
lives under an object key and is addressed by a unified `/`-path grammar, removing
the `dataPath` special-case. Includes the central path/field-access API and routes
text/link/media/validation/defaults/multi-node-split through it.

### Commits
- `112d7aca` **fix(tables):** declare the nested `slateTable` schema (`table → rows → cells → value`) in every frontend schema source. An empty schema was overriding the admin baseline and erasing table cells from the pathMap → table 2-D cursor nav broke on all frontends (was red on `main` too).
- `cddd9534` **fix(nuxt-example):** render the `objectBlocks` (`widget:'object'`) block in the real Nuxt example (nuxt-example-parity).
- `1239b75f` **test(block-sanity):** add a schema-independent **DOM→pathMap coverage** assertion — every rendered `[data-block-uid]` must be in the pathMap. This is the guardrail that catches the incomplete-schema class the above bug belonged to; it runs in CI unconditionally (the existing schema checks are gated on `MOCK_PARENT_URL`, never set in CI, and traverse schema-first so they can't see gaps the schema doesn't describe).
- `a70cdfea` **fix(test-drag):** make drop-edge verification distinguish before/after for short blocks — de-flakes `templates.spec.ts:563` (the ±30px tolerance exceeded the ~18px placeholder-paragraph height, so an insertBefore indicator satisfied an insertAfter check).
- `3f69c2d8` **docs:** regenerate out-of-sync content copies; `49f9f2d6` **test(mock-api):** raise `b_size` for full-listing queries; `837d5f95` merge `main`.

### CI
Green on the integrated branch (`837d5f95`) except `test-nuxt-admin`, whose 4 failures are **pre-existing admin-nuxt flakes** — all 4 pass on local re-run, and 2 (`template-edit-mode` `persist`/`slotId`) flake on `main` independently. No rerun-to-fake-green.

### Before merge
`main` has since gained #252 (`fieldRules` operators), which overlaps the path/schema files but conflicts cleanly (0 markers). I'll fold it in and re-run the unit suites before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
