### PR TITLE
feat: drag / paste into a spot via conversion

### DIFF
--- a/docs/content/content/content/docs/custom-blocks/data.json
+++ b/docs/content/content/content/docs/custom-blocks/data.json
@@ -1981,7 +1981,7 @@
     },
     "p-37": {
       "@type": "slate",
-      "plaintext": "`fieldMappings` (plural) on a block config defines how fields map between block types. This enables three things:",
+      "plaintext": "`fieldMappings` (plural) on a block config defines how fields map between block types. This enables four things:",
       "value": [
         {
           "type": "p",
@@ -1995,7 +1995,7 @@
               ]
             },
             {
-              "text": " (plural) on a block config defines how fields map between block types. This enables three things:"
+              "text": " (plural) on a block config defines how fields map between block types. This enables four things:"
             }
           ]
         }
@@ -2003,7 +2003,7 @@
     },
     "ul-38": {
       "@type": "slate",
-      "plaintext": "\"Convert to...\" UI action — editors can convert a block to another type (e.g. teaser → image). Listing item types — query results are mapped to item blocks via @default (see Listings). Synchronised container children — a parent controls child type, all children convert together (see Container Blocks › Synchronised Block Types).",
+      "plaintext": "\"Convert to...\" UI action — editors can convert a block to another type (e.g. teaser → image). Listing item types — query results are mapped to item blocks via @default (see Listings). Synchronised container children — a parent controls child type, all children convert together (see Container Blocks › Synchronised Block Types). Drag / paste via conversion — a block can be dropped or pasted into a container that only accepts a convertible type; it's converted on drop (see below).",
       "value": [
         {
           "type": "ul",
@@ -2092,6 +2092,33 @@
                 },
                 {
                   "text": ")."
+                }
+              ]
+            },
+            {
+              "type": "li",
+              "children": [
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "text": "Drag / paste via conversion"
+                    }
+                  ]
+                },
+                {
+                  "text": " — a block can be dropped or pasted into a container that only accepts a "
+                },
+                {
+                  "type": "em",
+                  "children": [
+                    {
+                      "text": "convertible"
+                    }
+                  ]
+                },
+                {
+                  "text": " type; it's converted on drop (see below)."
                 }
               ]
             }
@@ -2491,6 +2518,67 @@
     },
     "h-47": {
       "@type": "slate",
+      "plaintext": "Drag / paste via conversion",
+      "value": [
+        {
+          "type": "h3",
+          "children": [
+            {
+              "text": "Drag / paste via conversion"
+            }
+          ]
+        }
+      ]
+    },
+    "p-48": {
+      "@type": "slate",
+      "plaintext": "The same conversion graph gives drag-and-drop (and paste) more valid destinations: a block can be dropped or pasted into a container whose `allowedBlocks` only admits a type the block can *convert* to. On drop it's converted automatically when exactly one target type is reachable, or a chooser popup appears when several are (single-block only — the block moves only once you pick, so cancelling leaves it untouched). Multi-block selections and paste are auto-convert only. On mobile, conversion happens via cut → paste (drag/chevron move stays native-only). External-link and other type restrictions are unaffected; only the container's `allowedBlocks` gate is relaxed to \"allowed or convertible\".",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "The same conversion graph gives drag-and-drop (and paste) more valid destinations: a block can be dropped or pasted into a container whose "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "allowedBlocks"
+                }
+              ]
+            },
+            {
+              "text": " only admits a type the block can "
+            },
+            {
+              "type": "em",
+              "children": [
+                {
+                  "text": "convert"
+                }
+              ]
+            },
+            {
+              "text": " to. On drop it's converted automatically when exactly one target type is reachable, or a chooser popup appears when several are (single-block only — the block moves only once you pick, so cancelling leaves it untouched). Multi-block selections and paste are auto-convert only. On mobile, conversion happens via cut → paste (drag/chevron move stays native-only). External-link and other type restrictions are unaffected; only the container's "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "allowedBlocks"
+                }
+              ]
+            },
+            {
+              "text": " gate is relaxed to \"allowed or convertible\"."
+            }
+          ]
+        }
+      ]
+    },
+    "h-49": {
+      "@type": "slate",
       "plaintext": "Mapping value format",
       "value": [
         {
@@ -2503,7 +2591,7 @@
         }
       ]
     },
-    "p-48": {
+    "p-50": {
       "@type": "slate",
       "plaintext": "A mapping value is either a string (simple field rename) or `{ field, type }` (rename with type conversion):",
       "value": [
@@ -2528,18 +2616,18 @@
         }
       ]
     },
-    "ce-49": {
+    "ce-51": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-49-json-2e1a67",
+          "@id": "ce-51-json-620d51",
           "label": "Json",
           "language": "json",
           "code": "{\n    \"@id\": { \"field\": \"href\", \"type\": \"link\" },\n    \"title\": \"title\",\n    \"description\": \"description\",\n    \"image\": \"preview_image\"\n}"
         }
       ]
     },
-    "p-50": {
+    "p-52": {
       "@type": "slate",
       "plaintext": "When `type` is specified, the value is converted at runtime:",
       "value": [
@@ -2564,7 +2652,7 @@
         }
       ]
     },
-    "tbl-51": {
+    "tbl-53": {
       "@type": "slateTable",
       "table": {
         "fixed": true,
@@ -2575,10 +2663,10 @@
         "striped": false,
         "rows": [
           {
-            "key": "tbl-51-r0",
+            "key": "tbl-53-r0",
             "cells": [
               {
-                "key": "tbl-51-r0c0",
+                "key": "tbl-53-r0c0",
                 "type": "header",
                 "value": [
                   {
@@ -2592,7 +2680,7 @@
                 ]
               },
               {
-                "key": "tbl-51-r0c1",
+                "key": "tbl-53-r0c1",
                 "type": "header",
                 "value": [
                   {
@@ -2608,10 +2696,10 @@
             ]
           },
           {
-            "key": "tbl-51-r1",
+            "key": "tbl-53-r1",
             "cells": [
               {
-                "key": "tbl-51-r1c0",
+                "key": "tbl-53-r1c0",
                 "type": "data",
                 "value": [
                   {
@@ -2630,7 +2718,7 @@
                 ]
               },
               {
-                "key": "tbl-51-r1c1",
+                "key": "tbl-53-r1c1",
                 "type": "data",
                 "value": [
                   {
@@ -2657,10 +2745,10 @@
             ]
           },
           {
-            "key": "tbl-51-r2",
+            "key": "tbl-53-r2",
             "cells": [
               {
-                "key": "tbl-51-r2c0",
+                "key": "tbl-53-r2c0",
                 "type": "data",
                 "value": [
                   {
@@ -2679,7 +2767,7 @@
                 ]
               },
               {
-                "key": "tbl-51-r2c1",
+                "key": "tbl-53-r2c1",
                 "type": "data",
                 "value": [
                   {
@@ -2706,10 +2794,10 @@
             ]
           },
           {
-            "key": "tbl-51-r3",
+            "key": "tbl-53-r3",
             "cells": [
               {
-                "key": "tbl-51-r3c0",
+                "key": "tbl-53-r3c0",
                 "type": "data",
                 "value": [
                   {
@@ -2728,7 +2816,7 @@
                 ]
               },
               {
-                "key": "tbl-51-r3c1",
+                "key": "tbl-53-r3c1",
                 "type": "data",
                 "value": [
                   {
@@ -2755,10 +2843,10 @@
             ]
           },
           {
-            "key": "tbl-51-r4",
+            "key": "tbl-53-r4",
             "cells": [
               {
-                "key": "tbl-51-r4c0",
+                "key": "tbl-53-r4c0",
                 "type": "data",
                 "value": [
                   {
@@ -2777,7 +2865,7 @@
                 ]
               },
               {
-                "key": "tbl-51-r4c1",
+                "key": "tbl-53-r4c1",
                 "type": "data",
                 "value": [
                   {
@@ -2801,10 +2889,10 @@
             ]
           },
           {
-            "key": "tbl-51-r5",
+            "key": "tbl-53-r5",
             "cells": [
               {
-                "key": "tbl-51-r5c0",
+                "key": "tbl-53-r5c0",
                 "type": "data",
                 "value": [
                   {
@@ -2823,7 +2911,7 @@
                 ]
               },
               {
-                "key": "tbl-51-r5c1",
+                "key": "tbl-53-r5c1",
                 "type": "data",
                 "value": [
                   {
@@ -2841,7 +2929,7 @@
         ]
       }
     },
-    "h-52": {
+    "h-54": {
       "@type": "slate",
       "plaintext": "FieldMappingWidget",
       "value": [
@@ -2855,7 +2943,7 @@
         }
       ]
     },
-    "p-53": {
+    "p-55": {
       "@type": "slate",
       "plaintext": "When a parent block has `mappingField` set in its `inheritSchemaFrom` recipe, the admin sidebar shows a widget that lets editors configure field mappings visually:",
       "value": [
@@ -2891,7 +2979,7 @@
         }
       ]
     },
-    "ul-54": {
+    "ul-56": {
       "@type": "slate",
       "plaintext": "Shows the @default source fields (@id, title, description, image) on the left. For each source field, lets the editor pick a field from the selected child type's schema. Auto-detects the conversion type from the target field definition (e.g. object_browser with mode=link → type: \"link\"). Saves the result as fieldMapping (singular) on the block data.",
       "value": [
@@ -3044,7 +3132,7 @@
         }
       ]
     },
-    "p-55": {
+    "p-57": {
       "@type": "slate",
       "plaintext": "The saved `fieldMapping` is read at render time by `expandListingBlocks` — no block registry access needed at render time.",
       "value": [
@@ -3080,7 +3168,7 @@
         }
       ]
     },
-    "h-56": {
+    "h-58": {
       "@type": "slate",
       "plaintext": "HTML Paste Support (TODO)",
       "value": [
@@ -3094,7 +3182,7 @@
         }
       ]
     },
-    "p-57": {
+    "p-59": {
       "@type": "slate",
       "plaintext": "When the editor pastes rich HTML into the page, Hydra will eventually be able to recognise it as a custom block by matching against a CSS selector mapping. The proposed shape:",
       "value": [
@@ -3108,18 +3196,18 @@
         }
       ]
     },
-    "ce-58": {
+    "ce-60": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-58-javascript-81cc43",
+          "@id": "ce-60-javascript-47c624",
           "label": "Javascript",
           "language": "javascript",
           "code": "video: {\n    fieldMappings: {\n        'css:video': { 'src': 'url', 'caption[@class=\"alt\"]': 'alt' },\n    },\n}"
         }
       ]
     },
-    "p-59": {
+    "p-61": {
       "@type": "slate",
       "plaintext": "The `css:<selector>` key in `fieldMappings` matches a pasted HTML element; the value maps element attributes to block fields. Not yet implemented — open question on whether this should run via `htmlTagsToSlate` (bypassing slate conversion) or be encoded into slate so attributes/classes survive.",
       "value": [
@@ -3218,17 +3306,19 @@
       "ul-46",
       "h-47",
       "p-48",
-      "ce-49",
+      "h-49",
       "p-50",
-      "tbl-51",
-      "h-52",
-      "p-53",
-      "ul-54",
+      "ce-51",
+      "p-52",
+      "tbl-53",
+      "h-54",
       "p-55",
-      "h-56",
+      "ul-56",
       "p-57",
-      "ce-58",
-      "p-59"
+      "h-58",
+      "p-59",
+      "ce-60",
+      "p-61"
     ]
   }
 }

--- a/docs/content/content/content/docs/what-editors-will-experience/adding-and-moving-blocks/data.json
+++ b/docs/content/content/content/docs/what-editors-will-experience/adding-and-moving-blocks/data.json
@@ -447,7 +447,7 @@
     },
     "p-17": {
       "@type": "slate",
-      "plaintext": "Drop targets are filtered by `allowedBlocks` — you can't drop into a region that doesn't accept this block type. The line/shade indicator only appears over valid drop targets.",
+      "plaintext": "Drop targets are filtered by `allowedBlocks` — the line/shade indicator only appears where the block can land. This **includes regions that don't accept the block directly but accept a type it can convert to**: dropping there converts the block on the fly — silently when only one target type is possible, or via a small chooser when several are (pick one, or dismiss to cancel the move). So a \"Text\" block can be dropped into a region that only takes \"Cards\" and it becomes a Card on drop.",
       "value": [
         {
           "type": "p",
@@ -464,7 +464,18 @@
               ]
             },
             {
-              "text": " — you can't drop into a region that doesn't accept this block type. The line/shade indicator only appears over valid drop targets."
+              "text": " — the line/shade indicator only appears where the block can land. This "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "includes regions that don't accept the block directly but accept a type it can convert to"
+                }
+              ]
+            },
+            {
+              "text": ": dropping there converts the block on the fly — silently when only one target type is possible, or via a small chooser when several are (pick one, or dismiss to cancel the move). So a \"Text\" block can be dropped into a region that only takes \"Cards\" and it becomes a Card on drop."
             }
           ]
         }
@@ -623,13 +634,24 @@
     },
     "p-23": {
       "@type": "slate",
-      "plaintext": "This works across pages — copy a block on one page, navigate to another, paste.",
+      "plaintext": "This works across pages — copy a block on one page, navigate to another, paste. Paste also **converts** like drag-and-drop: pasting into a region that only accepts a type the block can convert to converts it on paste. On touch devices, where dragging between distant spots is awkward, cut-and-paste is the easiest way to move (and convert) a block.",
       "value": [
         {
           "type": "p",
           "children": [
             {
-              "text": "This works across pages — copy a block on one page, navigate to another, paste."
+              "text": "This works across pages — copy a block on one page, navigate to another, paste. Paste also "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "converts"
+                }
+              ]
+            },
+            {
+              "text": " like drag-and-drop: pasting into a region that only accepts a type the block can convert to converts it on paste. On touch devices, where dragging between distant spots is awkward, cut-and-paste is the easiest way to move (and convert) a block."
             }
           ]
         }

--- a/docs/custom-blocks.md
+++ b/docs/custom-blocks.md
@@ -218,11 +218,12 @@ Field paths: `../field` for the parent block's field, `/field` for a page metada
 
 ## Block Conversion & fieldMappings
 
-`fieldMappings` (plural) on a block config defines how fields map between block types. This enables three things:
+`fieldMappings` (plural) on a block config defines how fields map between block types. This enables four things:
 
 - **"Convert to..." UI action** — editors can convert a block to another type (e.g. teaser → image).
 - **Listing item types** — query results are mapped to item blocks via `@default` (see [Listings](listings.md)).
 - **Synchronised container children** — a parent controls child type, all children convert together (see [Container Blocks › Synchronised Block Types](container-blocks.md#synchronised-block-types-in-a-container)).
+- **Drag / paste via conversion** — a block can be dropped or pasted into a container that only accepts a *convertible* type; it's converted on drop (see below).
 
 Each key in `fieldMappings` is either a **specific block type name** or **`@default`**.
 
@@ -263,6 +264,10 @@ checkboxFacet: { fieldMappings: { selectFacet: { /* ... */ }, daterangeFacet: { 
 - Types without `fieldMappings` never appear in the "Convert to..." menu.
 - Transitive conversions use paths through intermediate types (e.g. hero → teaser → image).
 - Unmapped fields are kept in the data so converting back restores them.
+
+### Drag / paste via conversion
+
+The same conversion graph gives drag-and-drop (and paste) more valid destinations: a block can be dropped or pasted into a container whose `allowedBlocks` only admits a type the block can *convert* to. On drop it's converted automatically when exactly one target type is reachable, or a chooser popup appears when several are (single-block only — the block moves only once you pick, so cancelling leaves it untouched). Multi-block selections and paste are auto-convert only. On mobile, conversion happens via cut → paste (drag/chevron move stays native-only). External-link and other type restrictions are unaffected; only the container's `allowedBlocks` gate is relaxed to "allowed or convertible".
 
 ### Mapping value format
 

--- a/docs/superpowers/plans/2026-07-18-dnd-paste-via-conversion.md
+++ b/docs/superpowers/plans/2026-07-18-dnd-paste-via-conversion.md
@@ -1,0 +1,552 @@
+# Drag / paste into a spot via conversion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:executing-plans to implement this plan task-by-task (inline, no subagents — per user instruction). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a block drag/paste into a container it doesn't natively fit by converting it to a type the container accepts — auto-convert when one option, chooser popup when several.
+
+**Architecture:** A static `conversionMap` (`{type: [reachableTypes]}`) built admin-side from the existing `fieldMappings` graph and shipped to the iframe on `INITIAL_DATA`. The iframe's drag-acceptance gate (`hydra.src.js:9073`) consults a shared pure `acceptableAt` predicate to offer convert-reachable spots. The admin re-resolves on drop/paste with `getConvertibleTypes` and converts (reusing the existing chooser overlay for the multi-option popup, ask-first/atomic).
+
+**Tech stack:** React admin (`packages/volto-hydra`), Volto-free shared modules + bundled iframe bridge (`packages/hydra-js`, esbuild `hydra.src.js` → `hydra.js`). Tests: jest (hydra-js), vitest (admin utils), Playwright admin-mock (integration).
+
+**Spec:** `docs/superpowers/specs/2026-07-18-dnd-paste-via-conversion-design.md`
+
+---
+
+## File structure
+
+**Create:**
+- `packages/hydra-js/conversionMap.js` — Volto-free pure module: `acceptableAt(type, allowed, isMulti, conversionMap)`. Imported by both `hydra.src.js` and the admin, so the iframe and admin agree by construction.
+- `packages/hydra-js/conversionMap.test.js` — jest unit tests for `acceptableAt`.
+- `tests-playwright/integration/dnd-convert.spec.ts` — integration coverage.
+
+**Modify:**
+- `packages/volto-hydra/src/utils/schemaInheritance.js` — add `getConversionMap(blocksConfig)` next to `getConvertibleTypes` (~2012).
+- `packages/volto-hydra/src/utils/schemaInheritance.test.js` (or the existing vitest file) — unit test `getConversionMap`.
+- `packages/hydra-js/hydra.src.js` — store `this.conversionMap` from `INITIAL_DATA` (~3776); use `acceptableAt` at the drag gate (~9073).
+- `packages/volto-hydra/src/components/Iframe/View.jsx` — send `conversionMap` on the three `INITIAL_DATA` posts (~2021/3696/3784); extract `convertBlockInPlace` helper from `commitChooser` (~4236-4255); convert-on-drop in `MOVE_BLOCKS` (~2799); convert-on-paste in `handlePaste` (~951); add `pendingMove` handling to `commitChooser` (~4224).
+- `tests-playwright/fixtures/shared-block-schemas.js` — a small conversion graph + a container restricted to a convert-target.
+- `docs/custom-blocks.md` — note that DnD/paste offer convert-targets (short addition to the fieldMappings section).
+
+**Build note:** `hydra.src.js` edits are picked up live by admin-mock (loaded directly). The distributable `hydra.js` must be rebuilt (`pnpm --filter @volto-hydra/hydra-js build`) before committing / for bridge (react/nuxt) CI — do NOT rebuild before running admin-mock tests locally (memory: `feedback_no_rebuild_hydra`).
+
+---
+
+## Task 1: `getConversionMap` (admin, pure)
+
+**Files:**
+- Modify: `packages/volto-hydra/src/utils/schemaInheritance.js` (add export near `getConvertibleTypes:2012`)
+- Test: `packages/volto-hydra/src/utils/schemaInheritance.test.js`
+
+- [ ] **Step 1: Write the failing test** (append to the vitest file)
+
+```js
+import { getConversionMap } from './schemaInheritance';
+
+describe('getConversionMap', () => {
+  const cfg = {
+    a: { id: 'a', fieldMappings: { b: { x: 'x' } } },        // a -> b
+    b: { id: 'b', fieldMappings: { c: { y: 'y' } } },        // b -> c
+    c: { id: 'c', fieldMappings: {} },                        // sink
+    lone: { id: 'lone' },                                     // no fieldMappings
+  };
+  it('maps each source type to its full reachable set (BFS)', () => {
+    const m = getConversionMap(cfg);
+    expect(new Set(m.a)).toEqual(new Set(['b', 'c']));
+    expect(new Set(m.b)).toEqual(new Set(['c']));
+    expect(m.c || []).toEqual([]);
+  });
+  it('omits/empties types with no fieldMappings', () => {
+    const m = getConversionMap(cfg);
+    expect(m.lone || []).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`getConversionMap` undefined)
+
+Run: `pnpm exec vitest run packages/volto-hydra/src/utils/schemaInheritance.test.js -t getConversionMap`
+Expected: FAIL (not exported).
+
+- [ ] **Step 3: Implement** (in `schemaInheritance.js`, after `getConvertibleTypes`)
+
+```js
+/**
+ * Static map { sourceType: [reachableTypes] } over the fieldMappings conversion
+ * graph — the full reachable set, UNFILTERED by any container's allowedBlocks
+ * (the target filters at check time). Built once and shipped to the iframe so it
+ * can offer convert-reachable drop spots. Types with no reachable targets map to [].
+ */
+export function getConversionMap(blocksConfig) {
+  const map = {};
+  if (!blocksConfig) return map;
+  for (const sourceType of Object.keys(blocksConfig)) {
+    map[sourceType] = getConvertibleTypes(sourceType, blocksConfig).map((t) => t.type);
+  }
+  return map;
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pnpm exec vitest run packages/volto-hydra/src/utils/schemaInheritance.test.js -t getConversionMap`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/volto-hydra/src/utils/schemaInheritance.js packages/volto-hydra/src/utils/schemaInheritance.test.js
+git commit -m "feat(conversion): getConversionMap — static reachable-type map from fieldMappings"
+```
+
+---
+
+## Task 2: `acceptableAt` predicate (Volto-free, shared)
+
+**Files:**
+- Create: `packages/hydra-js/conversionMap.js`
+- Test: `packages/hydra-js/conversionMap.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+import { acceptableAt } from './conversionMap.js';
+
+const cmap = { a: ['b', 'c'], d: ['b'] }; // a→{b,c}, d→{b}
+
+describe('acceptableAt', () => {
+  test('unrestricted container accepts anything', () => {
+    expect(acceptableAt('a', null, false, cmap)).toBe(true);
+  });
+  test('native fit', () => {
+    expect(acceptableAt('a', ['a'], false, cmap)).toBe(true);
+  });
+  test('single block: one convertible option → accept', () => {
+    expect(acceptableAt('d', ['b'], false, cmap)).toBe(true);
+  });
+  test('single block: multiple convertible options → accept (popup)', () => {
+    expect(acceptableAt('a', ['b', 'c'], false, cmap)).toBe(true);
+  });
+  test('multi block: exactly one option → accept', () => {
+    expect(acceptableAt('a', ['b'], true, cmap)).toBe(true);   // only b in allowed
+  });
+  test('multi block: multiple options → reject (no popup chains)', () => {
+    expect(acceptableAt('a', ['b', 'c'], true, cmap)).toBe(false);
+  });
+  test('not reachable → reject', () => {
+    expect(acceptableAt('a', ['z'], false, cmap)).toBe(false);
+  });
+  test('no conversion map → native only', () => {
+    expect(acceptableAt('a', ['b'], false, undefined)).toBe(false);
+    expect(acceptableAt('a', ['a'], false, undefined)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `cd packages/hydra-js && NODE_OPTIONS='--experimental-vm-modules' npx jest conversionMap.test.js`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement** `packages/hydra-js/conversionMap.js`
+
+```js
+/**
+ * Can a block of `type` be dropped/pasted into a container whose sibling types
+ * are `allowed`, given the static `conversionMap` ({type:[reachableTypes]})?
+ *
+ * - unrestricted container (allowed nullish) → always
+ * - native fit (type ∈ allowed) → always
+ * - else options = conversionMap[type] ∩ allowed:
+ *     empty            → no
+ *     single block     → yes (1 = auto-convert, >1 = popup; both are valid spots)
+ *     multi block      → yes only if exactly one option (auto-only, no popup chains)
+ *
+ * Shared verbatim by the iframe drag gate and (implicitly, by construction) the
+ * admin's drop resolution, so a spot the iframe offers is never rejected on drop.
+ */
+export function acceptableAt(type, allowed, isMulti, conversionMap) {
+  if (allowed == null) return true;
+  if (allowed.includes(type)) return true;
+  const reachable = (conversionMap && conversionMap[type]) || [];
+  const options = reachable.filter((t) => allowed.includes(t));
+  if (options.length === 0) return false;
+  if (isMulti) return options.length === 1;
+  return true;
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `cd packages/hydra-js && NODE_OPTIONS='--experimental-vm-modules' npx jest conversionMap.test.js`
+Expected: PASS (8 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hydra-js/conversionMap.js packages/hydra-js/conversionMap.test.js
+git commit -m "feat(conversion): acceptableAt — shared drop-acceptance predicate"
+```
+
+---
+
+## Task 3: Ship `conversionMap` admin → iframe
+
+No unit test (pure wiring); covered end-to-end by Task 5's integration test. Keep this task minimal.
+
+**Files:**
+- Modify: `packages/volto-hydra/src/components/Iframe/View.jsx` (3 INITIAL_DATA posts)
+- Modify: `packages/hydra-js/hydra.src.js` (INITIAL_DATA handler ~3776, field init ~246)
+
+- [ ] **Step 1: Admin — build the map once and attach it.** Near the top of the component (where `blocksConfig` is in scope), memoize:
+
+```js
+const conversionMap = useMemo(
+  () => getConversionMap(config.blocks.blocksConfig),
+  [],
+);
+```
+
+Add `getConversionMap` to the `schemaInheritance` import. On EACH of the three `type: 'INITIAL_DATA'` postMessages (~2021, ~3696, ~3784), add `conversionMap,` to the message object.
+
+- [ ] **Step 2: Iframe — store it.** In `hydra.src.js` constructor (~246) add `this.conversionMap = {};`. In the `INITIAL_DATA` handler (~3776, alongside `setFormDataFromAdmin(...)`):
+
+```js
+if (e.data.conversionMap) this.conversionMap = e.data.conversionMap;
+```
+
+- [ ] **Step 3: Sanity check** — start admin-mock, open a page, and confirm in the iframe console `bridge.conversionMap` (or a temporary log) is populated. No automated assertion here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/volto-hydra/src/components/Iframe/View.jsx packages/hydra-js/hydra.src.js
+git commit -m "feat(conversion): ship conversionMap to the iframe on INITIAL_DATA"
+```
+
+---
+
+## Task 4: Test fixtures — a conversion graph + a restricted container
+
+**Files:**
+- Modify: `tests-playwright/fixtures/shared-block-schemas.js`
+- (Content fixture) a page with a draggable source block + a restricted container.
+
+- [ ] **Step 1: Inspect what convertible types already exist** in the mock schemas so we reuse rather than invent where possible:
+
+Run: `grep -n 'fieldMappings\|allowedBlocks' tests-playwright/fixtures/shared-block-schemas.js`
+
+- [ ] **Step 2: Add a minimal deterministic graph.** Ensure there is:
+  - a source block type `S` draggable at page level (in the page `allowedBlocks`),
+  - `S.fieldMappings` reaching a target type `T` (single option) and, separately, a type reachable to two targets `T1`/`T2` for the popup test,
+  - a container block `C` (reuse `grid`/columns if it already restricts, else add) whose region `allowedBlocks: ['T']` (single) — and a second container/region `allowedBlocks: ['T1','T2']` for the popup case.
+
+  Prefer reusing existing types (e.g. slate/@default, teaser, facet types). Only add toy types if no existing pair fits. Keep names obvious (`convSource`, `convTargetA`, `convTargetB`) if adding.
+
+- [ ] **Step 3: Add the content fixture** under `tests-playwright/fixtures/content/dnd-convert-page/data.json`: page with one `S` block in `items` and one restricted container `C` (seeded empty) in `items`.
+
+- [ ] **Step 4: Commit** (fixtures only; no behavior yet)
+
+```bash
+git add tests-playwright/fixtures/shared-block-schemas.js tests-playwright/fixtures/content/dnd-convert-page
+git commit -m "test(conversion): fixtures — conversion graph + restricted container"
+```
+
+---
+
+## Task 5: Convert-on-drop, single option (auto)
+
+**Files:**
+- Modify: `packages/hydra-js/hydra.src.js` (drag gate ~9073)
+- Modify: `packages/volto-hydra/src/components/Iframe/View.jsx` (extract `convertBlockInPlace`; MOVE_BLOCKS ~2799)
+- Test: `tests-playwright/integration/dnd-convert.spec.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+import { test, expect } from '../fixtures';
+import { AdminUIHelper } from '../helpers/AdminUIHelper';
+
+test('drag a block into a container that only accepts a convert-target auto-converts it', async ({ page }) => {
+  const helper = new AdminUIHelper(page);
+  await helper.login();
+  await helper.navigateToEdit('/dnd-convert-page');
+  // Drag the source block onto the restricted container (empty seed).
+  await helper.dragBlockOntoBlock('conv-source-1', 'restricted-container-empty-seed');
+  // After drop: a block of the target type now lives in the container.
+  await expect
+    .poll(async () => helper.getBlockTypeInContainer('restricted-container-1'))
+    .toBe('convTargetA');
+});
+```
+
+(Use the existing DnD helper — inspect `AdminUIHelper` for the drag method name, e.g. `dragAndDropBlock`/`dragBlockTo`; adapt the assertion helper or read formData via an existing helper.)
+
+- [ ] **Step 2: Run — expect FAIL** (drop rejected today; container stays empty)
+
+Run: `pnpm exec playwright test tests-playwright/integration/dnd-convert.spec.ts --project=admin-mock`
+Expected: FAIL.
+
+- [ ] **Step 3a: Iframe drag gate** — `hydra.src.js:9073`, import `acceptableAt` at top (`import { acceptableAt } from './conversionMap.js';`) and replace:
+
+```js
+const allTypesAllowed = !allowedSiblingTypes || draggedBlockTypes.length === 0 ||
+  draggedBlockTypes.every((type) => allowedSiblingTypes.includes(type));
+```
+
+with:
+
+```js
+const isMulti = draggedBlockTypes.length > 1;
+const allTypesAllowed = draggedBlockTypes.length === 0 ||
+  draggedBlockTypes.every((type) =>
+    acceptableAt(type, allowedSiblingTypes, isMulti, this.conversionMap));
+```
+
+- [ ] **Step 3b: Extract shared convert helper** in `View.jsx` from `commitChooser` (~4236-4255):
+
+```js
+// Convert a block to newType IN PLACE (container-aware), returning new formData.
+const convertBlockInPlace = (props, bpm, blockId, newType) => {
+  const blockData = getBlockById(props, bpm, blockId);
+  if (!blockData) return props;
+  const hasChildren = getContainerRegionDescriptors(blockData['@type'], blocksConfig, intl, blockData)
+    .some((d) => getChildBlockEntries(blockData, d).length > 0);
+  if (hasChildren) {
+    return convertContainerBlock(props, bpm, blockId, newType, blocksConfig, intl);
+  }
+  const typeFieldName = bpm?.[blockId]?.typeField || '@type';
+  const newBlockData = convertBlockType(blockData, newType, blocksConfig, typeFieldName, intl);
+  return updateBlockById(props, bpm, blockId, newBlockData);
+};
+```
+
+Refactor `commitChooser`'s convert branch to call it (no behavior change; keep tests green).
+
+- [ ] **Step 3c: MOVE_BLOCKS convert-on-drop** — `View.jsx:2799`. Replace the hard reject with resolution. For each block compute `options = getConvertibleTypes(type, blocksConfig, targetAllowedTypes).map(t=>t.type)`:
+  - native → leave as-is;
+  - `options.length === 1` → `newFormData = convertBlockInPlace(newFormData, currentBpm, bid, options[0])` (rebuild bpm) BEFORE the move loop;
+  - single-block & `options.length > 1` → open the popup (Task 6) and RETURN (don't move here);
+  - `options.length === 0` && not native → keep the existing reject `break`.
+
+  Do the conversions first (updating formData + a rebuilt pathMap), THEN run the existing move loop so the moved block already has the accepted type.
+
+- [ ] **Step 4: Run — expect PASS** (single-option case)
+
+Run: `pnpm exec playwright test tests-playwright/integration/dnd-convert.spec.ts --project=admin-mock -g "auto-converts"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hydra-js/hydra.src.js packages/volto-hydra/src/components/Iframe/View.jsx tests-playwright/integration/dnd-convert.spec.ts
+git commit -m "feat(conversion): drag into a restricted container auto-converts (single option)"
+```
+
+---
+
+## Task 6: Convert-on-drop, multiple options (ask-first popup)
+
+**Files:**
+- Modify: `packages/volto-hydra/src/components/Iframe/View.jsx` (`chooser` pendingMove; `commitChooser` ~4224; MOVE_BLOCKS branch from Task 5)
+- Test: `tests-playwright/integration/dnd-convert.spec.ts`
+
+- [ ] **Step 1: Write failing tests** — popup appears + choose converts&moves as one undo; cancel leaves the block at origin.
+
+```ts
+test('drag into a container with multiple convert-targets opens the chooser and commits atomically', async ({ page }) => {
+  const helper = new AdminUIHelper(page);
+  await helper.login();
+  await helper.navigateToEdit('/dnd-convert-page');
+  await helper.dragBlockOntoBlock('conv-source-1', 'multi-container-empty-seed');
+  await expect(page.locator('.blocks-chooser')).toBeVisible();       // ask-first: no move yet
+  expect(await helper.getBlockTypeInContainer('multi-container-1')).toBeNull();
+  await page.locator('.blocks-chooser').getByText('convTargetB').click();
+  await expect.poll(() => helper.getBlockTypeInContainer('multi-container-1')).toBe('convTargetB');
+  // one undo restores both the move and the conversion
+  await helper.undo();
+  await expect.poll(() => helper.getBlockTypeInContainer('multi-container-1')).toBeNull();
+});
+
+test('cancelling the convert chooser leaves the block where it was', async ({ page }) => {
+  const helper = new AdminUIHelper(page);
+  await helper.login();
+  await helper.navigateToEdit('/dnd-convert-page');
+  await helper.dragBlockOntoBlock('conv-source-1', 'multi-container-empty-seed');
+  await expect(page.locator('.blocks-chooser')).toBeVisible();
+  await page.mouse.click(5, 5); // outside → dismiss
+  await expect(page.locator('.blocks-chooser')).toBeHidden();
+  expect(await helper.getBlockTypeInContainer('multi-container-1')).toBeNull();
+  // source still present/unchanged at page level
+  expect(await helper.blockExists('conv-source-1')).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm exec playwright test tests-playwright/integration/dnd-convert.spec.ts --project=admin-mock -g "multiple convert-targets|cancelling"`
+Expected: FAIL.
+
+- [ ] **Step 3a: Open the popup from MOVE_BLOCKS** (the `options.length > 1`, single-block branch from Task 5):
+
+```js
+setChooser({
+  kind: 'convert',
+  blockId: moveBlockId,
+  allowedBlocks: options,                 // BlockChooser lists only these
+  pendingMove: { targetBlockId, insertAfter, targetParentId, replaceTargetId },
+});
+break; // do not move now — ask first
+```
+
+- [ ] **Step 3b: `commitChooser` honors `pendingMove`** (~4256, convert branch). After computing `updatedProperties = convertBlockInPlace(properties, bpm, chooser.blockId, newType)`, if `chooser.pendingMove` is set, run the move on the converted formData and feed ONE `onChangeFormData`:
+
+```js
+let out = convertBlockInPlace(properties, bpm, chooser.blockId, newType);
+if (chooser.pendingMove) {
+  const bpm2 = buildBlockPathMap(out, blocksConfig, intl);
+  const pm = chooser.pendingMove;
+  const srcParent = bpm2[chooser.blockId]?.parentId || null;
+  out = moveBlockBetweenContainers(
+    out, bpm2, chooser.blockId, pm.targetBlockId, pm.insertAfter,
+    srcParent, pm.targetParentId, blocksConfig, intl,
+  ) || out;
+}
+onChangeFormData(out);            // single update → single undo
+```
+
+(Dismiss already no-ops via the existing outside-click effect → `setChooser(null)`, and nothing was moved, so cancel needs no rollback.)
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pnpm exec playwright test tests-playwright/integration/dnd-convert.spec.ts --project=admin-mock -g "multiple convert-targets|cancelling"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/volto-hydra/src/components/Iframe/View.jsx tests-playwright/integration/dnd-convert.spec.ts
+git commit -m "feat(conversion): multi-option drop opens the chooser, converts+moves atomically"
+```
+
+---
+
+## Task 7: Convert-on-paste
+
+**Files:**
+- Modify: `packages/volto-hydra/src/components/Iframe/View.jsx` (`handlePaste` ~951)
+- Test: `tests-playwright/integration/dnd-convert.spec.ts`
+
+- [ ] **Step 1: Write failing test** — copy/cut a source block, paste into the restricted container → auto-convert (single); paste into the multi container → chooser.
+
+```ts
+test('pasting a block into a restricted container auto-converts it', async ({ page }) => {
+  const helper = new AdminUIHelper(page);
+  await helper.login();
+  await helper.navigateToEdit('/dnd-convert-page');
+  await helper.selectBlock('conv-source-1');
+  await helper.copyBlock();                    // or cut
+  await helper.selectBlock('restricted-container-empty-seed');
+  await helper.pasteBlock();
+  await expect.poll(() => helper.getBlockTypeInContainer('restricted-container-1')).toBe('convTargetA');
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm exec playwright test tests-playwright/integration/dnd-convert.spec.ts --project=admin-mock -g "pasting"`
+Expected: FAIL (paste blocked today).
+
+- [ ] **Step 3: Implement** — in `handlePaste` (~951), replace the all-or-nothing reject with per-block resolution against `allowedTypes`:
+  - native → keep;
+  - `options.length === 1` → convert the clone to `options[0]` before insertion (`convertBlockInPlace` on the staged formData, or convert the block data in `cloneWithIds` via `convertBlockType`);
+  - single pasted block & `options.length > 1` → `setChooser({ kind:'convert', ..., pendingPaste })` (mirror `pendingMove`; commit path inserts then converts). *(If time-boxing, the single-block-multi-option paste popup can reuse the same `pendingMove` mechanism by inserting first then converting; keep atomic.)*
+  - `options.length === 0` && not native → keep the existing reject `return`.
+  - multi-paste → auto-only (no popup): drop any block that would need a popup, log it.
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pnpm exec playwright test tests-playwright/integration/dnd-convert.spec.ts --project=admin-mock -g "pasting"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/volto-hydra/src/components/Iframe/View.jsx tests-playwright/integration/dnd-convert.spec.ts
+git commit -m "feat(conversion): paste into a restricted container converts (auto / popup)"
+```
+
+---
+
+## Task 8: Multi-block auto-only
+
+**Files:**
+- Test: `tests-playwright/integration/dnd-convert.spec.ts` (behavior already implemented via `acceptableAt` isMulti + Task 5 loop)
+
+- [ ] **Step 1: Write test** — select two source blocks each with exactly one convert-target → drag into the restricted container → both auto-convert. Then a case where one selected block has multiple options → the container is NOT a valid drop (indicator not offered / drop rejected), asserting native-only fallback.
+
+- [ ] **Step 2: Run — expect it to PASS already** (if `acceptableAt(isMulti)` + the drop loop are correct). If the multi-option member is NOT rejected, fix the MOVE_BLOCKS loop to skip/reject a batch block whose `options.length !== 1 && !native`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests-playwright/integration/dnd-convert.spec.ts packages/volto-hydra/src/components/Iframe/View.jsx
+git commit -m "test(conversion): multi-block drag auto-converts single-option members only"
+```
+
+---
+
+## Task 9: Regression + rebuild bundle
+
+- [ ] **Step 1: Native DnD/paste regression** — the existing specs must stay green:
+
+Run: `pnpm exec playwright test tests-playwright/integration/drag-and-drop.spec.ts --project=admin-mock`
+Expected: PASS (esp. `:461`, `:496`, `:26`).
+
+- [ ] **Step 2: Unit suites**
+
+Run: `cd packages/hydra-js && NODE_OPTIONS='--experimental-vm-modules' npx jest conversionMap` and `pnpm exec vitest run packages/volto-hydra/src/utils/schemaInheritance.test.js`
+Expected: PASS.
+
+- [ ] **Step 3: Rebuild the distributable bundle** (for bridge/react/nuxt CI which loads built `hydra.js`):
+
+Run: `pnpm --filter @volto-hydra/hydra-js build`
+Then `git add packages/hydra-js/hydra.js packages/hydra-js/hydra.js.map`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "build(hydra-js): rebuild bundle with convert-drop acceptance"
+```
+
+---
+
+## Task 10: Docs
+
+**Files:**
+- Modify: `docs/custom-blocks.md` (fieldMappings / conversion section)
+
+- [ ] **Step 1: Add a short paragraph** under the conversion section: dragging or pasting a block into a container that only accepts a *convertible* type now converts it on drop — auto when one target type is reachable, a chooser popup when several; multi-block and mobile (cut/paste) are auto-only. Keep it brief (memory: `feedback_concise_docs`).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/custom-blocks.md
+git commit -m "docs(conversion): DnD/paste offer convert-reachable destinations"
+```
+
+---
+
+## Verification (whole feature)
+
+1. `cd packages/hydra-js && NODE_OPTIONS='--experimental-vm-modules' npx jest conversionMap` — green.
+2. `pnpm exec vitest run packages/volto-hydra/src/utils/schemaInheritance.test.js` — green.
+3. `pnpm exec playwright test tests-playwright/integration/dnd-convert.spec.ts --project=admin-mock` — all green.
+4. `pnpm exec playwright test tests-playwright/integration/drag-and-drop.spec.ts --project=admin-mock` — no regression.
+5. Bundle rebuilt; push branch, open PR (separate from #256). Full suite on CI (don't run large suites locally — memory `feedback_ci_for_large_suites`).
+
+## Risks / watch-items
+
+- **Iframe/admin agreement:** iframe uses `acceptableAt(conversionMap)`, admin uses `getConvertibleTypes(...allowed)`. They agree because `conversionMap[t] = getConvertibleTypes(t)` unfiltered, `∩ allowed` = filtered. Keep both derived from the same graph; don't hand-edit one.
+- **Atomicity:** convert+move must be ONE `onChangeFormData` (Task 6 Step 3b) — verify undo is single-step in the test.
+- **Rebuild:** don't rebuild `hydra.js` before admin-mock runs (live-reload uses `hydra.src.js`); DO rebuild before pushing (bridge CI uses the bundle).
+- **Empty-seed anchor:** a restricted container drop-target needs a real `data-block-uid` anchor — the seeded `empty` placeholder provides it (existing behavior); the convert path reuses the same shade/replace flow.

--- a/docs/superpowers/specs/2026-07-18-dnd-paste-via-conversion-design.md
+++ b/docs/superpowers/specs/2026-07-18-dnd-paste-via-conversion-design.md
@@ -1,0 +1,161 @@
+# Drag / paste into a spot via conversion — design
+
+**Status:** approved (brainstorm), pre-implementation
+**Date:** 2026-07-18
+**Scope:** separate PR from the copy-from-target work (#256).
+
+## Problem
+
+Today a block can only be dragged (or pasted) into a container whose
+`allowedBlocks` already admits its `@type`. If the type isn't allowed, the drop
+indicator is hidden during drag (`hydra.js`) and the move/paste is hard-rejected
+in the admin (`View.jsx`). But Hydra already has a **conversion graph** over
+`fieldMappings`: many blocks can be converted into one another. We should let a
+block drop into a spot it doesn't natively fit **by converting it** to a type the
+spot accepts.
+
+This makes drag-and-drop (and paste) offer *more* valid destinations: any spot
+reachable via an existing `fieldMappings` conversion.
+
+## Decisions (from brainstorming)
+
+1. **Indicators are identical.** A convert-drop spot looks exactly like a
+   native-fit spot; conversion happens transparently on drop. No new drag chrome.
+2. **Auto-convert when one option, popup when several.** If the source can
+   convert to exactly one allowed type, convert silently. If multiple allowed
+   target types are reachable, show the normal conversion chooser popup.
+3. **Ask-first, commit atomically (popup case).** On release over a
+   multi-option spot, show the popup *without moving*. Choosing a type performs
+   convert + move as a single `formData` update (one undo). Dismissing is a
+   no-op — the block never leaves its origin, so a container never briefly holds
+   an invalid-typed block.
+4. **Multi-block = auto-convert only, no popup chains.** A multi-block selection
+   may drop into a spot only where every block is either natively allowed or has
+   exactly one convertible target. If any block would need a popup, that spot
+   stays native-only for the batch.
+5. **Mobile via cut/paste.** Mobile chevron/edge move (`_computeEdgePlan`) keeps
+   native-only targets. Conversion on mobile is reached through cut → paste,
+   which this PR makes convert-aware. No new mobile geometry.
+6. **No data migration.** Pure interaction/feature addition.
+
+## Existing machinery (reused, not rebuilt)
+
+- **Drag validity (iframe):** `hydra.js:7439-7471` walks up the parent chain for
+  a container whose `allowedSiblingTypes` includes every dragged type; if none,
+  it hides the indicator and rejects the spot. This is the single rejection point.
+- **Drop re-validation (admin):** `View.jsx` `MOVE_BLOCKS` handler `:2799-2808`
+  re-checks `allowedBlocks` and breaks (hard reject) on a disallowed type.
+- **Paste re-validation (admin):** `View.jsx` `handlePaste` `:959` — same gate.
+- **Conversion graph:** `getConvertibleTypes(sourceType, blocksConfig,
+  allowedTypes)` (`schemaInheritance.js:2012`) BFS's `fieldMappings` and returns
+  the allowed types a source can convert into.
+- **Conversion op:** `convertContainerBlock(formData, blockPathMap, blockId,
+  targetType, blocksConfig, intl)` (`blockPath.js:1178`).
+- **Chooser overlay:** `chooser` state in `View.jsx` (`kind: 'convert' | 'wrap'`)
+  rendered via `BlockChooser`. The natural home for the multi-option popup.
+
+## Design
+
+### 1. A static conversion map to the iframe
+
+New pure helper (admin-side, lives with the graph):
+
+```js
+// { [sourceType]: string[] }  — full reachable set, unfiltered by allowedBlocks
+getConversionMap(blocksConfig)
+```
+
+Each value is `getConvertibleTypes(sourceType, blocksConfig)` mapped to type
+names (no `allowedTypes` filter — the *target's* `allowedBlocks` filters at check
+time). Computed once at init; recomputed only when `blocksConfig` changes. Sent
+to the iframe in the payload that already carries config / `blockPathMap`.
+
+Rationale: the graph stays a single source of truth in the admin; the iframe
+does a cheap set-membership check; the map is small and static.
+
+### 2. Iframe accepts convert-reachable spots
+
+Extract the acceptance test into a shared pure predicate:
+
+```js
+// options = (conversionMap[type] || []) ∩ allowed
+acceptableAt(type, allowed, isMulti, conversionMap):
+  if !allowed            -> true          // unrestricted container
+  if allowed.includes(type) -> true       // native fit
+  if options.length === 0 -> false        // not reachable
+  if isMulti             -> options.length === 1   // batch: auto-only
+  return true                             // single block: 1=auto, >1=popup
+```
+
+Replace the inline `allTypesAllowed` computation at `hydra.js:7442` with
+`draggedBlockTypes.every(t => acceptableAt(t, allowedSiblingTypes, isMulti,
+conversionMap))`, `isMulti = draggedBlockTypes.length > 1`. The walk-up loop and
+the empty-container "shade" branch (`findOnlyEmptyChildUid`) are unchanged — they
+sit below this predicate, so convert-drops into empty containers fall out for
+free.
+
+### 3. Admin converts on drop (`MOVE_BLOCKS`)
+
+Replace the hard reject at `View.jsx:2799` with per-block resolution against
+`targetAllowedTypes`:
+
+- native (`type ∈ allowed`) → move as today.
+- `options = getConvertibleTypes(type, blocksConfig, targetAllowedTypes)`:
+  - `length === 0` → reject (unchanged behaviour).
+  - `length === 1` → auto-convert to `options[0]`, then move.
+  - single block & `length > 1` → **ask first**: stash a `pendingMove`
+    (`{ targetBlockId, insertAfter, targetParentId, replaceTargetId }`) on the
+    `chooser` (`kind: 'convert'`), show `BlockChooser` scoped to `options`. On
+    select → `convertContainerBlock` then `moveBlockBetweenContainers` in one
+    `formData` chain (one undo). On dismiss → no-op.
+- multi-block: each block auto-converts to its single option or is native; a
+  block that would need a popup is re-rejected (the iframe won't have offered it,
+  but the admin stays authoritative).
+
+The post-move `applyBlockDefaultsWithContext` pass already runs and settles the
+converted block's neighbour-derived fields.
+
+### 4. Admin converts on paste (`handlePaste`)
+
+Same resolution against the container's `allowedBlocks`: auto-convert
+single-option pasted blocks; a single pasted block with multiple options opens
+the same ask-first chooser; multi-paste is auto-only. This is the path mobile
+uses (cut → paste), so mobile gains conversion without touching chevron geometry.
+
+## Testing (TDD — red first)
+
+- **Unit:**
+  - `getConversionMap` — reachable sets for a small `fieldMappings` graph.
+  - `acceptableAt` — truth table: native / single-convert / multi auto-only /
+    reject / unrestricted. Pure and shared by iframe + admin.
+- **Integration (Playwright, admin-mock):**
+  - Drag into a restricted container that admits only a convert-*target* →
+    drop auto-converts (single option); block is now the target type, in place.
+  - Drag into a container with multiple convertible options → chooser popup →
+    choose → convert+move is a single undo.
+  - Popup cancel → block unchanged, still at origin.
+  - Paste a block into a restricted container → auto-convert.
+  - Multi-block drag where every block has one option → all auto-convert; a
+    member with multiple options keeps the spot native-only (not offered).
+  - Existing native drag/paste specs stay green (no regression).
+- **Fixtures:** a small conversion graph (reuse `@default` / existing convertible
+  types) + a container whose `allowedBlocks` admits only a convert-target of a
+  draggable source.
+
+## Scope guardrails / non-goals
+
+- Identical indicators — no new drag chrome.
+- Mobile chevron move stays native-only (conversion via cut/paste only).
+- Convert popup is single-block only; multi-block is auto-convert only.
+- No data migration; no changes to the conversion graph semantics.
+
+## Risks
+
+- **Iframe/admin agreement.** The iframe's `acceptableAt` must match the admin's
+  drop resolution or a spot could show then reject. Mitigated by sharing the pure
+  predicate and by the admin filtering with the same `getConvertibleTypes`.
+- **Atomic convert+move.** Convert then move must be one `formData` update so undo
+  is single-step and the intermediate never persists. Chain both before the
+  single `onChangeFormData`.
+- **`convertContainerBlock` on non-container blocks.** Confirm it converts a plain
+  block (not only containers) via `fieldMappings`; generalize/rename if needed.

--- a/docs/what-editors-will-experience/adding-and-moving-blocks.md
+++ b/docs/what-editors-will-experience/adding-and-moving-blocks.md
@@ -34,7 +34,7 @@ Each selected block has a **drag handle** in the Quanta toolbar above it. Click 
 - A **shaded overlay** highlights the whole drop target when you hover over an empty container — dropping there places the block as the container's first child (replacing the empty placeholder rather than landing as a sibling).
 - The page auto-scrolls when you drag near the top or bottom of the viewport.
 
-Drop targets are filtered by `allowedBlocks` — you can't drop into a region that doesn't accept this block type. The line/shade indicator only appears over valid drop targets.
+Drop targets are filtered by `allowedBlocks` — the line/shade indicator only appears where the block can land. This **includes regions that don't accept the block directly but accept a type it can convert to**: dropping there converts the block on the fly — silently when only one target type is possible, or via a small chooser when several are (pick one, or dismiss to cancel the move). So a "Text" block can be dropped into a region that only takes "Cards" and it becomes a Card on drop.
 
 ### Reordering from the sidebar
 
@@ -48,7 +48,7 @@ Standard keyboard shortcuts work on the selected block(s):
 - `Cmd/Ctrl+X` — cut (block disappears from the original spot when you paste)
 - `Cmd/Ctrl+V` — paste at the current selection
 
-This works across pages — copy a block on one page, navigate to another, paste.
+This works across pages — copy a block on one page, navigate to another, paste. Paste also **converts** like drag-and-drop: pasting into a region that only accepts a type the block can convert to converts it on paste. On touch devices, where dragging between distant spots is awkward, cut-and-paste is the easiest way to move (and convert) a block.
 
 ### Block-mode keyboard
 

--- a/packages/hydra-js/conversionMap.js
+++ b/packages/hydra-js/conversionMap.js
@@ -1,0 +1,26 @@
+/**
+ * Can a block of `type` be dropped/pasted into a container whose accepted
+ * sibling types are `allowed`, given the static `conversionMap`
+ * ({ sourceType: [reachableTypes] })?
+ *
+ * - unrestricted container (allowed nullish) → always
+ * - native fit (type ∈ allowed) → always
+ * - else options = conversionMap[type] ∩ allowed:
+ *     empty        → no
+ *     single block → yes (1 = auto-convert, >1 = popup; both are valid spots)
+ *     multi block  → yes only if exactly one option (auto-only, no popup chains)
+ *
+ * Shared by the iframe drag gate and (by construction) the admin's drop
+ * resolution — a spot the iframe offers is never rejected on drop, because the
+ * admin's `getConvertibleTypes(type, cfg, allowed)` yields the same options set
+ * as `conversionMap[type] ∩ allowed`.
+ */
+export function acceptableAt(type, allowed, isMulti, conversionMap) {
+  if (allowed == null) return true;
+  if (allowed.includes(type)) return true;
+  const reachable = (conversionMap && conversionMap[type]) || [];
+  const options = reachable.filter((t) => allowed.includes(t));
+  if (options.length === 0) return false;
+  if (isMulti) return options.length === 1;
+  return true;
+}

--- a/packages/hydra-js/conversionMap.test.js
+++ b/packages/hydra-js/conversionMap.test.js
@@ -1,0 +1,41 @@
+import { acceptableAt } from './conversionMap.js';
+
+// cmap: a reaches {b,c}; d reaches {b}
+const cmap = { a: ['b', 'c'], d: ['b'] };
+
+describe('acceptableAt', () => {
+  test('unrestricted container accepts anything', () => {
+    expect(acceptableAt('a', null, false, cmap)).toBe(true);
+    expect(acceptableAt('a', undefined, false, cmap)).toBe(true);
+  });
+
+  test('native fit', () => {
+    expect(acceptableAt('a', ['a'], false, cmap)).toBe(true);
+  });
+
+  test('single block: one convertible option → accept', () => {
+    expect(acceptableAt('d', ['b'], false, cmap)).toBe(true);
+  });
+
+  test('single block: multiple convertible options → accept (popup)', () => {
+    expect(acceptableAt('a', ['b', 'c'], false, cmap)).toBe(true);
+  });
+
+  test('multi block: exactly one option → accept', () => {
+    // only b is in allowed → single option → auto-convertible for a batch
+    expect(acceptableAt('a', ['b'], true, cmap)).toBe(true);
+  });
+
+  test('multi block: multiple options → reject (no popup chains)', () => {
+    expect(acceptableAt('a', ['b', 'c'], true, cmap)).toBe(false);
+  });
+
+  test('not reachable → reject', () => {
+    expect(acceptableAt('a', ['z'], false, cmap)).toBe(false);
+  });
+
+  test('no conversion map → native only', () => {
+    expect(acceptableAt('a', ['b'], false, undefined)).toBe(false);
+    expect(acceptableAt('a', ['a'], false, undefined)).toBe(true);
+  });
+});

--- a/packages/hydra-js/hydra.src.js
+++ b/packages/hydra-js/hydra.src.js
@@ -28,6 +28,7 @@ import {
   resolveFieldPath as resolveFieldPathHelper,
 } from '@volto-hydra/helpers';
 import { expelAllowedTypes, findOnlyEmptyChildUid } from './containerOps.js';
+import { acceptableAt } from './conversionMap.js';
 
 /**
  * This IS a large file and it needs to be written in one file so for better understanding and
@@ -9072,9 +9073,13 @@ export class Bridge {
             const targetPathInfo = this.blockPathMap?.[validDropTargetUid];
             const allowedSiblingTypes = targetPathInfo?.allowedSiblingTypes;
 
-            // Check if drop is allowed here - all dragged block types must be allowed
-            const allTypesAllowed = !allowedSiblingTypes || draggedBlockTypes.length === 0 ||
-              draggedBlockTypes.every(type => allowedSiblingTypes.includes(type));
+            // Check if drop is allowed here — each dragged type must be allowed
+            // natively OR reachable via conversion (single-block: 1=auto, >1=popup;
+            // multi-block: auto-only). See acceptableAt / conversionMap.
+            const isMulti = draggedBlockTypes.length > 1;
+            const allTypesAllowed = draggedBlockTypes.length === 0 ||
+              draggedBlockTypes.every(type =>
+                acceptableAt(type, allowedSiblingTypes, isMulti, this.conversionMap));
             if (allTypesAllowed) {
               // Drop is allowed at this level
               break;

--- a/packages/hydra-js/hydra.src.js
+++ b/packages/hydra-js/hydra.src.js
@@ -244,6 +244,7 @@ export class Bridge {
     this.scrollTimeout = null; // Timer for scroll debouncing
     this.expectedSelectionFromAdmin = null; // Selection we're restoring from Admin - suppress sending it back
     this.blockPathMap = {}; // Maps blockUid -> { path: [...], parentId: string|null }
+    this.conversionMap = {}; // { sourceType: [reachableTypes] } — for convert-reachable drop spots
     this.voltoConfig = null; // Store voltoConfig for allowedBlocks checking
     // Track active prospective inline element (link/format with ZWS) for Chrome workaround.
     // Chrome always positions cursor outside <a> elements, unlike <span> for bold.
@@ -3776,6 +3777,8 @@ export class Bridge {
             if (e.data.type === 'INITIAL_DATA') {
               // Central method sets formData, lastReceivedFormData, and blockPathMap
               this.setFormDataFromAdmin(e.data.data, 'INITIAL_DATA', e.data.blockPathMap);
+              // Static conversion graph for convert-reachable drop spots (drag).
+              if (e.data.conversionMap) this.conversionMap = e.data.conversionMap;
 
               // Store Slate configuration for keyboard shortcuts and toolbar
               this.slateConfig = e.data.slateConfig || { hotkeys: {}, toolbarButtons: [] };

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -1153,13 +1153,6 @@ const Iframe = (props) => {
     [intl],
   );
 
-  // Static conversion graph ({ sourceType: [reachableTypes] }) shipped to the
-  // iframe on INITIAL_DATA so it can offer convert-reachable drop spots during a
-  // drag. Derived once from blocksConfig (which doesn't change at runtime).
-  const conversionMap = useMemo(
-    () => getConversionMap(config.blocks.blocksConfig),
-    [],
-  );
 
 
   // Trigger for template sync effect - INIT increments this when templates need loading
@@ -2030,7 +2023,7 @@ const Iframe = (props) => {
                 type: 'INITIAL_DATA',
                 data: resendFormWithDefaults,
                 blockPathMap: stripBlockPathMapForPostMessage(resendBlockPathMap),
-                conversionMap,
+                conversionMap: getConversionMap(config.blocks.blocksConfig),
                 selectedBlockUid: selectedBlock,
                 slateConfig: {
                   hotkeys: config.settings.slate?.hotkeys || {},
@@ -2802,23 +2795,53 @@ const Iframe = (props) => {
             ? getContainerFieldConfig(firstBlockId, currentBlockPathMap, currentFormData, blocksConfig, intl)
             : null;
 
-          // Check all block types are allowed in the target container
+          // Resolve each block against the target container's allowedBlocks:
+          // native fit, or convertible (auto when one target type; a single-block
+          // drag with several options opens the chooser — ask-first). A block that
+          // can't be placed rejects the whole move. Multi-block is auto-only.
           const targetContainerCfg = getContainerFieldConfig(targetBlockId, currentBlockPathMap, currentFormData, blocksConfig, intl);
           const targetAllowedTypes = targetContainerCfg?.allowedBlocks;
+          const dropConversions = {}; // bid -> type to convert to before moving
+          let rejectMove = false;
+          let deferredToChooser = false;
           if (targetAllowedTypes?.length > 0) {
-            const allAllowed = blocksToMove.every(bid => {
-              const blockData = getBlockById(currentFormData, currentBlockPathMap, bid);
-              return targetAllowedTypes.includes(blockData?.['@type']);
-            });
-            if (!allAllowed) {
-              log('MOVE_BLOCKS: blocked — block types not allowed in target container');
+            const singleDrag = blocksToMove.length === 1;
+            for (const bid of blocksToMove) {
+              const bType = getBlockById(currentFormData, currentBlockPathMap, bid)?.['@type'];
+              if (targetAllowedTypes.includes(bType)) continue; // native fit
+              const options = getConvertibleTypes(bType, blocksConfig, targetAllowedTypes).map((t) => t.type);
+              if (options.length === 1) {
+                dropConversions[bid] = options[0]; // auto-convert
+                continue;
+              }
+              if (options.length > 1 && singleDrag) {
+                // Ask-first: show the chooser; commitChooser converts + moves atomically.
+                setChooser({
+                  kind: 'convert',
+                  blockId: bid,
+                  allowedBlocks: options,
+                  pendingMove: { targetBlockId, insertAfter, targetParentId },
+                });
+                deferredToChooser = true;
+                break;
+              }
+              // 0 options, or a multi-option member of a multi-block batch → can't place.
+              log('MOVE_BLOCKS: blocked — type not allowed/convertible in target container');
+              rejectMove = true;
               break;
             }
           }
+          if (rejectMove || deferredToChooser) break;
 
           // Move all blocks in sequence, each one after the previous
           // Track insertAfter for each block (needed for template inheritance)
           let newFormData = currentFormData;
+          // Auto-convert (single-option) blocks BEFORE moving so each already
+          // fits the target container's allowedBlocks.
+          for (const [bid, toType] of Object.entries(dropConversions)) {
+            const cbpm = buildBlockPathMap(newFormData, config.blocks.blocksConfig, intl);
+            newFormData = convertBlockInPlace(newFormData, cbpm, bid, toType);
+          }
           let currentTarget = targetBlockId;
           let currentInsertAfter = insertAfter;
           const blockInsertAfterMap = {};
@@ -3706,7 +3729,7 @@ const Iframe = (props) => {
             type: 'INITIAL_DATA',
             data: formDataToSend,
             blockPathMap: stripBlockPathMapForPostMessage(blockPathMap),
-            conversionMap,
+            conversionMap: getConversionMap(config.blocks.blocksConfig),
             selectedBlockUid: selectedBlock,
             slateConfig: { hotkeys: config.settings.slate?.hotkeys || {}, toolbarButtons },
           }, origin);
@@ -3795,7 +3818,7 @@ const Iframe = (props) => {
           type: 'INITIAL_DATA',
           data: formDataToSend,
           blockPathMap: stripBlockPathMapForPostMessage(blockPathMap),
-          conversionMap,
+          conversionMap: getConversionMap(config.blocks.blocksConfig),
           selectedBlockUid: selectedBlock,
           slateConfig: { hotkeys: config.settings.slate?.hotkeys || {}, toolbarButtons },
         }, origin);
@@ -4233,6 +4256,24 @@ const Iframe = (props) => {
     }
   }, [iframeAllowedBlocks, selectedBlock, insertAndSelectBlock]);
 
+  // Convert a block to newType IN PLACE (container-aware), returning new formData.
+  // Container blocks (any region with children) go through convertContainerBlock
+  // so their children carry over; a childless block converts its own fields.
+  // Shared by the chooser commit and the auto-convert-on-drop/paste paths.
+  const convertBlockInPlace = (props, bpm, blockId, newType) => {
+    const blockData = getBlockById(props, bpm, blockId);
+    if (!blockData) return props;
+    const hasChildren = getContainerRegionDescriptors(
+      blockData['@type'], blocksConfig, intl, blockData,
+    ).some((d) => getChildBlockEntries(blockData, d).length > 0);
+    if (hasChildren) {
+      return convertContainerBlock(props, bpm, blockId, newType, blocksConfig, intl);
+    }
+    const typeFieldName = bpm?.[blockId]?.typeField || '@type';
+    const newBlockData = convertBlockType(blockData, newType, blocksConfig, typeFieldName, intl);
+    return updateBlockById(props, bpm, blockId, newBlockData);
+  };
+
   // Commits a chooser action (wrap or convert) once the user picks a target type.
   const commitChooser = (newType) => {
     if (!chooser) return;
@@ -4248,22 +4289,18 @@ const Iframe = (props) => {
       } else if (chooser.kind === 'convert') {
         const blockData = getBlockById(properties, bpm, chooser.blockId);
         if (blockData) {
-          const blockType = blockData['@type'];
-          // Children across ALL regions (blocks_layout + object_list), not just the default.
-          const hasChildren = blockType
-            ? getContainerRegionDescriptors(blockData['@type'], blocksConfig, intl, blockData).some(
-                (d) => getChildBlockEntries(blockData, d).length > 0,
-              )
-            : false;
-          let updatedProperties;
-          if (hasChildren) {
-            updatedProperties = convertContainerBlock(
-              properties, bpm, chooser.blockId, newType, blocksConfig, intl,
-            );
-          } else {
-            const typeFieldName = bpm?.[chooser.blockId]?.typeField || '@type';
-            const newBlockData = convertBlockType(blockData, newType, blocksConfig, typeFieldName, intl);
-            updatedProperties = updateBlockById(properties, bpm, chooser.blockId, newBlockData);
+          let updatedProperties = convertBlockInPlace(properties, bpm, chooser.blockId, newType);
+          // Ask-first drop: the block hasn't moved yet. Move it (now that it's the
+          // chosen type) on the converted formData so convert + move is ONE update
+          // (single undo). Dismissing the chooser is a no-op — nothing was moved.
+          if (chooser.pendingMove) {
+            const bpm2 = buildBlockPathMap(updatedProperties, blocksConfig, intl);
+            const pm = chooser.pendingMove;
+            const srcParent = bpm2[chooser.blockId]?.parentId || null;
+            updatedProperties = moveBlockBetweenContainers(
+              updatedProperties, bpm2, chooser.blockId, pm.targetBlockId, pm.insertAfter,
+              srcParent, pm.targetParentId, blocksConfig, intl,
+            ) || updatedProperties;
           }
           onChangeFormData(updatedProperties);
           const newBlockPathMap = buildBlockPathMap(updatedProperties, blocksConfig, intl);

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -951,21 +951,44 @@ const Iframe = (props) => {
 
       const containerConfig = getContainerFieldConfig(afterBlockId, bpm, properties, blocksConfig, intl);
       const allowedTypes = containerConfig?.allowedBlocks;
+      // Resolve each pasted block against the container's allowedBlocks: native,
+      // or convertible (auto when one target type; a single pasted block with
+      // several options opens the chooser — ask-first). Multi-paste is auto-only.
+      let pasteBlocks = cloneWithIds;
       if (allowedTypes?.length > 0) {
-        const allAllowed = cloneWithIds.every(([, blockData]) =>
-          allowedTypes.includes(blockData?.['@type']),
-        );
-        if (!allAllowed) {
-          log('hydra-paste-blocks: blocked — types not allowed in container');
+        const singlePaste = cloneWithIds.length === 1;
+        const resolved = [];
+        for (const [newId, blockData] of cloneWithIds) {
+          const bType = blockData?.['@type'];
+          if (allowedTypes.includes(bType)) {
+            resolved.push([newId, blockData]); // native fit
+            continue;
+          }
+          const options = getConvertibleTypes(bType, blocksConfig, allowedTypes).map((t) => t.type);
+          if (options.length === 1) {
+            resolved.push([newId, convertBlockType(blockData, options[0], blocksConfig, '@type', intl)]);
+            continue;
+          }
+          if (options.length > 1 && singlePaste) {
+            // Ask-first: pick a target type, then insert the converted block.
+            setChooser({
+              kind: 'convert',
+              allowedBlocks: options,
+              pendingPaste: { newId, blockData, afterBlockId },
+            });
+            return; // insertion happens on chooser pick (commitChooser)
+          }
+          log('hydra-paste-blocks: blocked — type not allowed/convertible in container');
           return;
         }
+        pasteBlocks = resolved;
       }
 
-      log('hydra-paste-blocks:', cloneWithIds.length, 'blocks after', afterBlockId);
+      log('hydra-paste-blocks:', pasteBlocks.length, 'blocks after', afterBlockId);
       let newFormData = { ...properties };
       let currentBpm = bpm;
       let lastId = afterBlockId;
-      for (const [newId, blockData] of cloneWithIds) {
+      for (const [newId, blockData] of pasteBlocks) {
         newFormData = insertBlockInContainer(newFormData, currentBpm, lastId, newId, blockData, containerConfig, 'after');
         currentBpm = buildBlockPathMap(newFormData, blocksConfig, intl);
         lastId = newId;
@@ -4286,6 +4309,22 @@ const Iframe = (props) => {
         onChangeFormData(newFormData);
         if (onSetMultiSelected) onSetMultiSelected([]);
         if (onSelectBlock) onSelectBlock(newContainerId);
+      } else if (chooser.kind === 'convert' && chooser.pendingPaste) {
+        // Ask-first paste: insert a NEW block, converted to the chosen type,
+        // after the paste target. One update → one undo.
+        const pp = chooser.pendingPaste;
+        const converted = convertBlockType(pp.blockData, newType, blocksConfig, '@type', intl);
+        const cfg = getContainerFieldConfig(pp.afterBlockId, bpm, properties, blocksConfig, intl);
+        const updatedProperties = insertBlockInContainer(
+          properties, bpm, pp.afterBlockId, pp.newId, converted, cfg, 'after',
+        );
+        onChangeFormData(updatedProperties);
+        setIframeSyncState(prev => ({
+          ...prev,
+          formData: updatedProperties,
+          blockPathMap: buildBlockPathMap(updatedProperties, blocksConfig, intl),
+          toolbarRequestDone: `paste-convert-${Date.now()}`,
+        }));
       } else if (chooser.kind === 'convert') {
         const blockData = getBlockById(properties, bpm, chooser.blockId);
         if (blockData) {

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -270,6 +270,7 @@ import {
   populateTypeSchemaCache,
   syncChildBlockTypes,
   getConvertibleTypes,
+  getConversionMap,
   convertBlockType,
   validateFieldMappings,
 } from '../../utils/schemaInheritance';
@@ -1152,6 +1153,14 @@ const Iframe = (props) => {
     [intl],
   );
 
+  // Static conversion graph ({ sourceType: [reachableTypes] }) shipped to the
+  // iframe on INITIAL_DATA so it can offer convert-reachable drop spots during a
+  // drag. Derived once from blocksConfig (which doesn't change at runtime).
+  const conversionMap = useMemo(
+    () => getConversionMap(config.blocks.blocksConfig),
+    [],
+  );
+
 
   // Trigger for template sync effect - INIT increments this when templates need loading
   // This causes the effect to run and fetch templates, then send deferred INITIAL_DATA
@@ -2021,6 +2030,7 @@ const Iframe = (props) => {
                 type: 'INITIAL_DATA',
                 data: resendFormWithDefaults,
                 blockPathMap: stripBlockPathMapForPostMessage(resendBlockPathMap),
+                conversionMap,
                 selectedBlockUid: selectedBlock,
                 slateConfig: {
                   hotkeys: config.settings.slate?.hotkeys || {},
@@ -3696,6 +3706,7 @@ const Iframe = (props) => {
             type: 'INITIAL_DATA',
             data: formDataToSend,
             blockPathMap: stripBlockPathMapForPostMessage(blockPathMap),
+            conversionMap,
             selectedBlockUid: selectedBlock,
             slateConfig: { hotkeys: config.settings.slate?.hotkeys || {}, toolbarButtons },
           }, origin);
@@ -3784,6 +3795,7 @@ const Iframe = (props) => {
           type: 'INITIAL_DATA',
           data: formDataToSend,
           blockPathMap: stripBlockPathMapForPostMessage(blockPathMap),
+          conversionMap,
           selectedBlockUid: selectedBlock,
           slateConfig: { hotkeys: config.settings.slate?.hotkeys || {}, toolbarButtons },
         }, origin);

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -2843,7 +2843,7 @@ const Iframe = (props) => {
                   kind: 'convert',
                   blockId: bid,
                   allowedBlocks: options,
-                  pendingMove: { targetBlockId, insertAfter, targetParentId },
+                  pendingMove: { targetBlockId, insertAfter, targetParentId, replaceTargetId },
                 });
                 deferredToChooser = true;
                 break;
@@ -4340,6 +4340,18 @@ const Iframe = (props) => {
               updatedProperties, bpm2, chooser.blockId, pm.targetBlockId, pm.insertAfter,
               srcParent, pm.targetParentId, blocksConfig, intl,
             ) || updatedProperties;
+            // Dropped onto an empty-container placeholder → remove it so the
+            // converted block takes its place (mirrors the MOVE_BLOCKS replace path).
+            if (pm.replaceTargetId) {
+              const rbpm = buildBlockPathMap(updatedProperties, blocksConfig, intl);
+              const rdata = getBlockById(updatedProperties, rbpm, pm.replaceTargetId);
+              if (rdata?.['@type'] === 'empty') {
+                const rcfg = getContainerFieldConfig(pm.replaceTargetId, rbpm, updatedProperties, blocksConfig, intl);
+                if (rcfg) {
+                  updatedProperties = deleteBlockFromContainer(updatedProperties, rbpm, pm.replaceTargetId, rcfg);
+                }
+              }
+            }
           }
           onChangeFormData(updatedProperties);
           const newBlockPathMap = buildBlockPathMap(updatedProperties, blocksConfig, intl);

--- a/packages/volto-hydra/src/utils/schemaInheritance.js
+++ b/packages/volto-hydra/src/utils/schemaInheritance.js
@@ -2060,6 +2060,23 @@ export function getConvertibleTypes(sourceType, blocksConfig, allowedTypes = nul
 }
 
 /**
+ * Static map { sourceType: [reachableTypes] } over the fieldMappings conversion
+ * graph — the full reachable set, UNFILTERED by any container's allowedBlocks
+ * (the target filters at check time). Built once and shipped to the iframe so it
+ * can offer convert-reachable drop spots. Types with no reachable targets map to [].
+ */
+export function getConversionMap(blocksConfig) {
+  const map = {};
+  if (!blocksConfig) return map;
+  for (const sourceType of Object.keys(blocksConfig)) {
+    map[sourceType] = getConvertibleTypes(sourceType, blocksConfig).map(
+      (t) => t.type,
+    );
+  }
+  return map;
+}
+
+/**
  * Find the conversion path from source to target type.
  * Returns array of types representing the path, or null if no path exists.
  * Prefers direct mappings over default mappings.

--- a/packages/volto-hydra/src/utils/schemaInheritance.test.js
+++ b/packages/volto-hydra/src/utils/schemaInheritance.test.js
@@ -12,6 +12,7 @@ vi.mock('../context', () => ({
 import {
   applyBlockDefaultsWithContext,
   createSchemaEnhancerFromRecipe,
+  getConversionMap,
 } from './schemaInheritance';
 
 /**
@@ -198,5 +199,33 @@ describe('fieldRules — contains operator (multiselect-driven visibility)', () 
     const enhancer = createSchemaEnhancerFromRecipe(notContainsRecipe);
     const out = enhancer({ schema: baseSchema(), formData: {} });
     expect(out.properties.date).toBeDefined();
+  });
+});
+
+describe('getConversionMap', () => {
+  // Edge direction: `X.fieldMappings[Y]` means "X can be built FROM Y", i.e. Y→X.
+  // So the edge a→b→c is declared on the TARGETS: b.fieldMappings.a, c.fieldMappings.b.
+  const cfg = {
+    a: { id: 'a', fieldMappings: {} }, // valid source; reaches b then c
+    b: { id: 'b', fieldMappings: { a: { x: 'x' } } }, // a → b
+    c: { id: 'c', fieldMappings: { b: { y: 'y' } } }, // b → c
+    lone: { id: 'lone' }, // no fieldMappings → not convertible
+  };
+
+  test('maps each source type to its full reachable set (BFS)', () => {
+    const m = getConversionMap(cfg);
+    expect(new Set(m.a)).toEqual(new Set(['b', 'c']));
+    expect(new Set(m.b)).toEqual(new Set(['c']));
+    expect(m.c || []).toEqual([]);
+  });
+
+  test('empties types with no fieldMappings', () => {
+    const m = getConversionMap(cfg);
+    expect(m.lone || []).toEqual([]);
+  });
+
+  test('null/empty config → empty map', () => {
+    expect(getConversionMap(null)).toEqual({});
+    expect(getConversionMap({})).toEqual({});
   });
 });

--- a/tests-playwright/bridge/block-sanity.spec.ts
+++ b/tests-playwright/bridge/block-sanity.spec.ts
@@ -52,6 +52,11 @@ if (fs.existsSync(discoveredPath)) {
   discoveredBlocks = JSON.parse(fs.readFileSync(discoveredPath, 'utf-8'));
 }
 
+// Synthetic conversion-test blocks (dnd-convert.spec.ts) are drag/paste fixtures
+// with no editable fields and are only rendered by the mock test frontend — they
+// aren't part of the cross-frontend render contract, so exclude them from sanity.
+discoveredBlocks = discoveredBlocks.filter((b) => !b.blockType.startsWith('conv'));
+
 // Block sanity is the cross-cutting render contract. We only enforce it on
 // the three frontends that ship full block coverage and are the canonical
 // references for downstream consumers — the mock test frontend (the spec's

--- a/tests-playwright/bridge/empty-region-sanity.spec.ts
+++ b/tests-playwright/bridge/empty-region-sanity.spec.ts
@@ -38,6 +38,11 @@ if (fs.existsSync(casesPath)) {
   cases = JSON.parse(fs.readFileSync(casesPath, 'utf-8'));
 }
 
+// Synthetic conversion-test containers (dnd-convert.spec.ts) are rendered only
+// by the mock frontend, so they aren't part of the cross-frontend empty-region
+// contract — exclude them (same rationale as block-sanity).
+cases = cases.filter((c) => !c.parentType.startsWith('conv'));
+
 // Same frontends as block-sanity — the ones with full block coverage.
 const SANITY_PROJECTS = new Set(['mock', 'nuxt', 'nextjs']);
 const EMPTY_CHILD_ID = 'sanity-empty-child';

--- a/tests-playwright/fixtures/content/dnd-convert-page/data.json
+++ b/tests-playwright/fixtures/content/dnd-convert-page/data.json
@@ -9,8 +9,11 @@
     "src-1": { "@type": "convSource", "title": "Draggable source" },
     "box-1": {
       "@type": "convBox",
-      "blocks": { "a-1": { "@type": "convTargetA", "title": "Existing A" } },
-      "blocks_layout": { "items": ["a-1"] }
+      "blocks": {
+        "a-1": { "@type": "convTargetA", "title": "Existing A1" },
+        "a-2": { "@type": "convTargetA", "title": "Existing A2" }
+      },
+      "blocks_layout": { "items": ["a-1", "a-2"] }
     },
     "boxm-1": {
       "@type": "convBoxMulti",

--- a/tests-playwright/fixtures/content/dnd-convert-page/data.json
+++ b/tests-playwright/fixtures/content/dnd-convert-page/data.json
@@ -1,0 +1,22 @@
+{
+  "@id": "http://localhost:8888/dnd-convert-page",
+  "@type": "Document",
+  "UID": "dnd-convert-page-uid",
+  "id": "dnd-convert-page",
+  "title": "DnD Convert Page",
+  "blocks": {
+    "title-block": { "@type": "title" },
+    "src-1": { "@type": "convSource", "title": "Draggable source" },
+    "box-1": {
+      "@type": "convBox",
+      "blocks": { "a-1": { "@type": "convTargetA", "title": "Existing A" } },
+      "blocks_layout": { "items": ["a-1"] }
+    },
+    "boxm-1": {
+      "@type": "convBoxMulti",
+      "blocks": { "em-1": { "@type": "empty" } },
+      "blocks_layout": { "items": ["em-1"] }
+    }
+  },
+  "blocks_layout": { "items": ["title-block", "src-1", "box-1", "boxm-1"] }
+}

--- a/tests-playwright/fixtures/content/dnd-convert-page/data.json
+++ b/tests-playwright/fixtures/content/dnd-convert-page/data.json
@@ -17,8 +17,11 @@
     },
     "boxm-1": {
       "@type": "convBoxMulti",
-      "blocks": { "em-1": { "@type": "empty" } },
-      "blocks_layout": { "items": ["em-1"] }
+      "blocks": {
+        "b-1": { "@type": "convTargetA", "title": "Multi B1" },
+        "b-2": { "@type": "convTargetA", "title": "Multi B2" }
+      },
+      "blocks_layout": { "items": ["b-1", "b-2"] }
     }
   },
   "blocks_layout": { "items": ["title-block", "src-1", "box-1", "boxm-1"] }

--- a/tests-playwright/fixtures/content/dnd-convert-page/data.json
+++ b/tests-playwright/fixtures/content/dnd-convert-page/data.json
@@ -29,9 +29,22 @@
       "@type": "convBoxMulti",
       "blocks": { "eseed-1": { "@type": "empty" } },
       "blocks_layout": { "items": ["eseed-1"] }
+    },
+    "grp-src-1": {
+      "@type": "convGroupSrc",
+      "blocks": { "gc-1": { "@type": "convTargetA", "title": "Grouped child" } },
+      "blocks_layout": { "items": ["gc-1"] }
+    },
+    "grp-box-1": {
+      "@type": "convGroupBox",
+      "blocks": {
+        "gd-1": { "@type": "convGroupDst", "blocks": { "gdc-1": { "@type": "convTargetA", "title": "gd-1 child" } }, "blocks_layout": { "items": ["gdc-1"] } },
+        "gd-2": { "@type": "convGroupDst", "blocks": { "gdc-2": { "@type": "convTargetA", "title": "gd-2 child" } }, "blocks_layout": { "items": ["gdc-2"] } }
+      },
+      "blocks_layout": { "items": ["gd-1", "gd-2"] }
     }
   },
   "blocks_layout": {
-    "items": ["title-block", "src-1", "src-2", "alien-1", "box-1", "boxm-1", "boxe-1"]
+    "items": ["title-block", "src-1", "src-2", "alien-1", "box-1", "boxm-1", "boxe-1", "grp-src-1", "grp-box-1"]
   }
 }

--- a/tests-playwright/fixtures/content/dnd-convert-page/data.json
+++ b/tests-playwright/fixtures/content/dnd-convert-page/data.json
@@ -24,9 +24,14 @@
         "b-2": { "@type": "convTargetA", "title": "Multi B2" }
       },
       "blocks_layout": { "items": ["b-1", "b-2"] }
+    },
+    "boxe-1": {
+      "@type": "convBoxMulti",
+      "blocks": { "eseed-1": { "@type": "empty" } },
+      "blocks_layout": { "items": ["eseed-1"] }
     }
   },
   "blocks_layout": {
-    "items": ["title-block", "src-1", "src-2", "alien-1", "box-1", "boxm-1"]
+    "items": ["title-block", "src-1", "src-2", "alien-1", "box-1", "boxm-1", "boxe-1"]
   }
 }

--- a/tests-playwright/fixtures/content/dnd-convert-page/data.json
+++ b/tests-playwright/fixtures/content/dnd-convert-page/data.json
@@ -6,7 +6,8 @@
   "title": "DnD Convert Page",
   "blocks": {
     "title-block": { "@type": "title" },
-    "src-1": { "@type": "convSource", "title": "Draggable source" },
+    "src-1": { "@type": "convSource", "title": "Draggable source 1" },
+    "src-2": { "@type": "convSource", "title": "Draggable source 2" },
     "box-1": {
       "@type": "convBox",
       "blocks": {
@@ -24,5 +25,7 @@
       "blocks_layout": { "items": ["b-1", "b-2"] }
     }
   },
-  "blocks_layout": { "items": ["title-block", "src-1", "box-1", "boxm-1"] }
+  "blocks_layout": {
+    "items": ["title-block", "src-1", "src-2", "box-1", "boxm-1"]
+  }
 }

--- a/tests-playwright/fixtures/content/dnd-convert-page/data.json
+++ b/tests-playwright/fixtures/content/dnd-convert-page/data.json
@@ -8,6 +8,7 @@
     "title-block": { "@type": "title" },
     "src-1": { "@type": "convSource", "title": "Draggable source 1" },
     "src-2": { "@type": "convSource", "title": "Draggable source 2" },
+    "alien-1": { "@type": "convAlien", "title": "Alien block" },
     "box-1": {
       "@type": "convBox",
       "blocks": {
@@ -26,6 +27,6 @@
     }
   },
   "blocks_layout": {
-    "items": ["title-block", "src-1", "src-2", "box-1", "boxm-1"]
+    "items": ["title-block", "src-1", "src-2", "alien-1", "box-1", "boxm-1"]
   }
 }

--- a/tests-playwright/fixtures/shared-block-schemas.js
+++ b/tests-playwright/fixtures/shared-block-schemas.js
@@ -1170,6 +1170,18 @@ export const sharedBlocksConfig = {
             required: [],
         },
     },
+    // A block with NO fieldMappings → not convertible to anything, so a
+    // restricted container that doesn't list it rejects it outright.
+    convAlien: {
+        id: 'convAlien',
+        title: 'Conv Alien',
+        group: 'common',
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: ['title'] }],
+            properties: { title: { title: 'Title', type: 'string' } },
+            required: [],
+        },
+    },
     // Container restricted to a SINGLE convert-target → convSource drops auto-convert.
     convBox: {
         id: 'convBox',

--- a/tests-playwright/fixtures/shared-block-schemas.js
+++ b/tests-playwright/fixtures/shared-block-schemas.js
@@ -1139,6 +1139,7 @@ export const sharedBlocksConfig = {
     // Edge direction: `X.fieldMappings[Y]` = "X can be built FROM Y" (Y → X).
     convSource: {
         id: 'convSource',
+        restricted: true,
         title: 'Conv Source',
         group: 'common',
         fieldMappings: {}, // present (truthy) so it's a valid conversion source
@@ -1150,6 +1151,7 @@ export const sharedBlocksConfig = {
     },
     convTargetA: {
         id: 'convTargetA',
+        restricted: true,
         title: 'Conv Target A',
         group: 'common',
         fieldMappings: { convSource: { title: 'title' } }, // convSource → convTargetA
@@ -1161,6 +1163,7 @@ export const sharedBlocksConfig = {
     },
     convTargetB: {
         id: 'convTargetB',
+        restricted: true,
         title: 'Conv Target B',
         group: 'common',
         fieldMappings: { convSource: { title: 'title' } }, // convSource → convTargetB
@@ -1174,6 +1177,7 @@ export const sharedBlocksConfig = {
     // restricted container that doesn't list it rejects it outright.
     convAlien: {
         id: 'convAlien',
+        restricted: true,
         title: 'Conv Alien',
         group: 'common',
         blockSchema: {
@@ -1186,6 +1190,7 @@ export const sharedBlocksConfig = {
     // convGroupDst, carrying its children. Exercises convertContainerBlock on drop.
     convGroupSrc: {
         id: 'convGroupSrc',
+        restricted: true,
         title: 'Conv Group Src',
         group: 'common',
         fieldMappings: {}, // valid conversion source
@@ -1199,6 +1204,7 @@ export const sharedBlocksConfig = {
     },
     convGroupDst: {
         id: 'convGroupDst',
+        restricted: true,
         title: 'Conv Group Dst',
         group: 'common',
         fieldMappings: { convGroupSrc: {} }, // convGroupSrc → convGroupDst
@@ -1213,6 +1219,7 @@ export const sharedBlocksConfig = {
     // Restricted to convGroupDst → a dropped convGroupSrc auto-converts to it.
     convGroupBox: {
         id: 'convGroupBox',
+        restricted: true,
         title: 'Conv Group Box',
         group: 'common',
         blockSchema: {
@@ -1226,6 +1233,7 @@ export const sharedBlocksConfig = {
     // Container restricted to a SINGLE convert-target → convSource drops auto-convert.
     convBox: {
         id: 'convBox',
+        restricted: true,
         title: 'Convert Box',
         group: 'common',
         blockSchema: {
@@ -1239,6 +1247,7 @@ export const sharedBlocksConfig = {
     // Container restricted to TWO convert-targets → convSource drop opens the chooser.
     convBoxMulti: {
         id: 'convBoxMulti',
+        restricted: true,
         title: 'Convert Box (multi)',
         group: 'common',
         blockSchema: {

--- a/tests-playwright/fixtures/shared-block-schemas.js
+++ b/tests-playwright/fixtures/shared-block-schemas.js
@@ -1182,6 +1182,47 @@ export const sharedBlocksConfig = {
             required: [],
         },
     },
+    // Container-to-container conversion: convGroupSrc (holds children) converts to
+    // convGroupDst, carrying its children. Exercises convertContainerBlock on drop.
+    convGroupSrc: {
+        id: 'convGroupSrc',
+        title: 'Conv Group Src',
+        group: 'common',
+        fieldMappings: {}, // valid conversion source
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: [] }],
+            properties: {
+                items: { widget: 'blocks_layout', allowedBlocks: ['convTargetA'] },
+            },
+            required: [],
+        },
+    },
+    convGroupDst: {
+        id: 'convGroupDst',
+        title: 'Conv Group Dst',
+        group: 'common',
+        fieldMappings: { convGroupSrc: {} }, // convGroupSrc → convGroupDst
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: [] }],
+            properties: {
+                items: { widget: 'blocks_layout', allowedBlocks: ['convTargetA'] },
+            },
+            required: [],
+        },
+    },
+    // Restricted to convGroupDst → a dropped convGroupSrc auto-converts to it.
+    convGroupBox: {
+        id: 'convGroupBox',
+        title: 'Conv Group Box',
+        group: 'common',
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: [] }],
+            properties: {
+                items: { widget: 'blocks_layout', allowedBlocks: ['convGroupDst'] },
+            },
+            required: [],
+        },
+    },
     // Container restricted to a SINGLE convert-target → convSource drops auto-convert.
     convBox: {
         id: 'convBox',

--- a/tests-playwright/fixtures/shared-block-schemas.js
+++ b/tests-playwright/fixtures/shared-block-schemas.js
@@ -1133,4 +1133,70 @@ export const sharedBlocksConfig = {
             required: [],
         },
     },
+    // --- Conversion drag/paste test graph (dnd-convert.spec.ts) ---
+    // A deterministic toy graph with EXPLICIT edges only (no '@default'), so
+    // convSource reaches exactly convTargetA + convTargetB and nothing else.
+    // Edge direction: `X.fieldMappings[Y]` = "X can be built FROM Y" (Y → X).
+    convSource: {
+        id: 'convSource',
+        title: 'Conv Source',
+        group: 'common',
+        fieldMappings: {}, // present (truthy) so it's a valid conversion source
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: ['title'] }],
+            properties: { title: { title: 'Title', type: 'string' } },
+            required: [],
+        },
+    },
+    convTargetA: {
+        id: 'convTargetA',
+        title: 'Conv Target A',
+        group: 'common',
+        fieldMappings: { convSource: { title: 'title' } }, // convSource → convTargetA
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: ['title'] }],
+            properties: { title: { title: 'Title', type: 'string' } },
+            required: [],
+        },
+    },
+    convTargetB: {
+        id: 'convTargetB',
+        title: 'Conv Target B',
+        group: 'common',
+        fieldMappings: { convSource: { title: 'title' } }, // convSource → convTargetB
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: ['title'] }],
+            properties: { title: { title: 'Title', type: 'string' } },
+            required: [],
+        },
+    },
+    // Container restricted to a SINGLE convert-target → convSource drops auto-convert.
+    convBox: {
+        id: 'convBox',
+        title: 'Convert Box',
+        group: 'common',
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: [] }],
+            properties: {
+                items: { widget: 'blocks_layout', allowedBlocks: ['convTargetA'] },
+            },
+            required: [],
+        },
+    },
+    // Container restricted to TWO convert-targets → convSource drop opens the chooser.
+    convBoxMulti: {
+        id: 'convBoxMulti',
+        title: 'Convert Box (multi)',
+        group: 'common',
+        blockSchema: {
+            fieldsets: [{ id: 'default', title: 'Default', fields: [] }],
+            properties: {
+                items: {
+                    widget: 'blocks_layout',
+                    allowedBlocks: ['convTargetA', 'convTargetB'],
+                },
+            },
+            required: [],
+        },
+    },
 };

--- a/tests-playwright/fixtures/test-frontend/index.html
+++ b/tests-playwright/fixtures/test-frontend/index.html
@@ -455,7 +455,7 @@
                                 properties: {
                                     items: {
                                         title: 'Blocks',
-                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample', 'objectBlocks', 'convSource', 'convAlien', 'convBox', 'convBoxMulti'],
+                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample', 'objectBlocks', 'convSource', 'convAlien', 'convBox', 'convBoxMulti', 'convGroupSrc', 'convGroupBox'],
                                         allowedTemplates: ['/_test_data/templates/test-layout'],
                                         allowedLayouts: contextNavLayoutForced
                                             || [null, '/_test_data/templates/test-layout', '/_test_data/templates/header-footer-layout', '/_test_data/templates/header-only-layout', '/_test_data/templates/editable-fixed-layout'],

--- a/tests-playwright/fixtures/test-frontend/index.html
+++ b/tests-playwright/fixtures/test-frontend/index.html
@@ -455,7 +455,7 @@
                                 properties: {
                                     items: {
                                         title: 'Blocks',
-                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample', 'objectBlocks'],
+                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample', 'objectBlocks', 'convSource', 'convBox', 'convBoxMulti'],
                                         allowedTemplates: ['/_test_data/templates/test-layout'],
                                         allowedLayouts: contextNavLayoutForced
                                             || [null, '/_test_data/templates/test-layout', '/_test_data/templates/header-footer-layout', '/_test_data/templates/header-only-layout', '/_test_data/templates/editable-fixed-layout'],

--- a/tests-playwright/fixtures/test-frontend/index.html
+++ b/tests-playwright/fixtures/test-frontend/index.html
@@ -455,7 +455,7 @@
                                 properties: {
                                     items: {
                                         title: 'Blocks',
-                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample', 'objectBlocks', 'convSource', 'convBox', 'convBoxMulti'],
+                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample', 'objectBlocks', 'convSource', 'convAlien', 'convBox', 'convBoxMulti'],
                                         allowedTemplates: ['/_test_data/templates/test-layout'],
                                         allowedLayouts: contextNavLayoutForced
                                             || [null, '/_test_data/templates/test-layout', '/_test_data/templates/header-footer-layout', '/_test_data/templates/header-only-layout', '/_test_data/templates/editable-fixed-layout'],

--- a/tests-playwright/fixtures/test-frontend/index.html
+++ b/tests-playwright/fixtures/test-frontend/index.html
@@ -455,7 +455,7 @@
                                 properties: {
                                     items: {
                                         title: 'Blocks',
-                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample', 'objectBlocks', 'convSource', 'convAlien', 'convBox', 'convBoxMulti', 'convGroupSrc', 'convGroupBox'],
+                                        allowedBlocks: ['slate', 'image', 'separator', 'hero', 'columns', 'slider', 'accordion', 'teaser', 'gridBlock', 'listing', 'search', 'skiplogicTest', 'title', 'description', 'section', 'contextNavigation', 'codeExample', 'objectBlocks', 'convSource'],
                                         allowedTemplates: ['/_test_data/templates/test-layout'],
                                         allowedLayouts: contextNavLayoutForced
                                             || [null, '/_test_data/templates/test-layout', '/_test_data/templates/header-footer-layout', '/_test_data/templates/header-only-layout', '/_test_data/templates/editable-fixed-layout'],

--- a/tests-playwright/fixtures/test-frontend/renderer.js
+++ b/tests-playwright/fixtures/test-frontend/renderer.js
@@ -246,6 +246,7 @@ async function renderBlock(blockId, block) {
         case 'convSource':
         case 'convTargetA':
         case 'convTargetB':
+        case 'convAlien':
             wrapper.innerHTML = `<p data-conv-type="${block['@type']}">${escapeHtml(block.title || block['@type'])}</p>`;
             break;
         case 'convBox':

--- a/tests-playwright/fixtures/test-frontend/renderer.js
+++ b/tests-playwright/fixtures/test-frontend/renderer.js
@@ -250,7 +250,7 @@ async function renderBlock(blockId, block) {
             break;
         case 'convBox':
         case 'convBoxMulti':
-            wrapper.innerHTML = await renderSectionBlock(block);
+            wrapper.innerHTML = await renderConvBox(block);
             break;
         case 'contextNavigation': {
             // Return the <nav> directly so aria-label / class /
@@ -1267,6 +1267,33 @@ function renderColumnBlock(block) {
  * @param {Object} block
  * @returns {Promise<string>} HTML string
  */
+/**
+ * Conversion-test container renderer. Like renderSectionBlock but marks each
+ * child `data-block-add="bottom"` so getAddDirection treats the vertically
+ * stacked children as a vertical list (nested blocks default to 'right'/
+ * horizontal without this) — keeping drop-position resolution on the Y axis.
+ */
+async function renderConvBox(block) {
+    const blocks = block.blocks || {};
+    const items = block.blocks_layout?.items || [];
+    let html = '<div class="section-body" style="padding: 12px; border: 1px dashed #888; border-radius: 4px;">';
+    for (const childId of items) {
+        const child = blocks[childId];
+        if (!child) continue;
+        const rendered = await renderBlock(childId, child);
+        let el = rendered;
+        if (rendered instanceof DocumentFragment) {
+            const c = document.createElement('div');
+            c.appendChild(rendered);
+            el = c.firstElementChild;
+        }
+        if (el && el.setAttribute) el.setAttribute('data-block-add', 'bottom');
+        html += el ? el.outerHTML : '';
+    }
+    html += '</div>';
+    return html;
+}
+
 async function renderSectionBlock(block) {
     const blocks = block.blocks || {};
     const items = block.blocks_layout?.items || [];

--- a/tests-playwright/fixtures/test-frontend/renderer.js
+++ b/tests-playwright/fixtures/test-frontend/renderer.js
@@ -240,6 +240,18 @@ async function renderBlock(blockId, block) {
         case 'section':
             wrapper.innerHTML = await renderSectionBlock(block);
             break;
+        // Conversion drag/paste test blocks (dnd-convert.spec.ts). Leaf types
+        // render a titled paragraph; the containers reuse the generic section
+        // renderer (children in blocks_layout.items, incl. a seeded empty).
+        case 'convSource':
+        case 'convTargetA':
+        case 'convTargetB':
+            wrapper.innerHTML = `<p data-conv-type="${block['@type']}">${escapeHtml(block.title || block['@type'])}</p>`;
+            break;
+        case 'convBox':
+        case 'convBoxMulti':
+            wrapper.innerHTML = await renderSectionBlock(block);
+            break;
         case 'contextNavigation': {
             // Return the <nav> directly so aria-label / class /
             // data-block-uid all live on the same element. The default

--- a/tests-playwright/fixtures/test-frontend/renderer.js
+++ b/tests-playwright/fixtures/test-frontend/renderer.js
@@ -253,6 +253,11 @@ async function renderBlock(blockId, block) {
         case 'convBoxMulti':
             wrapper.innerHTML = await renderConvBox(block);
             break;
+        case 'convGroupSrc':
+        case 'convGroupDst':
+        case 'convGroupBox':
+            wrapper.innerHTML = await renderConvGroup(block);
+            break;
         case 'contextNavigation': {
             // Return the <nav> directly so aria-label / class /
             // data-block-uid all live on the same element. The default
@@ -1278,6 +1283,32 @@ async function renderConvBox(block) {
     const blocks = block.blocks || {};
     const items = block.blocks_layout?.items || [];
     let html = '<div class="section-body" style="padding: 12px; border: 1px dashed #888; border-radius: 4px;">';
+    for (const childId of items) {
+        const child = blocks[childId];
+        if (!child) continue;
+        const rendered = await renderBlock(childId, child);
+        let el = rendered;
+        if (rendered instanceof DocumentFragment) {
+            const c = document.createElement('div');
+            c.appendChild(rendered);
+            el = c.firstElementChild;
+        }
+        if (el && el.setAttribute) el.setAttribute('data-block-add', 'bottom');
+        html += el ? el.outerHTML : '';
+    }
+    html += '</div>';
+    return html;
+}
+
+/**
+ * Nested-container renderer for the container→container conversion test. Stamps
+ * `data-container-type` (the block's @type) so the test can assert a container's
+ * converted type, and renders children with `data-block-add="bottom"` (vertical).
+ */
+async function renderConvGroup(block) {
+    const blocks = block.blocks || {};
+    const items = block.blocks_layout?.items || [];
+    let html = `<div class="section-body" data-container-type="${block['@type']}" style="padding: 12px; border: 1px solid #4a90d9; border-radius: 4px;">`;
     for (const childId of items) {
         const child = blocks[childId];
         if (!child) continue;

--- a/tests-playwright/helpers/AdminUIHelper.ts
+++ b/tests-playwright/helpers/AdminUIHelper.ts
@@ -4157,6 +4157,24 @@ export class AdminUIHelper {
   }
 
   /**
+   * Drag a block after another block and RELEASE, without asserting a reorder.
+   * Use for drops that intentionally don't move immediately — e.g. a convert-drop
+   * with multiple options, which opens the chooser first (ask-first) and only
+   * moves once the user picks a type. Returns after the mouse is released.
+   * @param sourceBlockId - The block ID to drag
+   * @param targetBlockId - The block ID to drop after
+   */
+  async dragBlockAfterNoReorderAssert(sourceBlockId: string, targetBlockId: string): Promise<void> {
+    const iframe = this.getIframe();
+    await this.clickBlockInIframe(sourceBlockId);
+    await this.waitForBlockSelectedInAdmin(sourceBlockId);
+    const targetBlock = iframe.locator(`[data-block-uid="${targetBlockId}"]`).first();
+    // Position after the target with the mouse still down, then release.
+    await this.dragBlockWithMouseNoDrop(targetBlock, targetBlock, true);
+    await this.page.mouse.up();
+  }
+
+  /**
    * Drag a block before another block by their IDs.
    * First selects the source block, then drags it before the target block.
    * @param sourceBlockId - The block ID to drag

--- a/tests-playwright/integration/dnd-convert.spec.ts
+++ b/tests-playwright/integration/dnd-convert.spec.ts
@@ -32,4 +32,54 @@ test.describe('DnD / paste via conversion', () => {
     ).toHaveCount(3);
     await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(0);
   });
+
+  test('drag into a container with multiple convert-targets opens the chooser and commits atomically', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    // Drop the convSource between convBoxMulti's two children (options: A or B).
+    await helper.dragBlockAfterNoReorderAssert('src-1', 'b-1');
+
+    // Ask-first: the chooser appears and NOTHING has moved/converted yet.
+    await expect(page.locator('.blocks-chooser')).toBeVisible();
+    await expect(
+      iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
+    ).toHaveCount(0);
+    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(1);
+
+    // Choose Conv Target B → convert + move happen together.
+    await page.locator('.blocks-chooser').getByText('Conv Target B', { exact: false }).click();
+    await expect(
+      iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
+    ).toHaveCount(1);
+    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(0);
+
+    // One undo reverts BOTH the move and the conversion (single step).
+    await page.locator('#toolbar-body .undo').click();
+    await expect(
+      iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
+    ).toHaveCount(0);
+    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(1);
+  });
+
+  test('cancelling the convert chooser leaves the block where it was', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    await helper.dragBlockAfterNoReorderAssert('src-1', 'b-1');
+    await expect(page.locator('.blocks-chooser')).toBeVisible();
+
+    // Dismiss (outside click) → no-op: nothing moved or converted.
+    await page.mouse.click(5, 5);
+    await expect(page.locator('.blocks-chooser')).toBeHidden();
+    await expect(
+      iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
+    ).toHaveCount(0);
+    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(1);
+    expect(await helper.blockExists('src-1')).toBe(true);
+  });
 });

--- a/tests-playwright/integration/dnd-convert.spec.ts
+++ b/tests-playwright/integration/dnd-convert.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Drag / paste into a spot via conversion.
+ *
+ * Fixtures (dnd-convert-page): convSource (page-level, draggable) converts to
+ * convTargetA and convTargetB. convBox accepts only convTargetA (single option
+ * → auto-convert); convBoxMulti accepts convTargetA + convTargetB (two options
+ * → chooser popup). Toy blocks render `<p data-conv-type="...">`.
+ */
+import { test, expect } from '../fixtures';
+import { AdminUIHelper } from '../helpers/AdminUIHelper';
+
+test.describe('DnD / paste via conversion', () => {
+  test('drag into a container that only accepts a convert-target auto-converts it', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    // Before: box-1 holds two convTargetA (a-1, a-2); src-1 is a convSource at page level.
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(2);
+
+    // Drop the convSource BETWEEN the box's two children (a clearly interior
+    // position, away from the container's padded edges).
+    await helper.dragBlockAfter('src-1', 'a-1');
+
+    // After: the dropped convSource was auto-converted → box-1 has THREE convTargetA,
+    // and no convSource survives anywhere.
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(3);
+    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(0);
+  });
+});

--- a/tests-playwright/integration/dnd-convert.spec.ts
+++ b/tests-playwright/integration/dnd-convert.spec.ts
@@ -163,6 +163,63 @@ test.describe('DnD / paste via conversion', () => {
     ).toHaveCount(1);
   });
 
+  test('cut then paste converts into a restricted container (the mobile move path)', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(2);
+
+    // Cut the convSource (mobile has no drag-convert → cut/paste is the move
+    // path). Cut removes the block immediately and holds it in the clipboard.
+    await helper.clickBlockInIframe('src-1');
+    await helper.waitForIframeBlockHandle('src-1');
+    await page.keyboard.press('ControlOrMeta+x');
+    await expect.poll(async () => helper.blockExists('src-1')).toBe(false);
+
+    // Select a block inside box-1 and paste after it → the moved block auto-converts.
+    await helper.clickBlockInIframe('a-1');
+    await helper.waitForIframeBlockHandle('a-1');
+    await expect(page.locator('#toolbar-paste-blocks')).toBeVisible({ timeout: 3000 });
+    await page.keyboard.press('ControlOrMeta+v');
+
+    // box-1 gains a third convTargetA; src-1 (moved, not copied) is now that
+    // converted block — no longer a convSource.
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(3);
+    await expect(
+      iframe.locator('[data-block-uid="src-1"] [data-conv-type="convSource"]'),
+    ).toHaveCount(0);
+  });
+
+  test('a block that cannot convert is rejected by a restricted container', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(2);
+
+    // alien-1 has no fieldMappings → not convertible to convTargetA, so box-1
+    // (allowedBlocks: [convTargetA]) must not accept it.
+    await helper.dragBlockAfterNoReorderAssert('alien-1', 'a-1');
+
+    // box-1 unchanged: still exactly 2 convTargetA, and no alien inside it.
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(2);
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convAlien"]'),
+    ).toHaveCount(0);
+    expect(await helper.blockExists('alien-1')).toBe(true);
+  });
+
   test('cancelling the convert chooser leaves the block where it was', async ({ page }) => {
     const helper = new AdminUIHelper(page);
     await helper.login();

--- a/tests-playwright/integration/dnd-convert.spec.ts
+++ b/tests-playwright/integration/dnd-convert.spec.ts
@@ -64,6 +64,35 @@ test.describe('DnD / paste via conversion', () => {
     await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(1);
   });
 
+  test('pasting a block into a restricted container auto-converts it', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(2);
+
+    // Copy the convSource (a non-editable block → selecting it IS block mode).
+    await helper.clickBlockInIframe('src-1');
+    await helper.waitForIframeBlockHandle('src-1');
+    await page.keyboard.press('ControlOrMeta+c');
+    await expect(page.locator('#toolbar-paste-blocks')).toBeVisible({ timeout: 3000 });
+
+    // Select a block inside box-1 and paste after it → auto-convert into the box.
+    await helper.clickBlockInIframe('a-1');
+    await helper.waitForIframeBlockHandle('a-1');
+    await page.keyboard.press('ControlOrMeta+v');
+
+    // box-1 gains a third convTargetA (the pasted convSource converted); the
+    // original src-1 (a copy) remains a convSource at page level.
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(3);
+    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(1);
+  });
+
   test('cancelling the convert chooser leaves the block where it was', async ({ page }) => {
     const helper = new AdminUIHelper(page);
     await helper.login();

--- a/tests-playwright/integration/dnd-convert.spec.ts
+++ b/tests-playwright/integration/dnd-convert.spec.ts
@@ -41,6 +41,43 @@ test.describe('DnD / paste via conversion', () => {
       iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
     ).toHaveCount(3);
     await expect(iframe.locator('[data-block-uid="src-1"] [data-conv-type="convSource"]')).toHaveCount(0);
+    // The mapped field (title → title) survives the conversion: src-1 is now a
+    // convTargetA still showing its original title.
+    await expect(
+      iframe.locator('[data-block-uid="src-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveText('Draggable source 1');
+  });
+
+  test('a multi-block selection with a multi-option member is rejected by the container', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    await expect(
+      iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(2);
+
+    // Select src-1 + src-2. Each convSource has TWO options (A, B) in convBoxMulti,
+    // and a batch is auto-only (no popup chains) — so the container withholds the spot.
+    await helper.clickBlockInIframe('src-1');
+    await helper.waitForIframeBlockHandle('src-1');
+    await page.keyboard.press('Shift+ArrowDown');
+    await expect(page.locator('.quanta-toolbar')).toBeVisible({ timeout: 5000 });
+    const dragHandle = page.locator('.quanta-toolbar .drag-handle');
+    await expect(dragHandle).toBeVisible({ timeout: 3000 });
+
+    // Position inside convBoxMulti and release; the batch must not enter it.
+    const target = iframe.locator('[data-block-uid="b-1"]').first();
+    await helper.dragBlockWithMouseNoDrop(dragHandle, target, true);
+    await page.mouse.up();
+
+    await expect(
+      iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(2);
+    await expect(
+      iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convSource"]'),
+    ).toHaveCount(0);
   });
 
   test('multi-selected blocks each auto-convert into a single-option container', async ({ page }) => {
@@ -218,6 +255,38 @@ test.describe('DnD / paste via conversion', () => {
       iframe.locator('[data-block-uid="box-1"] [data-conv-type="convAlien"]'),
     ).toHaveCount(0);
     expect(await helper.blockExists('alien-1')).toBe(true);
+  });
+
+  test('dropping onto an empty container converts and replaces the placeholder', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    // boxe-1 is an empty convBoxMulti (only a synthetic 'empty' placeholder).
+    await expect(
+      iframe.locator('[data-block-uid="boxe-1"] [data-conv-type]'),
+    ).toHaveCount(0);
+
+    // Drag the convSource onto the empty container (the shade drop path).
+    await helper.clickBlockInIframe('src-1');
+    await helper.waitForIframeBlockHandle('src-1');
+    const dragHandle = await helper.getDragHandle();
+    const target = iframe.locator('[data-block-uid="boxe-1"]').first();
+    await helper.dragBlockWithMouseNoDrop(dragHandle, target, true);
+    await page.mouse.up();
+
+    // Two options → chooser; pick Conv Target B.
+    await expect(page.locator('.blocks-chooser')).toBeVisible();
+    await page.locator('.blocks-chooser').getByText('Conv Target B', { exact: false }).click();
+
+    // The converted block took the placeholder's place (not sitting beside it).
+    await expect(
+      iframe.locator('[data-block-uid="boxe-1"] [data-conv-type="convTargetB"]'),
+    ).toHaveCount(1);
+    await expect(
+      iframe.locator('[data-block-uid="boxe-1"] [data-conv-type]'),
+    ).toHaveCount(1);
   });
 
   test('cancelling the convert chooser leaves the block where it was', async ({ page }) => {

--- a/tests-playwright/integration/dnd-convert.spec.ts
+++ b/tests-playwright/integration/dnd-convert.spec.ts
@@ -26,10 +26,42 @@ test.describe('DnD / paste via conversion', () => {
     await helper.dragBlockAfter('src-1', 'a-1');
 
     // After: the dropped convSource was auto-converted → box-1 has THREE convTargetA,
-    // and no convSource survives anywhere.
+    // and src-1 is no longer a convSource.
     await expect(
       iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
     ).toHaveCount(3);
+    await expect(iframe.locator('[data-block-uid="src-1"] [data-conv-type="convSource"]')).toHaveCount(0);
+  });
+
+  test('multi-selected blocks each auto-convert into a single-option container', async ({ page }) => {
+    // The multi-block auto-only rule (a batch drops only where every block has
+    // exactly one convertible option) is unit-covered by acceptableAt; here we
+    // check the end-to-end auto path: two convSource blocks → two convTargetA.
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(2);
+
+    // Select src-1 + src-2 (two adjacent convSource blocks).
+    await helper.clickBlockInIframe('src-1');
+    await helper.waitForIframeBlockHandle('src-1');
+    await page.keyboard.press('Shift+ArrowDown');
+    const toolbar = page.locator('.quanta-toolbar');
+    await expect(toolbar).toBeVisible({ timeout: 5000 });
+    const dragHandle = toolbar.locator('.drag-handle');
+    await expect(dragHandle).toBeVisible({ timeout: 3000 });
+
+    // Drag both between box-1's children → each auto-converts (single option).
+    const target = iframe.locator('[data-block-uid="a-1"]').first();
+    await helper.dragBlockWithMouse(dragHandle, target, true);
+
+    await expect(
+      iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(4);
     await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(0);
   });
 
@@ -47,21 +79,21 @@ test.describe('DnD / paste via conversion', () => {
     await expect(
       iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
     ).toHaveCount(0);
-    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(1);
+    await expect(iframe.locator('[data-block-uid="src-1"] [data-conv-type="convSource"]')).toHaveCount(1);
 
     // Choose Conv Target B → convert + move happen together.
     await page.locator('.blocks-chooser').getByText('Conv Target B', { exact: false }).click();
     await expect(
       iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
     ).toHaveCount(1);
-    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(0);
+    await expect(iframe.locator('[data-block-uid="src-1"] [data-conv-type="convSource"]')).toHaveCount(0);
 
     // One undo reverts BOTH the move and the conversion (single step).
     await page.locator('#toolbar-body .undo').click();
     await expect(
       iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
     ).toHaveCount(0);
-    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(1);
+    await expect(iframe.locator('[data-block-uid="src-1"] [data-conv-type="convSource"]')).toHaveCount(1);
   });
 
   test('pasting a block into a restricted container auto-converts it', async ({ page }) => {
@@ -90,7 +122,7 @@ test.describe('DnD / paste via conversion', () => {
     await expect(
       iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
     ).toHaveCount(3);
-    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(1);
+    await expect(iframe.locator('[data-block-uid="src-1"] [data-conv-type="convSource"]')).toHaveCount(1);
   });
 
   test('cancelling the convert chooser leaves the block where it was', async ({ page }) => {
@@ -108,7 +140,7 @@ test.describe('DnD / paste via conversion', () => {
     await expect(
       iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
     ).toHaveCount(0);
-    await expect(iframe.locator('[data-conv-type="convSource"]')).toHaveCount(1);
+    await expect(iframe.locator('[data-block-uid="src-1"] [data-conv-type="convSource"]')).toHaveCount(1);
     expect(await helper.blockExists('src-1')).toBe(true);
   });
 });

--- a/tests-playwright/integration/dnd-convert.spec.ts
+++ b/tests-playwright/integration/dnd-convert.spec.ts
@@ -289,6 +289,40 @@ test.describe('DnD / paste via conversion', () => {
     ).toHaveCount(1);
   });
 
+  test('a container block with children converts on drop, carrying its children', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    // Before: grp-box-1 holds two convGroupDst; grp-src-1 (convGroupSrc) holds one child.
+    await expect(
+      iframe.locator('[data-block-uid="grp-box-1"] [data-container-type="convGroupDst"]'),
+    ).toHaveCount(2);
+    await expect(
+      iframe.locator('[data-block-uid="grp-src-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(1);
+
+    // Select the container itself (not its child), then drag it between
+    // grp-box-1's children (convGroupSrc → convGroupDst).
+    await helper.clickContainerBlockInIframe('grp-src-1');
+    const dragHandle = await helper.getDragHandle();
+    const target = iframe.locator('[data-block-uid="gd-1"]').first();
+    await helper.dragBlockWithMouse(dragHandle, target, true);
+
+    // grp-src-1 auto-converted to convGroupDst and moved in — via convertContainerBlock,
+    // so its child came along.
+    await expect(
+      iframe.locator('[data-block-uid="grp-box-1"] [data-container-type="convGroupDst"]'),
+    ).toHaveCount(3);
+    await expect(
+      iframe.locator('[data-block-uid="grp-src-1"] [data-container-type="convGroupDst"]'),
+    ).toHaveCount(1);
+    await expect(
+      iframe.locator('[data-block-uid="grp-src-1"] [data-conv-type="convTargetA"]'),
+    ).toHaveCount(1);
+  });
+
   test('cancelling the convert chooser leaves the block where it was', async ({ page }) => {
     const helper = new AdminUIHelper(page);
     await helper.login();

--- a/tests-playwright/integration/dnd-convert.spec.ts
+++ b/tests-playwright/integration/dnd-convert.spec.ts
@@ -10,6 +10,16 @@ import { test, expect } from '../fixtures';
 import { AdminUIHelper } from '../helpers/AdminUIHelper';
 
 test.describe('DnD / paste via conversion', () => {
+  // The toy conversion graph (convSource/convTargetA/convTargetB + convBox*)
+  // lives only in the MOCK frontend's shared-block-schemas.js. On admin-nuxt /
+  // admin-nextjs / admin-f7 those blocks aren't registered, so run mock-only.
+  test.beforeEach(({}, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'admin-mock',
+      'mock-only synthetic conversion blocks',
+    );
+  });
+
   test('drag into a container that only accepts a convert-target auto-converts it', async ({ page }) => {
     const helper = new AdminUIHelper(page);
     await helper.login();
@@ -123,6 +133,34 @@ test.describe('DnD / paste via conversion', () => {
       iframe.locator('[data-block-uid="box-1"] [data-conv-type="convTargetA"]'),
     ).toHaveCount(3);
     await expect(iframe.locator('[data-block-uid="src-1"] [data-conv-type="convSource"]')).toHaveCount(1);
+  });
+
+  test('pasting a single block with multiple convert-targets opens the chooser', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/dnd-convert-page');
+    const iframe = helper.getIframe();
+
+    // Copy the convSource, then paste inside convBoxMulti (accepts A or B).
+    await helper.clickBlockInIframe('src-1');
+    await helper.waitForIframeBlockHandle('src-1');
+    await page.keyboard.press('ControlOrMeta+c');
+    await expect(page.locator('#toolbar-paste-blocks')).toBeVisible({ timeout: 3000 });
+    await helper.clickBlockInIframe('b-1');
+    await helper.waitForIframeBlockHandle('b-1');
+    await page.keyboard.press('ControlOrMeta+v');
+
+    // Ask-first: two options → chooser appears, nothing inserted yet.
+    await expect(page.locator('.blocks-chooser')).toBeVisible();
+    await expect(
+      iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
+    ).toHaveCount(0);
+
+    // Pick Conv Target B → the pasted block is inserted, converted to B.
+    await page.locator('.blocks-chooser').getByText('Conv Target B', { exact: false }).click();
+    await expect(
+      iframe.locator('[data-block-uid="boxm-1"] [data-conv-type="convTargetB"]'),
+    ).toHaveCount(1);
   });
 
   test('cancelling the convert chooser leaves the block where it was', async ({ page }) => {


### PR DESCRIPTION
## Drag / paste into a spot via conversion

Gives drag-and-drop (and paste) more valid destinations: a block can now be dropped or pasted into a container whose `allowedBlocks` only admits a type the block can **convert** to. On drop it converts — automatically when one target type is reachable, or via the normal conversion chooser when several are.

Built on Hydra's existing `fieldMappings` conversion graph — no new conversion machinery.

### Behaviour (from the design brainstorm)
- **Identical indicators** — a convert-drop spot looks exactly like a native-fit spot; conversion is transparent on drop.
- **Auto vs popup** — one reachable target type → auto-convert; several → the chooser popup (single-block only).
- **Ask-first, atomic** — the popup appears *without* moving; picking a type runs convert + move as one `formData` update (one undo); dismissing is a no-op (the block never leaves its origin).
- **Multi-block = auto-only** — a batch drops only where every block has exactly one convertible option; no popup chains.
- **Mobile via cut/paste** — chevron/edge move stays native-only; conversion on mobile happens through paste (which this PR makes convert-aware).

### How it works
- **`getConversionMap(blocksConfig)`** (admin) — a static `{ sourceType: [reachableTypes] }` map from `getConvertibleTypes`, shipped to the iframe on `INITIAL_DATA`.
- **`acceptableAt(type, allowed, isMulti, conversionMap)`** — a Volto-free shared predicate (in `packages/hydra-js`) used by the iframe drag gate, so a spot the iframe offers is never rejected on drop (the admin re-resolves with the same graph).
- **`MOVE_BLOCKS` / `handlePaste`** resolve each block against the target's `allowedBlocks`: native, auto-convert (single option, via the extracted `convertBlockInPlace`), or the ask-first chooser (multiple options). The chooser's existing overlay is reused with a `pendingMove` / `pendingPaste`.

### Tests
- **Unit:** `getConversionMap` (vitest, 3) + `acceptableAt` truth table (jest, 8).
- **Integration (admin-mock):** auto-convert drop; multi-option drop → popup → convert+move is one undo; popup cancel → no change; paste-convert; multi-block auto-convert. Native drag/paste suites stay green.
- Toy conversion graph fixtures (`convSource → convTargetA/convTargetB`, restricted containers) keep the single-vs-multi cases deterministic (real blocks cross-convert too promiscuously via `@default`).

### Notes / decisions
- `conversionMap` is computed **fresh at each `INITIAL_DATA` send** (not memoized at mount): a frontend's custom blocks register into the registry *after* the View mounts.
- The built `packages/hydra-js/hydra.js` bundle is git-ignored (a build artifact); consumers use the `hydra.src.js` source export or build it in CI, so nothing bundle-related is committed.

Design + implementation plan: `docs/superpowers/specs/2026-07-18-dnd-paste-via-conversion-design.md`, `docs/superpowers/plans/2026-07-18-dnd-paste-via-conversion.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
