### PR TITLE
test(block-sanity): aggregate slate-field editability across examples

### DIFF
--- a/tests-playwright/bridge/block-sanity.spec.ts
+++ b/tests-playwright/bridge/block-sanity.spec.ts
@@ -17,6 +17,7 @@
 import { test as base, expect } from '../fixtures';
 import { AdminUIHelper } from '../helpers/AdminUIHelper';
 import { verifyBlockRendering } from '../helpers/BlockVerificationHelper';
+import { slateFieldsNeverEditable } from '../helpers/field-coverage';
 import { axeCheckBlock, formatViolations } from '../helpers/axe-sanity';
 import { getFrontendUrl } from './fixtures';
 import { URLS } from '../ports';
@@ -211,4 +212,23 @@ test.describe('Block sanity (auto-discovered)', () => {
       }
     });
   }
+
+  // Aggregate check: every schema-declared slate field must have its
+  // [data-edit-text] edit container in AT LEAST ONE discovered example of its
+  // block type. The per-example render checks above record coverage instead of
+  // failing individually, because a field can be gated by an optional synced
+  // element (e.g. a card's `description` behind the grid's `copy` element) and
+  // legitimately not render in every example. This runs last (defined after the
+  // per-block loop; block-sanity is serial) so coverage is fully accumulated.
+  test('every slate field is editable in at least one example', () => {
+    const never = slateFieldsNeverEditable();
+    expect(
+      never,
+      `Slate fields with NO [data-edit-text] container in ANY discovered example ` +
+        `(each is uneditable everywhere it appears):\n` +
+        never
+          .map((n) => `  - ${n.blockType}.${n.field}\n      e.g. ${n.example}`)
+          .join('\n'),
+    ).toEqual([]);
+  });
 });

--- a/tests-playwright/helpers/BlockVerificationHelper.ts
+++ b/tests-playwright/helpers/BlockVerificationHelper.ts
@@ -9,6 +9,7 @@
  */
 import { expect } from '@playwright/test';
 import type { Page, FrameLocator, Locator } from '@playwright/test';
+import { recordSlateFieldContainer } from './field-coverage';
 
 export interface SubBlock {
   id: string;
@@ -307,15 +308,24 @@ export async function checkSlateAnnotations(
     slateHasValue = () => true;
   }
 
+  const blockType = (blockData?.['@type'] as string | undefined) ?? '(unknown)';
+  const coverageUid = (await block.getAttribute('data-block-uid')) ?? '(no uid)';
   for (const field of slateFields) {
     // Accept either a descendant [data-edit-text="<field>"] OR the block
     // element itself carrying the attribute (renderers are free to collapse
     // the block wrapper and the edit-text container onto one element).
     const blockHasAttr = (await block.getAttribute('data-edit-text')) === field;
     const container = blockHasAttr ? block : block.locator(`[data-edit-text="${field}"]`).first();
-    if (!(await container.count())) {
-      // Build a diagnostic showing what data-edit-text values ARE present in
-      // the block — usually it's a typo or a misplaced attribute.
+    const hasContainer = (await container.count()) > 0;
+
+    // Record editability rather than failing per-instance: a slate field only
+    // needs its edit container in ONE example of a block type. Some fields are
+    // gated by an optional synced element (e.g. a card's `description` behind
+    // the grid's `copy` element) and legitimately don't render in every
+    // example. A final aggregate test (slateFieldsNeverEditable) fails only if
+    // a field is never editable in ANY example. On a miss, capture which
+    // data-edit-text values ARE present for the aggregate's diagnostic.
+    if (!hasContainer) {
       const context = await block.evaluate((el) => {
         const outer = (el.outerHTML || '').slice(0, 200);
         const self = el.getAttribute('data-edit-text');
@@ -323,17 +333,21 @@ export async function checkSlateAnnotations(
           .map((d) => `${d.tagName.toLowerCase()}[data-edit-text="${d.getAttribute('data-edit-text')}"]`);
         return { outer, self, descendants };
       });
-      throw new Error(
-        `Slate field "${field}": no [data-edit-text="${field}"] container found.\n` +
-          `  block element's own data-edit-text: ${context.self ?? '(none)'}\n` +
-          `  descendants with data-edit-text: ${context.descendants.length ? context.descendants.join(', ') : '(none)'}\n` +
-          `  block outerHTML (truncated): ${context.outer}`,
+      recordSlateFieldContainer(
+        blockType,
+        field,
+        false,
+        `[${coverageUid}] own data-edit-text: ${context.self ?? '(none)'}; ` +
+          `descendants: ${context.descendants.length ? context.descendants.join(', ') : '(none)'}; ` +
+          `html: ${context.outer}`,
       );
+      continue;
     }
+    recordSlateFieldContainer(blockType, field, true, `[${coverageUid}]`);
 
-    // Empty/null slate fields still need the edit-text container (checked
-    // above) but nothing to round-trip — the renderer has no source value
-    // to mirror into the DOM.
+    // Empty/null slate fields have the edit-text container (checked above) but
+    // nothing to round-trip — the renderer has no source value to mirror into
+    // the DOM.
     if (!slateHasValue(field)) continue;
 
     // Round-trip via the bridge's own DOM→Slate reader. The bridge already

--- a/tests-playwright/helpers/field-coverage.ts
+++ b/tests-playwright/helpers/field-coverage.ts
@@ -1,0 +1,61 @@
+// Aggregate slate-field editability across all discovered block examples.
+//
+// A slate field only needs its [data-edit-text="<field>"] edit container in ONE
+// example of a block type — not every one. Some fields are gated by an optional
+// synced element (e.g. a card's `description` is only editable when the grid's
+// `copy` element is on), so they legitimately render in some examples and not
+// others. Requiring the container per-instance false-fails the gated-off ones.
+//
+// The per-example render check records coverage here instead of throwing; a
+// final aggregate test (via slateFieldsNeverEditable) fails only if a field is
+// never editable in ANY example of its block type.
+//
+// This relies on the per-example tests and the aggregate sharing module state,
+// i.e. running in one worker. block-sanity's config uses fullyParallel: false,
+// so this single spec file stays on one worker and the aggregation is exact.
+// Under a fully-parallel config the state splits per worker, but a field that
+// renders its container in every example (the norm) is still recorded in every
+// worker, so `missing` stays empty and the aggregate can't false-fail — only a
+// field editable in *some* examples and split across workers could, and that
+// gated pattern only occurs in this project's own (serial) content.
+
+const seenByType = new Map<string, Set<string>>();
+const missingByType = new Map<string, Map<string, string>>();
+
+export function recordSlateFieldContainer(
+  blockType: string,
+  field: string,
+  hasContainer: boolean,
+  example: string,
+): void {
+  if (hasContainer) {
+    let set = seenByType.get(blockType);
+    if (!set) seenByType.set(blockType, (set = new Set()));
+    set.add(field);
+  } else {
+    let miss = missingByType.get(blockType);
+    if (!miss) missingByType.set(blockType, (miss = new Map()));
+    // Keep the first example we saw a field missing in, for the diagnostic.
+    if (!miss.has(field)) miss.set(field, example);
+  }
+}
+
+export interface UneditableSlateField {
+  blockType: string;
+  field: string;
+  example: string;
+}
+
+// Fields that were missing their edit container in at least one example AND
+// never had it in any example of the same block type.
+export function slateFieldsNeverEditable(): UneditableSlateField[] {
+  const out: UneditableSlateField[] = [];
+  for (const [blockType, fields] of missingByType) {
+    for (const [field, example] of fields) {
+      if (!seenByType.get(blockType)?.has(field)) {
+        out.push({ blockType, field, example });
+      }
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## What

Makes the block-sanity slate-field editability check **aggregate**: a schema-declared slate field must have its `[data-edit-text="<field>"]` edit container in **at least one** discovered example of a block type, not in every one.

## Why

Fields can be gated by an optional synced element — e.g. a card's `description` is only editable when the grid's `copy` element is on. The previous per-instance check **threw** the moment any example lacked the container, so a legitimately copy-off card (description not rendered) hard-failed block-sanity even though the field is editable in a copy-on card.

## How

- `checkSlateAnnotations` (BlockVerificationHelper) now **records** per-`(blockType, field)` container coverage instead of throwing, and `continue`s when a container is absent (skipping the round-trip it can't perform).
- New `helpers/field-coverage.ts` accumulates coverage across examples.
- A final block-sanity test, `every slate field is editable in at least one example`, fails only if a field has **no** container in **any** example of its type.

## Concurrency

block-sanity runs serial (`fullyParallel: false`), so the aggregate test runs last with full coverage. Under a fully-parallel config the module state splits per worker, but a field whose container renders in every example (the norm) is still recorded in every worker, so `missing` stays empty and the aggregate cannot false-fail — only the gated pattern above (present in some examples, this project's own serial content) relies on the single-worker accumulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)