### PR TITLE
feat(block-sanity): optional per-block axe-core accessibility pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@babel/plugin-proposal-throw-expressions": "7.18.6",
     "@babel/plugin-syntax-export-namespace-from": "7.8.3",
     "@bgotink/playwright-coverage": "^0.3.2",
+    "axe-core": "^4.11.4",
     "@fiverr/afterbuild-webpack-plugin": "^1.0.0",
     "@loadable/babel-plugin": "5.13.2",
     "@loadable/webpack-plugin": "5.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@bgotink/playwright-coverage':
         specifier: ^0.3.2
         version: 0.3.2(@playwright/test@1.58.2)
+      axe-core:
+        specifier: ^4.11.4
+        version: 4.12.0
       '@fiverr/afterbuild-webpack-plugin':
         specifier: ^1.0.0
         version: 1.0.0

--- a/tests-playwright/bridge/block-sanity.spec.ts
+++ b/tests-playwright/bridge/block-sanity.spec.ts
@@ -17,6 +17,7 @@
 import { test as base, expect } from '../fixtures';
 import { AdminUIHelper } from '../helpers/AdminUIHelper';
 import { verifyBlockRendering } from '../helpers/BlockVerificationHelper';
+import { axeCheckBlock, formatViolations } from '../helpers/axe-sanity';
 import { getFrontendUrl } from './fixtures';
 import { URLS } from '../ports';
 import * as fs from 'fs';
@@ -191,6 +192,23 @@ test.describe('Block sanity (auto-discovered)', () => {
         // Skip data-edit-text clicks for discovered content — we just want rendering + annotation checks
         checkEditTextClicks: false,
       });
+
+      // Optional per-block accessibility pass (axe-core). Off by default; opt in
+      // with SANITY_AXE=1. Runs axe scoped to just this block — blocking =
+      // serious/critical WCAG A/AA that's block-level; advisory (moderate/minor
+      // or page-context rules) is logged but doesn't fail.
+      if (process.env.SANITY_AXE) {
+        const { blocking, advisory } = await axeCheckBlock(iframe, block.blockId);
+        if (advisory.length > 0) {
+          console.log(
+            `[axe] ${label}: ${advisory.length} advisory finding(s)\n${formatViolations(advisory)}`,
+          );
+        }
+        expect(
+          blocking,
+          `${label} has ${blocking.length} serious/critical a11y violation(s):\n${formatViolations(blocking)}`,
+        ).toEqual([]);
+      }
     });
   }
 });

--- a/tests-playwright/helpers/axe-sanity.ts
+++ b/tests-playwright/helpers/axe-sanity.ts
@@ -17,6 +17,12 @@ export interface AxeViolation {
   tags: string[];
 }
 
+// WCAG 2.0/2.1 A + AA plus axe's best-practice preset (heading-order, region,
+// landmark, page-has-heading-one, …). best-practice findings are reported as
+// advisory, never blocking. Override the whole set with SANITY_AXE_TAGS (a
+// comma-separated list of axe tags, e.g. "wcag2a,wcag2aa,wcag2aaa").
+const DEFAULT_AXE_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'];
+
 // Rules that need whole-page context. A block rendered in isolation in the sanity
 // harness isn't under a page's landmarks / heading outline, so these would
 // false-positive on every block — report them as advisory, never blocking.
@@ -57,27 +63,35 @@ export async function axeCheckBlock(
     }
   }, axeSource);
 
-  const raw = (await body.evaluate(async (_el, sel) => {
-    const results = await (
-      window as unknown as { axe: { run: (ctx: unknown, opts: unknown) => Promise<{ violations: unknown[] }> } }
-    ).axe.run(
-      { include: [sel] },
-      { runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] } },
-    );
-    return (results.violations as Array<Record<string, unknown>>).map((v) => ({
-      id: v.id as string,
-      impact: (v.impact as string) ?? null,
-      help: v.help as string,
-      nodes: (v.nodes as unknown[]).length,
-      tags: v.tags as string[],
-    }));
-  }, `[data-block-uid="${blockId}"]`)) as AxeViolation[];
+  const tags = process.env.SANITY_AXE_TAGS
+    ? process.env.SANITY_AXE_TAGS.split(',').map((t) => t.trim()).filter(Boolean)
+    : DEFAULT_AXE_TAGS;
+
+  const raw = (await body.evaluate(
+    async (_el, { sel, tags }: { sel: string; tags: string[] }) => {
+      const results = await (
+        window as unknown as { axe: { run: (ctx: unknown, opts: unknown) => Promise<{ violations: unknown[] }> } }
+      ).axe.run({ include: [sel] }, { runOnly: { type: 'tag', values: tags } });
+      return (results.violations as Array<Record<string, unknown>>).map((v) => ({
+        id: v.id as string,
+        impact: (v.impact as string) ?? null,
+        help: v.help as string,
+        nodes: (v.nodes as unknown[]).length,
+        tags: v.tags as string[],
+      }));
+    },
+    { sel: `[data-block-uid="${blockId}"]`, tags },
+  )) as AxeViolation[];
 
   const blocking: AxeViolation[] = [];
   const advisory: AxeViolation[] = [];
   for (const v of raw) {
     const severe = v.impact === 'serious' || v.impact === 'critical';
-    if (severe && !PAGE_LEVEL_RULES.has(v.id)) blocking.push(v);
+    // A best-practice-only rule (no WCAG tag) or a page-context rule can't be
+    // judged fairly on a block rendered in isolation — advisory, never blocking.
+    const bestPracticeOnly =
+      v.tags.includes('best-practice') && !v.tags.some((t) => t.startsWith('wcag'));
+    if (severe && !bestPracticeOnly && !PAGE_LEVEL_RULES.has(v.id)) blocking.push(v);
     else advisory.push(v);
   }
   return { blocking, advisory };

--- a/tests-playwright/helpers/axe-sanity.ts
+++ b/tests-playwright/helpers/axe-sanity.ts
@@ -1,0 +1,90 @@
+import type { FrameLocator } from '@playwright/test';
+import * as fs from 'fs';
+import { createRequire } from 'module';
+
+// Inject axe-core's source into the frame rather than using @axe-core/playwright:
+// that wrapper pulls in its OWN @playwright/test, which breaks the single linked
+// copy block-sanity relies on. axe-core is a standalone browser lib — run its
+// source in the frame, then call window.axe.run().
+const require = createRequire(import.meta.url);
+const axeSource = fs.readFileSync(require.resolve('axe-core/axe.min.js'), 'utf8');
+
+export interface AxeViolation {
+  id: string;
+  impact: string | null;
+  help: string;
+  nodes: number;
+  tags: string[];
+}
+
+// Rules that need whole-page context. A block rendered in isolation in the sanity
+// harness isn't under a page's landmarks / heading outline, so these would
+// false-positive on every block — report them as advisory, never blocking.
+const PAGE_LEVEL_RULES = new Set([
+  'region',
+  'landmark-one-main',
+  'landmark-unique',
+  'landmark-complementary-is-top-level',
+  'landmark-no-duplicate-banner',
+  'landmark-no-duplicate-contentinfo',
+  'page-has-heading-one',
+  'heading-order',
+  'bypass',
+  'document-title',
+  'html-has-lang',
+  'html-lang-valid',
+]);
+
+/**
+ * Run axe-core against a single rendered block inside the preview iframe.
+ *   blocking = serious/critical, block-level WCAG 2.0/2.1 A/AA violations
+ *   advisory = everything else (moderate/minor, or page-level rules that can't
+ *              be fairly judged on an isolated block)
+ * Optional — only called when SANITY_AXE is set on the block-sanity run.
+ */
+export async function axeCheckBlock(
+  iframe: FrameLocator,
+  blockId: string,
+): Promise<{ blocking: AxeViolation[]; advisory: AxeViolation[] }> {
+  const body = iframe.locator('body');
+
+  // Inject axe-core into the iframe's own frame (idempotent across blocks).
+  await body.evaluate((_el, src) => {
+    if (!(window as unknown as { axe?: unknown }).axe) {
+      const s = document.createElement('script');
+      s.textContent = src as string;
+      document.head.appendChild(s);
+    }
+  }, axeSource);
+
+  const raw = (await body.evaluate(async (_el, sel) => {
+    const results = await (
+      window as unknown as { axe: { run: (ctx: unknown, opts: unknown) => Promise<{ violations: unknown[] }> } }
+    ).axe.run(
+      { include: [sel] },
+      { runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] } },
+    );
+    return (results.violations as Array<Record<string, unknown>>).map((v) => ({
+      id: v.id as string,
+      impact: (v.impact as string) ?? null,
+      help: v.help as string,
+      nodes: (v.nodes as unknown[]).length,
+      tags: v.tags as string[],
+    }));
+  }, `[data-block-uid="${blockId}"]`)) as AxeViolation[];
+
+  const blocking: AxeViolation[] = [];
+  const advisory: AxeViolation[] = [];
+  for (const v of raw) {
+    const severe = v.impact === 'serious' || v.impact === 'critical';
+    if (severe && !PAGE_LEVEL_RULES.has(v.id)) blocking.push(v);
+    else advisory.push(v);
+  }
+  return { blocking, advisory };
+}
+
+export function formatViolations(vs: AxeViolation[]): string {
+  return vs
+    .map((v) => `  - [${v.impact}] ${v.id}: ${v.help} (${v.nodes} node(s))`)
+    .join('\n');
+}


### PR DESCRIPTION
## Optional per-block accessibility (axe-core) in block-sanity

Adds an **opt-in** accessibility pass to the auto-discovered block-sanity suite. Off by default — enable with `SANITY_AXE=1` on the run — so existing consumers are unchanged.

### What it does
After a block renders in the mock-parent iframe (the existing render + edit-annotation contract), it runs **axe-core scoped to just that block**:
- **blocking** — serious/critical WCAG 2.0/2.1 A/AA violations that are block-level → fails the test.
- **advisory** — moderate/minor, or page-context rules (`region`, `landmark-*`, `heading-order`, `page-has-heading-one`, …) that can't be judged fairly on a block rendered in isolation → logged, not failed.

Per-block scoping means a failure tells you exactly which block has the a11y issue, rather than a whole-page pass/fail.

### Why inject axe-core's source (not `@axe-core/playwright`)
The wrapper pulls in its own `@playwright/test`, which breaks the single linked copy the block-sanity helpers rely on. axe-core is a standalone browser lib, so its source is injected into the frame and `window.axe.run()` is called there (same approach pretagov-site uses).

### Files
- `tests-playwright/helpers/axe-sanity.ts` — the helper (inject + run + bucket).
- `tests-playwright/bridge/block-sanity.spec.ts` — gated call after `verifyBlockRendering`.
- `package.json` — `axe-core` devDependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
