### PR TITLE
feat(fieldRules): drop hidden fields from required (conditional required)

### DIFF
--- a/packages/volto-hydra/src/utils/schemaInheritance.js
+++ b/packages/volto-hydra/src/utils/schemaInheritance.js
@@ -1666,7 +1666,14 @@ function createFieldRulesEnhancer(rulesConfig) {
       ...schema,
       properties: newProperties,
       fieldsets: newFieldsets,
-      required: schema.required || [],
+      // A hidden field can't be required — the editor can't supply a value it
+      // can't see, and a required-but-absent property would wedge the form. So
+      // drop any hidden field from `required`. This also gives *conditional*
+      // required for free: declare a field required in the base schema, gate it
+      // with a `when` rule, and it's required exactly when the rule shows it
+      // (e.g. a card's `image` is required only when the grid enables the image
+      // element).
+      required: (schema.required || []).filter((f) => !fieldsToHide.has(f)),
     };
   };
 

--- a/packages/volto-hydra/src/utils/schemaInheritance.test.js
+++ b/packages/volto-hydra/src/utils/schemaInheritance.test.js
@@ -202,6 +202,58 @@ describe('fieldRules — contains operator (multiselect-driven visibility)', () 
   });
 });
 
+/**
+ * fieldRules + `required` — a hidden field must not stay required.
+ *
+ * A field declared required in the base schema but hidden by a `when` rule is
+ * dropped from `required` too: the editor can't supply a value it can't see,
+ * and a required-but-absent property would wedge the form. This gives
+ * *conditional* required — required exactly when the rule shows the field, e.g.
+ * a card's `image` required only when the grid enables the image element.
+ */
+describe('fieldRules — hidden fields are dropped from required (conditional required)', () => {
+  const baseSchema = () => ({
+    fieldsets: [{ id: 'default', title: 'Default', fields: ['elements', 'image'] }],
+    properties: {
+      elements: { title: 'Elements', type: 'array' },
+      image: { title: 'Image', widget: 'image' },
+    },
+    required: ['image'],
+  });
+
+  // Show (and thus keep required) `image` only when `elements` includes 'image'.
+  const recipe = {
+    fieldRules: {
+      image: { when: { elements: { contains: 'image' } }, else: false },
+    },
+  };
+
+  test('keeps the field required when the rule shows it', () => {
+    const enhancer = createSchemaEnhancerFromRecipe(recipe);
+    const out = enhancer({ schema: baseSchema(), formData: { elements: ['image'] } });
+    expect(out.properties.image).toBeDefined();
+    expect(out.required).toContain('image');
+  });
+
+  test('drops the field from required when the rule hides it', () => {
+    const enhancer = createSchemaEnhancerFromRecipe(recipe);
+    const out = enhancer({ schema: baseSchema(), formData: { elements: ['date'] } });
+    expect(out.properties.image).toBeUndefined();
+    expect(out.required).not.toContain('image');
+  });
+
+  test('leaves an unrelated always-required field in place', () => {
+    const schema = baseSchema();
+    schema.required = ['title', 'image'];
+    schema.properties.title = { title: 'Title' };
+    schema.fieldsets[0].fields.unshift('title');
+    const enhancer = createSchemaEnhancerFromRecipe(recipe);
+    const out = enhancer({ schema, formData: { elements: [] } });
+    expect(out.required).toContain('title'); // no rule → never hidden → stays
+    expect(out.required).not.toContain('image'); // hidden → dropped
+  });
+});
+
 describe('getConversionMap', () => {
   // Edge direction: `X.fieldMappings[Y]` means "X can be built FROM Y", i.e. Y→X.
   // So the edge a→b→c is declared on the TARGETS: b.fieldMappings.a, c.fieldMappings.b.


### PR DESCRIPTION
## What

`createFieldRulesEnhancer` now removes any **hidden** field from `schema.required`, instead of passing `required` through untouched.

## Why

A field declared `required` in the base schema but hidden by a `when` rule stayed in `required` — a required-but-absent property that wedges the sidebar form (the editor can't supply a value for a field it can't see).

## Bonus: conditional required, no new syntax

Because a hidden field is dropped from `required`, you get **conditional required** for free: declare a field required in the base schema and gate its visibility with a `when` rule, and it's required *exactly* when the rule shows it.

Motivating case: a card's `image` should be required only when the grid enables the image element. With this change:
```js
required: ['image'],
fieldRules: { image: { when: { '../itemDefaults_elements': { contains: 'image' } }, else: false } }
```
→ `image` required when the element is on, not required (and hidden) when off.

## Tests

`schemaInheritance.test.js` — new `fieldRules — hidden fields are dropped from required` describe: kept-required-when-shown, dropped-when-hidden, and an unrelated always-required field stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)