### PR TITLE
docs(examples): add description + show render snippet

### DIFF
--- a/docs/content/content/content/docs/examples/accordion/data.json
+++ b/docs/content/content/content/docs/examples/accordion/data.json
@@ -2298,21 +2298,13 @@
     },
     "ref-accordion-description": {
       "@type": "slate",
-      "plaintext": "A collapsible panel group. Each panel is an object_list item with a title and a content area that holds child blocks.\n\nThis is a custom block — register it via initBridge.",
+      "plaintext": "A collapsible panel group. Each panel is an object_list item with a title and a content area that holds child blocks.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A collapsible panel group. Each panel is an object_list item with a title and a content area that holds child blocks."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom block — register it via initBridge."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/accordion/data.json
+++ b/docs/content/content/content/docs/examples/accordion/data.json
@@ -2295,11 +2295,34 @@
       "alt": "The accordion example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-accordion-description": {
+      "@type": "slate",
+      "plaintext": "A collapsible panel group. Each panel is an object_list item with a title and a content area that holds child blocks.\n\nThis is a custom block — register it via initBridge.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A collapsible panel group. Each panel is an object_list item with a title and a content area that holds child blocks."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom block — register it via initBridge."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "fec13476-1231-42fc-84d5-b110e8e3c6e7",
+      "ref-accordion-description",
       "editor-screenshot",
       "41a82a93-c00c-4a40-bac8-53a3e3420c8e",
       "8f68209e-220e-4230-9d42-8b0602573bd9",

--- a/docs/content/content/content/docs/examples/button/data.json
+++ b/docs/content/content/content/docs/examples/button/data.json
@@ -455,11 +455,34 @@
       "alt": "The button example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-button-description": {
+      "@type": "slate",
+      "plaintext": "A call-to-action button with an editable label and link.\n\nThis is a custom block — register it via initBridge.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A call-to-action button with an editable label and link."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom block — register it via initBridge."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "f3ee132b-6215-4e42-b26b-713f668eea61",
+      "ref-button-description",
       "editor-screenshot",
       "eab7123b-6a41-4537-8979-09e4fbbf317b",
       "b03e7ce7-b7b5-4413-bd2e-d42bff4bba9a",

--- a/docs/content/content/content/docs/examples/button/data.json
+++ b/docs/content/content/content/docs/examples/button/data.json
@@ -458,21 +458,13 @@
     },
     "ref-button-description": {
       "@type": "slate",
-      "plaintext": "A call-to-action button with an editable label and link.\n\nThis is a custom block — register it via initBridge.",
+      "plaintext": "A call-to-action button with an editable label and link.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A call-to-action button with an editable label and link."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom block — register it via initBridge."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/columns/data.json
+++ b/docs/content/content/content/docs/examples/columns/data.json
@@ -60,11 +60,34 @@
         }
       ],
       "slotId": "rendering"
+    },
+    "ref-columns-description": {
+      "@type": "slate",
+      "plaintext": "A horizontal multi-column container. The block has one slot — columns — restricted to column children, capped at four. Each column is itself a container holding any of its allowed inner block types (slate, image, …).\n\nThis is a custom block — register it via initBridge.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A horizontal multi-column container. The block has one slot — columns — restricted to column children, capped at four. Each column is itself a container holding any of its allowed inner block types (slate, image, …)."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom block — register it via initBridge."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "title-1",
+      "ref-columns-description",
       "ref-columns-schema",
       "ref-columns-json-data",
       "ref-columns-rendering"

--- a/docs/content/content/content/docs/examples/columns/data.json
+++ b/docs/content/content/content/docs/examples/columns/data.json
@@ -63,21 +63,13 @@
     },
     "ref-columns-description": {
       "@type": "slate",
-      "plaintext": "A horizontal multi-column container. The block has one slot — columns — restricted to column children, capped at four. Each column is itself a container holding any of its allowed inner block types (slate, image, …).\n\nThis is a custom block — register it via initBridge.",
+      "plaintext": "A horizontal multi-column container. The block has one slot — columns — restricted to column children, capped at four. Each column is itself a container holding any of its allowed inner block types (slate, image, …).",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A horizontal multi-column container. The block has one slot — columns — restricted to column children, capped at four. Each column is itself a container holding any of its allowed inner block types (slate, image, …)."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom block — register it via initBridge."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/contextNavigation/data.json
+++ b/docs/content/content/content/docs/examples/contextNavigation/data.json
@@ -60,11 +60,34 @@
         }
       ],
       "slotId": "rendering"
+    },
+    "ref-contextNavigation-description": {
+      "@type": "slate",
+      "plaintext": "A vertical navigation list for grouped pages — a left sidebar on desktop and a collapsible disclosure at the top on mobile. Each row is a navItem (hand-added link) and/or a listing (auto-populated from a path query). The active link is detected from the current URL and gets aria-current=\"page\" plus a .current class. Named after Plone's @contextnavigation endpoint, which serves the same purpose.\n\nThis is a custom block — register it via initBridge. Pair it with navItem (a restricted child block).",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A vertical navigation list for grouped pages — a left sidebar on desktop and a collapsible disclosure at the top on mobile. Each row is a navItem (hand-added link) and/or a listing (auto-populated from a path query). The active link is detected from the current URL and gets aria-current=\"page\" plus a .current class. Named after Plone's @contextnavigation endpoint, which serves the same purpose."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom block — register it via initBridge. Pair it with navItem (a restricted child block)."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "title-1",
+      "ref-contextNavigation-description",
       "ref-contextNavigation-schema",
       "ref-contextNavigation-json-data",
       "ref-contextNavigation-rendering"

--- a/docs/content/content/content/docs/examples/contextNavigation/data.json
+++ b/docs/content/content/content/docs/examples/contextNavigation/data.json
@@ -63,21 +63,13 @@
     },
     "ref-contextNavigation-description": {
       "@type": "slate",
-      "plaintext": "A vertical navigation list for grouped pages — a left sidebar on desktop and a collapsible disclosure at the top on mobile. Each row is a navItem (hand-added link) and/or a listing (auto-populated from a path query). The active link is detected from the current URL and gets aria-current=\"page\" plus a .current class. Named after Plone's @contextnavigation endpoint, which serves the same purpose.\n\nThis is a custom block — register it via initBridge. Pair it with navItem (a restricted child block).",
+      "plaintext": "A vertical navigation list for grouped pages — a left sidebar on desktop and a collapsible disclosure at the top on mobile. Each row is a navItem (hand-added link) and/or a listing (auto-populated from a path query). The active link is detected from the current URL and gets aria-current=\"page\" plus a .current class. Named after Plone's @contextnavigation endpoint, which serves the same purpose.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A vertical navigation list for grouped pages — a left sidebar on desktop and a collapsible disclosure at the top on mobile. Each row is a navItem (hand-added link) and/or a listing (auto-populated from a path query). The active link is detected from the current URL and gets aria-current=\"page\" plus a .current class. Named after Plone's @contextnavigation endpoint, which serves the same purpose."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom block — register it via initBridge. Pair it with navItem (a restricted child block)."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/form/data.json
+++ b/docs/content/content/content/docs/examples/form/data.json
@@ -132,21 +132,13 @@
     },
     "ref-form-description": {
       "@type": "slate",
-      "plaintext": "A multi-field form with configurable field types, validation, and email submission. Fields are stored as a typed object_list — each field has a field_type that maps to a sub-block schema.\n\nThis is a custom block — register it via initBridge.",
+      "plaintext": "A multi-field form with configurable field types, validation, and email submission. Fields are stored as a typed object_list — each field has a field_type that maps to a sub-block schema.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A multi-field form with configurable field types, validation, and email submission. Fields are stored as a typed object_list — each field has a field_type that maps to a sub-block schema."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom block — register it via initBridge."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/form/data.json
+++ b/docs/content/content/content/docs/examples/form/data.json
@@ -129,11 +129,34 @@
       "alt": "The form example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-form-description": {
+      "@type": "slate",
+      "plaintext": "A multi-field form with configurable field types, validation, and email submission. Fields are stored as a typed object_list — each field has a field_type that maps to a sub-block schema.\n\nThis is a custom block — register it via initBridge.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A multi-field form with configurable field types, validation, and email submission. Fields are stored as a typed object_list — each field has a field_type that maps to a sub-block schema."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom block — register it via initBridge."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "00e8d49b-5b99-4d2f-83b3-7d69bc80b893",
+      "ref-form-description",
       "editor-screenshot",
       "3687103d-0766-4d5e-8aae-fc7e65c457a6",
       "eb25b89c-d64a-4566-8e6e-71fd0f371964",

--- a/docs/content/content/content/docs/examples/grid/data.json
+++ b/docs/content/content/content/docs/examples/grid/data.json
@@ -84,21 +84,13 @@
     },
     "ref-grid-description": {
       "@type": "slate",
-      "plaintext": "A responsive grid that lays out child blocks in equal-width cells. The block uses Volto's standard shared-blocks shape — blocks is the dict of children, blocks_layout.items is their order — and constrains the allowed types via allowedBlocks.\n\nThis is a built-in block.",
+      "plaintext": "A responsive grid that lays out child blocks in equal-width cells. The block uses Volto's standard shared-blocks shape — blocks is the dict of children, blocks_layout.items is their order — and constrains the allowed types via allowedBlocks.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A responsive grid that lays out child blocks in equal-width cells. The block uses Volto's standard shared-blocks shape — blocks is the dict of children, blocks_layout.items is their order — and constrains the allowed types via allowedBlocks."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/grid/data.json
+++ b/docs/content/content/content/docs/examples/grid/data.json
@@ -81,11 +81,34 @@
           "code": "<script>\n  import BlockRenderer from './BlockRenderer.svelte';\n  export let block;\n  $: blocks = block.blocks || {};\n  $: items = block.blocks_layout?.items || [];\n</script>\n\n<div data-block-uid={block['@uid']} class=\"grid-block\">\n  <div style=\"display: grid; grid-template-columns: repeat({items.length}, 1fr); gap: 1rem\">\n    {#each items as id (id)}\n      <div class=\"grid-cell\">\n        <BlockRenderer block={{ ...blocks[id], '@uid': id }} />\n      </div>\n    {/each}\n  </div>\n</div>"
         }
       ]
+    },
+    "ref-grid-description": {
+      "@type": "slate",
+      "plaintext": "A responsive grid that lays out child blocks in equal-width cells. The block uses Volto's standard shared-blocks shape — blocks is the dict of children, blocks_layout.items is their order — and constrains the allowed types via allowedBlocks.\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A responsive grid that lays out child blocks in equal-width cells. The block uses Volto's standard shared-blocks shape — blocks is the dict of children, blocks_layout.items is their order — and constrains the allowed types via allowedBlocks."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "d3f1c443-583f-4e8e-a682-3bf25752a300",
+      "ref-grid-description",
       "616b625c-b79f-4881-8536-b67a9e401a7d",
       "7624cf59-05d0-4055-8f55-5fd6597d84b0",
       "ref-grid-schema",

--- a/docs/content/content/content/docs/examples/heading/data.json
+++ b/docs/content/content/content/docs/examples/heading/data.json
@@ -217,11 +217,34 @@
           "type": "p"
         }
       ]
+    },
+    "ref-heading-description": {
+      "@type": "slate",
+      "plaintext": "A standalone heading block that renders as h1–h6 based on a configurable tag field. Unlike headings inside a slate block, this is a dedicated block type with its own heading text field.\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A standalone heading block that renders as h1–h6 based on a configurable tag field. Unlike headings inside a slate block, this is a dedicated block type with its own heading text field."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "e58cca3c-95d4-4819-951d-48415706bf41",
+      "ref-heading-description",
       "4a0352d5-89df-48aa-944e-7270e81351d4",
       "faabad67-4aa2-4774-a48c-b1accf288700",
       "fe637263-126e-4a7f-b4aa-36369c5155cc",

--- a/docs/content/content/content/docs/examples/heading/data.json
+++ b/docs/content/content/content/docs/examples/heading/data.json
@@ -220,21 +220,13 @@
     },
     "ref-heading-description": {
       "@type": "slate",
-      "plaintext": "A standalone heading block that renders as h1–h6 based on a configurable tag field. Unlike headings inside a slate block, this is a dedicated block type with its own heading text field.\n\nThis is a built-in block.",
+      "plaintext": "A standalone heading block that renders as h1–h6 based on a configurable tag field. Unlike headings inside a slate block, this is a dedicated block type with its own heading text field.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A standalone heading block that renders as h1–h6 based on a configurable tag field. Unlike headings inside a slate block, this is a dedicated block type with its own heading text field."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/hero/data.json
+++ b/docs/content/content/content/docs/examples/hero/data.json
@@ -63,21 +63,13 @@
     },
     "ref-hero-description": {
       "@type": "slate",
-      "plaintext": "A full-width hero section with heading, subheading, image, rich text description, and a call-to-action button. Demonstrates multiple field types in a single block: string, textarea, slate, image, and object_browser.\n\nThis is a custom block — register it via initBridge.",
+      "plaintext": "A full-width hero section with heading, subheading, image, rich text description, and a call-to-action button. Demonstrates multiple field types in a single block: string, textarea, slate, image, and object_browser.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A full-width hero section with heading, subheading, image, rich text description, and a call-to-action button. Demonstrates multiple field types in a single block: string, textarea, slate, image, and object_browser."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom block — register it via initBridge."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/hero/data.json
+++ b/docs/content/content/content/docs/examples/hero/data.json
@@ -60,11 +60,34 @@
         }
       ],
       "slotId": "rendering"
+    },
+    "ref-hero-description": {
+      "@type": "slate",
+      "plaintext": "A full-width hero section with heading, subheading, image, rich text description, and a call-to-action button. Demonstrates multiple field types in a single block: string, textarea, slate, image, and object_browser.\n\nThis is a custom block — register it via initBridge.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A full-width hero section with heading, subheading, image, rich text description, and a call-to-action button. Demonstrates multiple field types in a single block: string, textarea, slate, image, and object_browser."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom block — register it via initBridge."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "title-1",
+      "ref-hero-description",
       "ref-hero-schema",
       "ref-hero-json-data",
       "ref-hero-rendering"

--- a/docs/content/content/content/docs/examples/highlight/data.json
+++ b/docs/content/content/content/docs/examples/highlight/data.json
@@ -257,11 +257,34 @@
       "alt": "The highlight example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-highlight-description": {
+      "@type": "slate",
+      "plaintext": "A prominent content section with a background image, overlay, title, rich text body, and an optional call-to-action link. Used for feature callouts and banners.\n\nThis is a custom block — register it via initBridge.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A prominent content section with a background image, overlay, title, rich text body, and an optional call-to-action link. Used for feature callouts and banners."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom block — register it via initBridge."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "af3c704a-1f80-48c8-843b-dc29368d43d9",
+      "ref-highlight-description",
       "editor-screenshot",
       "8d932379-1247-4281-bd30-dfecd5b3c378",
       "417e7343-af04-4da4-96bf-29321a3e0fc6",

--- a/docs/content/content/content/docs/examples/highlight/data.json
+++ b/docs/content/content/content/docs/examples/highlight/data.json
@@ -260,21 +260,13 @@
     },
     "ref-highlight-description": {
       "@type": "slate",
-      "plaintext": "A prominent content section with a background image, overlay, title, rich text body, and an optional call-to-action link. Used for feature callouts and banners.\n\nThis is a custom block — register it via initBridge.",
+      "plaintext": "A prominent content section with a background image, overlay, title, rich text body, and an optional call-to-action link. Used for feature callouts and banners.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A prominent content section with a background image, overlay, title, rich text body, and an optional call-to-action link. Used for feature callouts and banners."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom block — register it via initBridge."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/image-block/data.json
+++ b/docs/content/content/content/docs/examples/image-block/data.json
@@ -266,11 +266,34 @@
       "alt": "The image-block example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-image-description": {
+      "@type": "slate",
+      "plaintext": "Displays an image with optional alt text and link. Supports the image picker widget for selecting images from the Plone content tree or uploading new ones.\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Displays an image with optional alt text and link. Supports the image picker widget for selecting images from the Plone content tree or uploading new ones."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "4bfc973c-5fbf-45a3-819a-750a3eff4def",
+      "ref-image-description",
       "editor-screenshot",
       "ed863393-7692-4cc3-8b39-503591d4ea80",
       "bcc07f9d-7f53-450a-b3f4-20286fd66692",

--- a/docs/content/content/content/docs/examples/image-block/data.json
+++ b/docs/content/content/content/docs/examples/image-block/data.json
@@ -269,21 +269,13 @@
     },
     "ref-image-description": {
       "@type": "slate",
-      "plaintext": "Displays an image with optional alt text and link. Supports the image picker widget for selecting images from the Plone content tree or uploading new ones.\n\nThis is a built-in block.",
+      "plaintext": "Displays an image with optional alt text and link. Supports the image picker widget for selecting images from the Plone content tree or uploading new ones.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Displays an image with optional alt text and link. Supports the image picker widget for selecting images from the Plone content tree or uploading new ones."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/introduction/data.json
+++ b/docs/content/content/content/docs/examples/introduction/data.json
@@ -138,21 +138,13 @@
     },
     "ref-introduction-description": {
       "@type": "slate",
-      "plaintext": "Displays the page's title and description as a styled header. The introduction block has no content of its own — it reads title and description from the page metadata.\n\nThis is a built-in block.",
+      "plaintext": "Displays the page's title and description as a styled header. The introduction block has no content of its own — it reads title and description from the page metadata.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Displays the page's title and description as a styled header. The introduction block has no content of its own — it reads title and description from the page metadata."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/introduction/data.json
+++ b/docs/content/content/content/docs/examples/introduction/data.json
@@ -135,11 +135,34 @@
       "alt": "The introduction example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-introduction-description": {
+      "@type": "slate",
+      "plaintext": "Displays the page's title and description as a styled header. The introduction block has no content of its own — it reads title and description from the page metadata.\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Displays the page's title and description as a styled header. The introduction block has no content of its own — it reads title and description from the page metadata."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "50727b9a-1f8a-4857-aab5-8acc6985bfc6",
+      "ref-introduction-description",
       "editor-screenshot",
       "d0438a28-aaaf-4db1-8887-c9b3351787d3",
       "d35f209e-12c1-4a30-ae36-52f84a4a0b7b",

--- a/docs/content/content/content/docs/examples/listing/data.json
+++ b/docs/content/content/content/docs/examples/listing/data.json
@@ -205,11 +205,34 @@
       "alt": "The listing example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-listing-description": {
+      "@type": "slate",
+      "plaintext": "Displays a list of content items from a query. The listing block fetches items from the Plone catalog based on a querystring and renders each item using a configurable item type (variation). Built-in item types are default (title + description) and summary (title + description + image).\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Displays a list of content items from a query. The listing block fetches items from the Plone catalog based on a querystring and renders each item using a configurable item type (variation). Built-in item types are default (title + description) and summary (title + description + image)."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "43068b6d-d8e9-4acc-912b-eabcdc650939",
+      "ref-listing-description",
       "editor-screenshot",
       "24280e07-e962-4414-8ee5-cdaf58ca5f35",
       "53ececaa-4219-42a9-861d-862be364fd60",

--- a/docs/content/content/content/docs/examples/listing/data.json
+++ b/docs/content/content/content/docs/examples/listing/data.json
@@ -208,21 +208,13 @@
     },
     "ref-listing-description": {
       "@type": "slate",
-      "plaintext": "Displays a list of content items from a query. The listing block fetches items from the Plone catalog based on a querystring and renders each item using a configurable item type (variation). Built-in item types are default (title + description) and summary (title + description + image).\n\nThis is a built-in block.",
+      "plaintext": "Displays a list of content items from a query. The listing block fetches items from the Plone catalog based on a querystring and renders each item using a configurable item type (variation). Built-in item types are default (title + description) and summary (title + description + image).",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Displays a list of content items from a query. The listing block fetches items from the Plone catalog based on a querystring and renders each item using a configurable item type (variation). Built-in item types are default (title + description) and summary (title + description + image)."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/maps/data.json
+++ b/docs/content/content/content/docs/examples/maps/data.json
@@ -266,21 +266,13 @@
     },
     "ref-maps-description": {
       "@type": "slate",
-      "plaintext": "Embeds a map from a URL (Google Maps, OpenStreetMap, etc.) using an iframe. The url field should contain the embed URL, and title provides an accessible label.\n\nThis is a built-in block.",
+      "plaintext": "Embeds a map from a URL (Google Maps, OpenStreetMap, etc.) using an iframe. The url field should contain the embed URL, and title provides an accessible label.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Embeds a map from a URL (Google Maps, OpenStreetMap, etc.) using an iframe. The url field should contain the embed URL, and title provides an accessible label."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/maps/data.json
+++ b/docs/content/content/content/docs/examples/maps/data.json
@@ -263,11 +263,34 @@
       "alt": "The maps example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-maps-description": {
+      "@type": "slate",
+      "plaintext": "Embeds a map from a URL (Google Maps, OpenStreetMap, etc.) using an iframe. The url field should contain the embed URL, and title provides an accessible label.\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Embeds a map from a URL (Google Maps, OpenStreetMap, etc.) using an iframe. The url field should contain the embed URL, and title provides an accessible label."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "68370edd-bfe5-47fb-937e-16a19a3a92ad",
+      "ref-maps-description",
       "editor-screenshot",
       "e36a9020-5e7e-4ef5-97f7-862c45fea81c",
       "96789bf6-953b-4777-a022-0f4cd852be64",

--- a/docs/content/content/content/docs/examples/relatedItemsListing/data.json
+++ b/docs/content/content/content/docs/examples/relatedItemsListing/data.json
@@ -84,21 +84,13 @@
     },
     "ref-relatedItemsListing-description": {
       "@type": "slate",
-      "plaintext": "Renders the current page's related items relation field (default relatedItems) as a list, reusing the listing machinery — each related item is rendered with a configurable item type (variation).\n\nThis is a custom example block — register its fetcher via initBridge (see below).",
+      "plaintext": "Renders the current page's related items relation field (default relatedItems) as a list, reusing the listing machinery — each related item is rendered with a configurable item type (variation).",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Renders the current page's related items relation field (default relatedItems) as a list, reusing the listing machinery — each related item is rendered with a configurable item type (variation)."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom example block — register its fetcher via initBridge (see below)."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/relatedItemsListing/data.json
+++ b/docs/content/content/content/docs/examples/relatedItemsListing/data.json
@@ -43,9 +43,9 @@
       "tabs": [
         {
           "@id": "ref-relatedItemsListing-rendering-javascript-2b9d44",
-          "label": "Register",
+          "label": "Render",
           "language": "javascript",
-          "code": "fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) }"
+          "code": "// 1. Register the fetcher when you init the bridge (keyed by block @type)\ninitBridge(origin, { blocks, fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) } });\n\n// 2. Render — identical to any list block\nconst { items } = await expandListingBlocks([blockId], {\n  blocks: { [blockId]: block },\n  fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) },\n  itemTypeField: 'variation',\n});\nitems.forEach((item) => renderBlock(item)); // your normal per-block renderer"
         }
       ]
     },
@@ -81,6 +81,28 @@
       "@type": "relatedItemsListing",
       "relationField": "relatedItems",
       "variation": "summary"
+    },
+    "ref-relatedItemsListing-description": {
+      "@type": "slate",
+      "plaintext": "Renders the current page's related items relation field (default relatedItems) as a list, reusing the listing machinery — each related item is rendered with a configurable item type (variation).\n\nThis is a custom example block — register its fetcher via initBridge (see below).",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Renders the current page's related items relation field (default relatedItems) as a list, reusing the listing machinery — each related item is rendered with a configurable item type (variation)."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom example block — register its fetcher via initBridge (see below)."
+            }
+          ]
+        }
+      ]
     },
     "ref-relatedItemsListing-rendering-intro": {
       "@type": "slate",
@@ -145,6 +167,7 @@
   "blocks_layout": {
     "items": [
       "title-1",
+      "ref-relatedItemsListing-description",
       "ri-live-heading",
       "ri-live-1",
       "ref-relatedItemsListing-schema",

--- a/docs/content/content/content/docs/examples/rssFeed/data.json
+++ b/docs/content/content/content/docs/examples/rssFeed/data.json
@@ -43,9 +43,9 @@
       "tabs": [
         {
           "@id": "ref-rssFeed-rendering-javascript-df4061",
-          "label": "Register",
+          "label": "Render",
           "language": "javascript",
-          "code": "fetchItems: { rssFeed: rssFetcher() }"
+          "code": "// 1. Register the fetcher when you init the bridge (keyed by block @type)\ninitBridge(origin, { blocks, fetchItems: { rssFeed: rssFetcher() } });\n\n// 2. Render — identical to any list block\nconst { items } = await expandListingBlocks([blockId], {\n  blocks: { [blockId]: block },\n  fetchItems: { rssFeed: rssFetcher() },\n  itemTypeField: 'variation',\n});\nitems.forEach((item) => renderBlock(item)); // your normal per-block renderer"
         }
       ]
     },
@@ -81,6 +81,28 @@
       "@type": "rssFeed",
       "feedUrl": "https://pypi.org/rss/project/plone/releases.xml",
       "variation": "default"
+    },
+    "ref-rssFeed-description": {
+      "@type": "slate",
+      "plaintext": "Renders entries from an external RSS feed, reusing the listing machinery. Each entry is rendered with a configurable item type (variation).\n\nThis is a custom example block — register its fetcher via initBridge (see below).",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Renders entries from an external RSS feed, reusing the listing machinery. Each entry is rendered with a configurable item type (variation)."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom example block — register its fetcher via initBridge (see below)."
+            }
+          ]
+        }
+      ]
     },
     "ref-rssFeed-rendering-intro": {
       "@type": "slate",
@@ -145,6 +167,7 @@
   "blocks_layout": {
     "items": [
       "title-1",
+      "ref-rssFeed-description",
       "rss-live-heading",
       "rss-live-1",
       "ref-rssFeed-schema",

--- a/docs/content/content/content/docs/examples/rssFeed/data.json
+++ b/docs/content/content/content/docs/examples/rssFeed/data.json
@@ -84,21 +84,13 @@
     },
     "ref-rssFeed-description": {
       "@type": "slate",
-      "plaintext": "Renders entries from an external RSS feed, reusing the listing machinery. Each entry is rendered with a configurable item type (variation).\n\nThis is a custom example block — register its fetcher via initBridge (see below).",
+      "plaintext": "Renders entries from an external RSS feed, reusing the listing machinery. Each entry is rendered with a configurable item type (variation).",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Renders entries from an external RSS feed, reusing the listing machinery. Each entry is rendered with a configurable item type (variation)."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom example block — register its fetcher via initBridge (see below)."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/search/data.json
+++ b/docs/content/content/content/docs/examples/search/data.json
@@ -178,21 +178,13 @@
     },
     "ref-search-description": {
       "@type": "slate",
-      "plaintext": "A search interface with faceted filtering. Contains a child listing block for results and typed facets (checkbox, select, date range, toggle) for filtering.\n\nThis is a built-in block. The facet types are custom sub-blocks.",
+      "plaintext": "A search interface with faceted filtering. Contains a child listing block for results and typed facets (checkbox, select, date range, toggle) for filtering.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A search interface with faceted filtering. Contains a child listing block for results and typed facets (checkbox, select, date range, toggle) for filtering."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block. The facet types are custom sub-blocks."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/search/data.json
+++ b/docs/content/content/content/docs/examples/search/data.json
@@ -175,11 +175,34 @@
       "alt": "The search example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-search-description": {
+      "@type": "slate",
+      "plaintext": "A search interface with faceted filtering. Contains a child listing block for results and typed facets (checkbox, select, date range, toggle) for filtering.\n\nThis is a built-in block. The facet types are custom sub-blocks.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A search interface with faceted filtering. Contains a child listing block for results and typed facets (checkbox, select, date range, toggle) for filtering."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block. The facet types are custom sub-blocks."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "f6d35d7e-6422-4496-8a65-f7cfd42fb519",
+      "ref-search-description",
       "editor-screenshot",
       "42b7d589-4d35-4b81-9fe9-ea17437beb81",
       "518c46e7-9823-4e03-aa3a-d2a9ec1746dd",

--- a/docs/content/content/content/docs/examples/searchShortcuts/data.json
+++ b/docs/content/content/content/docs/examples/searchShortcuts/data.json
@@ -86,21 +86,13 @@
     },
     "ref-searchShortcuts-description": {
       "@type": "slate",
-      "plaintext": "Renders a set of values as links into a faceted search — a \"tag cloud\" of shortcuts. Each value links to a search page with ?facet.<index>=<value> pre-set, which a Search block reads from the URL.\n\nThis is a custom example block — register its fetcher via initBridge (see below).",
+      "plaintext": "Renders a set of values as links into a faceted search — a \"tag cloud\" of shortcuts. Each value links to a search page with ?facet.<index>=<value> pre-set, which a Search block reads from the URL.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Renders a set of values as links into a faceted search — a \"tag cloud\" of shortcuts. Each value links to a search page with ?facet.<index>=<value> pre-set, which a Search block reads from the URL."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom example block — register its fetcher via initBridge (see below)."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/searchShortcuts/data.json
+++ b/docs/content/content/content/docs/examples/searchShortcuts/data.json
@@ -43,9 +43,9 @@
       "tabs": [
         {
           "@id": "ref-searchShortcuts-rendering-javascript-ab7111",
-          "label": "Register",
+          "label": "Render",
           "language": "javascript",
-          "code": "fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) }"
+          "code": "// 1. Register the fetcher when you init the bridge (keyed by block @type)\ninitBridge(origin, { blocks, fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) } });\n\n// 2. Render — identical to any list block\nconst { items } = await expandListingBlocks([blockId], {\n  blocks: { [blockId]: block },\n  fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) },\n  itemTypeField: 'variation',\n});\nitems.forEach((item) => renderBlock(item)); // your normal per-block renderer"
         }
       ]
     },
@@ -83,6 +83,28 @@
       "pageField": "subjects",
       "searchUrl": "/search",
       "variation": "default"
+    },
+    "ref-searchShortcuts-description": {
+      "@type": "slate",
+      "plaintext": "Renders a set of values as links into a faceted search — a \"tag cloud\" of shortcuts. Each value links to a search page with ?facet.<index>=<value> pre-set, which a Search block reads from the URL.\n\nThis is a custom example block — register its fetcher via initBridge (see below).",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Renders a set of values as links into a faceted search — a \"tag cloud\" of shortcuts. Each value links to a search page with ?facet.<index>=<value> pre-set, which a Search block reads from the URL."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom example block — register its fetcher via initBridge (see below)."
+            }
+          ]
+        }
+      ]
     },
     "ref-searchShortcuts-rendering-intro": {
       "@type": "slate",
@@ -147,6 +169,7 @@
   "blocks_layout": {
     "items": [
       "title-1",
+      "ref-searchShortcuts-description",
       "ss-live-heading",
       "ss-live-1",
       "ref-searchShortcuts-schema",

--- a/docs/content/content/content/docs/examples/separator/data.json
+++ b/docs/content/content/content/docs/examples/separator/data.json
@@ -282,11 +282,34 @@
       "alt": "The separator example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-separator-description": {
+      "@type": "slate",
+      "plaintext": "A horizontal rule used to visually divide sections of content. Supports an alignment style property.\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A horizontal rule used to visually divide sections of content. Supports an alignment style property."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "47b1e791-6f01-4b9b-a923-6658e7bc7871",
+      "ref-separator-description",
       "editor-screenshot",
       "dee0a2a5-dda7-407d-be26-1cecf1ba55a6",
       "be9ea3ae-29e1-41b8-b338-f32070a82675",

--- a/docs/content/content/content/docs/examples/separator/data.json
+++ b/docs/content/content/content/docs/examples/separator/data.json
@@ -285,21 +285,13 @@
     },
     "ref-separator-description": {
       "@type": "slate",
-      "plaintext": "A horizontal rule used to visually divide sections of content. Supports an alignment style property.\n\nThis is a built-in block.",
+      "plaintext": "A horizontal rule used to visually divide sections of content. Supports an alignment style property.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A horizontal rule used to visually divide sections of content. Supports an alignment style property."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/slate/data.json
+++ b/docs/content/content/content/docs/examples/slate/data.json
@@ -339,11 +339,34 @@
       "alt": "The slate example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-text-description": {
+      "@type": "slate",
+      "plaintext": "Rich text block powered by the Slate editor. Supports paragraphs, headings, lists, blockquotes, and inline formatting (bold, italic, strikethrough, underline, code, links).\n\nThis is a built-in block — no schema registration is needed. It's available by default when you include 'slate' in your page's allowedBlocks.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Rich text block powered by the Slate editor. Supports paragraphs, headings, lists, blockquotes, and inline formatting (bold, italic, strikethrough, underline, code, links)."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block — no schema registration is needed. It's available by default when you include 'slate' in your page's allowedBlocks."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "ccff41c6-b733-4b88-b02e-4c07460a19e2",
+      "ref-text-description",
       "editor-screenshot",
       "da904eda-9add-496c-ab09-4fee9820af1f",
       "244197b5-ac86-4d92-b235-18986a351580",

--- a/docs/content/content/content/docs/examples/slate/data.json
+++ b/docs/content/content/content/docs/examples/slate/data.json
@@ -342,21 +342,13 @@
     },
     "ref-text-description": {
       "@type": "slate",
-      "plaintext": "Rich text block powered by the Slate editor. Supports paragraphs, headings, lists, blockquotes, and inline formatting (bold, italic, strikethrough, underline, code, links).\n\nThis is a built-in block — no schema registration is needed. It's available by default when you include 'slate' in your page's allowedBlocks.",
+      "plaintext": "Rich text block powered by the Slate editor. Supports paragraphs, headings, lists, blockquotes, and inline formatting (bold, italic, strikethrough, underline, code, links).",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Rich text block powered by the Slate editor. Supports paragraphs, headings, lists, blockquotes, and inline formatting (bold, italic, strikethrough, underline, code, links)."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block — no schema registration is needed. It's available by default when you include 'slate' in your page's allowedBlocks."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/slider/data.json
+++ b/docs/content/content/content/docs/examples/slider/data.json
@@ -63,21 +63,13 @@
     },
     "ref-slider-description": {
       "@type": "slate",
-      "plaintext": "A carousel/slider that cycles through slides. Slides are stored as an object_list — each slide has a title, description, image, and optional button.\n\nThis is a custom block — register it via initBridge.",
+      "plaintext": "A carousel/slider that cycles through slides. Slides are stored as an object_list — each slide has a title, description, image, and optional button.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A carousel/slider that cycles through slides. Slides are stored as an object_list — each slide has a title, description, image, and optional button."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a custom block — register it via initBridge."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/slider/data.json
+++ b/docs/content/content/content/docs/examples/slider/data.json
@@ -60,11 +60,34 @@
         }
       ],
       "slotId": "rendering"
+    },
+    "ref-slider-description": {
+      "@type": "slate",
+      "plaintext": "A carousel/slider that cycles through slides. Slides are stored as an object_list — each slide has a title, description, image, and optional button.\n\nThis is a custom block — register it via initBridge.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A carousel/slider that cycles through slides. Slides are stored as an object_list — each slide has a title, description, image, and optional button."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a custom block — register it via initBridge."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "title-1",
+      "ref-slider-description",
       "ref-slider-schema",
       "ref-slider-json-data",
       "ref-slider-rendering"

--- a/docs/content/content/content/docs/examples/table/data.json
+++ b/docs/content/content/content/docs/examples/table/data.json
@@ -4263,11 +4263,34 @@
       "alt": "The table example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-table-description": {
+      "@type": "slate",
+      "plaintext": "A table with rich text (Slate) content in each cell. Supports adding/removing rows and columns via toolbar actions.\n\nThis is a built-in block (registered as slateTable).",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A table with rich text (Slate) content in each cell. Supports adding/removing rows and columns via toolbar actions."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block (registered as slateTable)."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "fb451586-3dab-4b40-a5f8-f73056685165",
+      "ref-table-description",
       "editor-screenshot",
       "ff4fd61a-f5eb-4733-a883-816985c44348",
       "0d727fc0-71c0-4e2c-918a-35b726636569",

--- a/docs/content/content/content/docs/examples/table/data.json
+++ b/docs/content/content/content/docs/examples/table/data.json
@@ -4266,21 +4266,13 @@
     },
     "ref-table-description": {
       "@type": "slate",
-      "plaintext": "A table with rich text (Slate) content in each cell. Supports adding/removing rows and columns via toolbar actions.\n\nThis is a built-in block (registered as slateTable).",
+      "plaintext": "A table with rich text (Slate) content in each cell. Supports adding/removing rows and columns via toolbar actions.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A table with rich text (Slate) content in each cell. Supports adding/removing rows and columns via toolbar actions."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block (registered as slateTable)."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/teaser/data.json
+++ b/docs/content/content/content/docs/examples/teaser/data.json
@@ -199,11 +199,34 @@
       "alt": "The teaser example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-teaser-description": {
+      "@type": "slate",
+      "plaintext": "A content preview card that links to another page. Selecting a target page via the object browser auto-fills the title, description, and preview image from that page. Editors can toggle \"overwrite\" to customize these values.\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "A content preview card that links to another page. Selecting a target page via the object browser auto-fills the title, description, and preview image from that page. Editors can toggle \"overwrite\" to customize these values."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "b986b92c-e180-42d3-b755-4728854e5a50",
+      "ref-teaser-description",
       "editor-screenshot",
       "61f0e286-0527-43a7-b8fe-29f1be40a8c3",
       "03fd3352-0845-4c70-9d01-805996bd127b",

--- a/docs/content/content/content/docs/examples/teaser/data.json
+++ b/docs/content/content/content/docs/examples/teaser/data.json
@@ -202,21 +202,13 @@
     },
     "ref-teaser-description": {
       "@type": "slate",
-      "plaintext": "A content preview card that links to another page. Selecting a target page via the object browser auto-fills the title, description, and preview image from that page. Editors can toggle \"overwrite\" to customize these values.\n\nThis is a built-in block.",
+      "plaintext": "A content preview card that links to another page. Selecting a target page via the object browser auto-fills the title, description, and preview image from that page. Editors can toggle \"overwrite\" to customize these values.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "A content preview card that links to another page. Selecting a target page via the object browser auto-fills the title, description, and preview image from that page. Editors can toggle \"overwrite\" to customize these values."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/toc/data.json
+++ b/docs/content/content/content/docs/examples/toc/data.json
@@ -392,21 +392,13 @@
     },
     "ref-toc-description": {
       "@type": "slate",
-      "plaintext": "Renders a table of contents generated from heading blocks on the current page. It scans sibling blocks for headings and builds a navigation list.\n\nThis is a built-in block.",
+      "plaintext": "Renders a table of contents generated from heading blocks on the current page. It scans sibling blocks for headings and builds a navigation list.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Renders a table of contents generated from heading blocks on the current page. It scans sibling blocks for headings and builds a navigation list."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/toc/data.json
+++ b/docs/content/content/content/docs/examples/toc/data.json
@@ -389,11 +389,34 @@
       "alt": "The toc example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-toc-description": {
+      "@type": "slate",
+      "plaintext": "Renders a table of contents generated from heading blocks on the current page. It scans sibling blocks for headings and builds a navigation list.\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Renders a table of contents generated from heading blocks on the current page. It scans sibling blocks for headings and builds a navigation list."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "537a9742-95f1-4930-9df3-d38766f54a71",
+      "ref-toc-description",
       "editor-screenshot",
       "22f22002-2159-4e42-942a-8ebc6e930ed5",
       "60a17689-6437-4a88-bf2c-76a62351ca5b",

--- a/docs/content/content/content/docs/examples/video/data.json
+++ b/docs/content/content/content/docs/examples/video/data.json
@@ -261,21 +261,13 @@
     },
     "ref-video-description": {
       "@type": "slate",
-      "plaintext": "Embeds a video from a URL. Detects YouTube links and renders an iframe embed; otherwise falls back to an HTML5 <video> element.\n\nThis is a built-in block.",
+      "plaintext": "Embeds a video from a URL. Detects YouTube links and renders an iframe embed; otherwise falls back to an HTML5 <video> element.",
       "value": [
         {
           "type": "p",
           "children": [
             {
               "text": "Embeds a video from a URL. Detects YouTube links and renders an iframe embed; otherwise falls back to an HTML5 <video> element."
-            }
-          ]
-        },
-        {
-          "type": "p",
-          "children": [
-            {
-              "text": "This is a built-in block."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/video/data.json
+++ b/docs/content/content/content/docs/examples/video/data.json
@@ -258,11 +258,34 @@
       "alt": "The video example block being edited in Volto Hydra",
       "align": "center",
       "size": "l"
+    },
+    "ref-video-description": {
+      "@type": "slate",
+      "plaintext": "Embeds a video from a URL. Detects YouTube links and renders an iframe embed; otherwise falls back to an HTML5 <video> element.\n\nThis is a built-in block.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Embeds a video from a URL. Detects YouTube links and renders an iframe embed; otherwise falls back to an HTML5 <video> element."
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "This is a built-in block."
+            }
+          ]
+        }
+      ]
     }
   },
   "blocks_layout": {
     "items": [
       "604e5248-8521-403d-9e5f-3f50d1229454",
+      "ref-video-description",
       "editor-screenshot",
       "7ace8ba6-13cb-4a5c-ab1c-fc6f8ce8737c",
       "c97a926c-b2d2-4a73-9691-fc6e1aca6c52",

--- a/docs/examples/relatedItemsListing.md
+++ b/docs/examples/relatedItemsListing.md
@@ -78,10 +78,19 @@ The optional field picker (`schemaFieldSelect`, `fieldType: 'relation'`) lists t
 
 ## Rendering
 
-The render is **identical to every list block** — call `expandListingBlocks`, then map over the items; only the fetcher above is block-specific. Register it in `fetchItems`:
+Register the fetcher (keyed by the block's `@type`), then render **exactly like any list block**: `expandListingBlocks` returns ready-to-render item blocks — map each through your normal block renderer. Only the fetcher above is block-specific.
 
 ```javascript
-fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) }
+// 1. Register the fetcher when you init the bridge (keyed by block @type)
+initBridge(origin, { blocks, fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) } });
+
+// 2. Render — identical to any list block
+const { items } = await expandListingBlocks([blockId], {
+  blocks: { [blockId]: block },
+  fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) },
+  itemTypeField: 'variation',
+});
+items.forEach((item) => renderBlock(item)); // your normal per-block renderer
 ```
 
-See the [Listing block](./listing.md#rendering) for the per-stack (React / Vue / Svelte / Astro) render component and [Listings › Example fetchers](../listings.md#example-fetchers) for the full picture.
+See the [Listing block](./listing.md#rendering) for the full per-stack (React / Vue / Svelte / Astro) render components.

--- a/docs/examples/rssFeed.md
+++ b/docs/examples/rssFeed.md
@@ -101,10 +101,19 @@ Because this fetch runs in the browser, the feed must send an `Access-Control-Al
 
 ## Rendering
 
-The render is **identical to every list block** — call `expandListingBlocks`, then map over the items; only the fetcher above is block-specific. Register it in `fetchItems`:
+Register the fetcher (keyed by the block's `@type`), then render **exactly like any list block**: `expandListingBlocks` returns ready-to-render item blocks — map each through your normal block renderer. Only the fetcher above is block-specific.
 
 ```javascript
-fetchItems: { rssFeed: rssFetcher() }
+// 1. Register the fetcher when you init the bridge (keyed by block @type)
+initBridge(origin, { blocks, fetchItems: { rssFeed: rssFetcher() } });
+
+// 2. Render — identical to any list block
+const { items } = await expandListingBlocks([blockId], {
+  blocks: { [blockId]: block },
+  fetchItems: { rssFeed: rssFetcher() },
+  itemTypeField: 'variation',
+});
+items.forEach((item) => renderBlock(item)); // your normal per-block renderer
 ```
 
-See the [Listing block](./listing.md#rendering) for the per-stack (React / Vue / Svelte / Astro) render component and [Listings › Example fetchers](../listings.md#example-fetchers) for the full picture.
+See the [Listing block](./listing.md#rendering) for the full per-stack (React / Vue / Svelte / Astro) render components.

--- a/docs/examples/searchShortcuts.md
+++ b/docs/examples/searchShortcuts.md
@@ -108,10 +108,19 @@ Pick the `index` with the existing `select_querystring_field` widget (e.g. `Subj
 
 ## Rendering
 
-The render is **identical to every list block** — call `expandListingBlocks`, then map over the items; only the fetcher above is block-specific. Register it in `fetchItems`:
+Register the fetcher (keyed by the block's `@type`), then render **exactly like any list block**: `expandListingBlocks` returns ready-to-render item blocks — map each through your normal block renderer. Only the fetcher above is block-specific.
 
 ```javascript
-fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) }
+// 1. Register the fetcher when you init the bridge (keyed by block @type)
+initBridge(origin, { blocks, fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) } });
+
+// 2. Render — identical to any list block
+const { items } = await expandListingBlocks([blockId], {
+  blocks: { [blockId]: block },
+  fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) },
+  itemTypeField: 'variation',
+});
+items.forEach((item) => renderBlock(item)); // your normal per-block renderer
 ```
 
-See the [Listing block](./listing.md#rendering) for the per-stack (React / Vue / Svelte / Astro) render component and [Listings › Example fetchers](../listings.md#example-fetchers) for the full picture.
+See the [Listing block](./listing.md#rendering) for the full per-stack (React / Vue / Svelte / Astro) render components.

--- a/docs/sync.mjs
+++ b/docs/sync.mjs
@@ -528,7 +528,15 @@ function extractCodeBlocks(text) {
  * Returns { schema, json, react, vue } where each is a string or null.
  */
 function extractMdSections(mdContent) {
-  const result = { schema: null, json: null, fetcher: null, react: null, vue: null, svelte: null };
+  const result = { description: null, schema: null, json: null, fetcher: null, react: null, vue: null, svelte: null };
+
+  // Description: the prose between the H1 title and the first `## ` section — a
+  // plain-language "what this block is for". Rendered as a paragraph after the title.
+  const descMatch = mdContent.match(/^#\s+.+?\r?\n+([\s\S]*?)(?=\r?\n##\s)/);
+  if (descMatch) {
+    const desc = descMatch[1].trim();
+    if (desc) result.description = desc;
+  }
 
   // Split into top-level sections by ## headings
   const topSections = {};
@@ -646,13 +654,11 @@ function makeCodeExampleBlock(blockId, templateInstanceId, slotId, tabs) {
  */
 function updateCodeExampleTabs(block, tabUpdates) {
   let changed = false;
-  for (const { language, code } of tabUpdates) {
-    if (code == null) continue;
+  for (const { language, code, label } of tabUpdates) {
     const tab = block.tabs.find(t => t.language === language);
-    if (tab && tab.code !== code) {
-      tab.code = code;
-      changed = true;
-    }
+    if (!tab) continue;
+    if (code != null && tab.code !== code) { tab.code = code; changed = true; }
+    if (label != null && tab.label !== label) { tab.label = label; changed = true; }
   }
   return changed;
 }
@@ -700,6 +706,41 @@ function ensureCodeExampleBlock(data, blockId, instanceId, slotId, tabs) {
     return true;
   }
   return updateCodeExampleTabs(existing, tabs);
+}
+
+/** Convert a chunk of markdown prose into a plain (non-template) slate block: one
+ * `p` per blank-line-separated paragraph, markdown emphasis/code/link syntax stripped
+ * to text. Used for the page description (no template slot — it sits above the fold). */
+function makeProseSlate(blockId, markdown) {
+  const paras = markdown.split(/\r?\n\s*\r?\n/)
+    .map((p) => p.replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+    .map((p) => p
+      .replace(/\*\*(.+?)\*\*/g, '$1')
+      .replace(/\*(?!\*)([^*]+?)\*/g, '$1')
+      .replace(/`([^`]+)`/g, '$1')
+      .replace(/\[(.+?)\]\([^)]*\)/g, '$1'));
+  return {
+    '@type': 'slate',
+    plaintext: paras.join('\n\n'),
+    value: paras.map((p) => ({ type: 'p', children: [{ text: p }] })),
+  };
+}
+
+/** Ensure a standalone prose slate exists for the given markdown; returns true if
+ * changed. Deletes the block when `markdown` is empty. */
+function ensureProseSlate(data, blockId, markdown) {
+  if (!markdown) {
+    if (data.blocks[blockId]) { delete data.blocks[blockId]; return true; }
+    return false;
+  }
+  const next = makeProseSlate(blockId, markdown);
+  const cur = data.blocks[blockId];
+  if (cur && cur['@type'] === 'slate' && JSON.stringify(cur.value) === JSON.stringify(next.value)) {
+    return false;
+  }
+  data.blocks[blockId] = next;
+  return true;
 }
 
 /** Ensure a slate block exists with the given text (and optional rich `value`);
@@ -804,6 +845,22 @@ for (const mdFile of mdFiles) {
     contentChanged = true;
   }
 
+  // --- Description: what the block is for. A standalone prose slate right after the
+  // title (from the .md intro between the H1 and the first `##`). ---
+  const descriptionId = `${prefix}-description`;
+  if (ensureProseSlate(data, descriptionId, sections.description)) contentChanged = true;
+  if (sections.description) {
+    const items = data.blocks_layout.items;
+    const titleIdx = items.findIndex((id) => data.blocks[id]?.['@type'] === 'title');
+    const curIdx = items.indexOf(descriptionId);
+    const wantIdx = titleIdx >= 0 ? titleIdx + 1 : 0;
+    if (curIdx !== wantIdx) {
+      if (curIdx !== -1) items.splice(curIdx, 1);
+      items.splice(items.findIndex((id) => data.blocks[id]?.['@type'] === 'title') + 1, 0, descriptionId);
+      contentChanged = true;
+    }
+  }
+
   // Ensure the 3 codeExample blocks exist
   // --- Schema + JSON Block Data: one codeExample each (idempotent create/update) ---
   const schemaId = `${prefix}-schema`;
@@ -847,7 +904,7 @@ for (const mdFile of mdFiles) {
       { label: 'Fetcher', language: 'javascript', code: sections.fetcher || '' },
     ])) contentChanged = true;
     if (ensureCodeExampleBlock(data, renderingId, instanceId, 'rendering', [
-      { label: 'Register', language: 'javascript', code: sections.register || '' },
+      { label: 'Render', language: 'javascript', code: sections.register || '' },
     ])) contentChanged = true;
     renderRegionIds = [renderIntroId, fetcherId, renderingId];
   } else {

--- a/docs/sync.mjs
+++ b/docs/sync.mjs
@@ -708,22 +708,22 @@ function ensureCodeExampleBlock(data, blockId, instanceId, slotId, tabs) {
   return updateCodeExampleTabs(existing, tabs);
 }
 
-/** Convert a chunk of markdown prose into a plain (non-template) slate block: one
- * `p` per blank-line-separated paragraph, markdown emphasis/code/link syntax stripped
- * to text. Used for the page description (no template slot — it sits above the fold). */
+/** Convert a chunk of markdown prose into a plain (non-template) slate block. A slate
+ * block must have exactly ONE top-level node, so this uses the FIRST paragraph (the
+ * block's "what is this for" line; any following "this is a custom example block…"
+ * boilerplate is redundant with the reference section below). Markdown emphasis/code/
+ * link syntax is stripped to text. No template slot — it sits above the fold. */
 function makeProseSlate(blockId, markdown) {
-  const paras = markdown.split(/\r?\n\s*\r?\n/)
-    .map((p) => p.replace(/\s+/g, ' ').trim())
-    .filter(Boolean)
-    .map((p) => p
-      .replace(/\*\*(.+?)\*\*/g, '$1')
-      .replace(/\*(?!\*)([^*]+?)\*/g, '$1')
-      .replace(/`([^`]+)`/g, '$1')
-      .replace(/\[(.+?)\]\([^)]*\)/g, '$1'));
+  const first = (markdown.split(/\r?\n\s*\r?\n/)[0] || '')
+    .replace(/\s+/g, ' ').trim()
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/\*(?!\*)([^*]+?)\*/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[(.+?)\]\([^)]*\)/g, '$1');
   return {
     '@type': 'slate',
-    plaintext: paras.join('\n\n'),
-    value: paras.map((p) => ({ type: 'p', children: [{ text: p }] })),
+    plaintext: first,
+    value: [{ type: 'p', children: [{ text: first }] }],
   };
 }
 


### PR DESCRIPTION
Follow-up to #259. Two gaps on the example pages:

1. **No description** of what each block is for — pages went title -> content -> "Developer Reference".
2. **Fetcher example pages only linked** to how-to-render; they never showed a render snippet.

## Changes
- **Description**: `sync.mjs` renders the `.md` intro prose (between the H1 and the first `##`) as a paragraph right after the title, on **every** example page (markdown stripped to text).
- **Rendering**: the three fetcher pages' `## Rendering` now shows a real render snippet (register the fetcher, `expandListingBlocks`, then map items through the block renderer) instead of a bare `fetchItems: {...}` line. Code block relabeled Register -> Render; the link to the Listing example (full React/Vue/Svelte) stays.

Idempotent; content validator passes; sync is a fixed point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
