### PR TITLE
docs(examples): frame fetcher blocks as the shared expand seam

### DIFF
--- a/docs/content/content/content/docs/examples/relatedItemsListing/data.json
+++ b/docs/content/content/content/docs/examples/relatedItemsListing/data.json
@@ -45,7 +45,7 @@
           "@id": "ref-relatedItemsListing-rendering-javascript-2b9d44",
           "label": "Render",
           "language": "javascript",
-          "code": "// 1. Register the fetcher when you init the bridge (keyed by block @type)\ninitBridge(origin, { blocks, fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) } });\n\n// 2. Render — identical to any list block\nconst { items } = await expandListingBlocks([blockId], {\n  blocks: { [blockId]: block },\n  fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) },\n  itemTypeField: 'variation',\n});\nitems.forEach((item) => renderBlock(item)); // your normal per-block renderer"
+          "code": "// One fetchItems map, keyed by @type, holds every fetch-based block you use.\nconst fetchItems = {\n  listing: ploneFetchItems({ apiUrl, contextPath }),\n  relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }), // ← this block\n};\n\n// Call this on each region you render (the list of block ids in that region).\nconst { items } = await expandListingBlocks(regionBlockIds, {\n  blocks, fetchItems, itemTypeField: 'variation',\n});\nitems.forEach((item) => renderBlock(item)); // your normal per-block renderer"
         }
       ]
     },
@@ -84,13 +84,13 @@
     },
     "ref-relatedItemsListing-description": {
       "@type": "slate",
-      "plaintext": "Renders the current page's related items relation field (default relatedItems) as a list, reusing the listing machinery — each related item is rendered with a configurable item type (variation).",
+      "plaintext": "Renders the current page's related items relation field (default relatedItems). Its items are fetched at render time and shown with a configurable item type (variation).",
       "value": [
         {
           "type": "p",
           "children": [
             {
-              "text": "Renders the current page's related items relation field (default relatedItems) as a list, reusing the listing machinery — each related item is rendered with a configurable item type (variation)."
+              "text": "Renders the current page's related items relation field (default relatedItems). Its items are fetched at render time and shown with a configurable item type (variation)."
             }
           ]
         }
@@ -101,27 +101,13 @@
       "templateId": "/templates/block-reference-layout",
       "templateInstanceId": "tpl-inst-relatedItemsListing",
       "slotId": "rendering",
-      "plaintext": "This block has no bespoke renderer — register the fetcher below, then render its items exactly like any list block. See the Listing example for the render component in React, Vue and Svelte, Listings for how expansion works, and Custom Blocks for registering a block type. Only the fetcher below is block-specific.",
+      "plaintext": "This block has no bespoke renderer. Add its fetcher to your fetchItems map (keyed by @type) and expandListingBlocks expands it in any region you render — the same seam that powers listings and other collection blocks. See Custom Blocks to define the block type. Only the fetcher below is block-specific.",
       "value": [
         {
           "type": "p",
           "children": [
             {
-              "text": "This block has no bespoke renderer — register the fetcher below, then render its items exactly like any list block. See the "
-            },
-            {
-              "type": "link",
-              "data": {
-                "url": "/docs/examples/listing"
-              },
-              "children": [
-                {
-                  "text": "Listing example"
-                }
-              ]
-            },
-            {
-              "text": " for the render component in React, Vue and Svelte, "
+              "text": "This block has no bespoke renderer. Add its fetcher to your fetchItems map (keyed by @type) and expandListingBlocks expands it in any region you render — the same seam that powers "
             },
             {
               "type": "link",
@@ -130,12 +116,12 @@
               },
               "children": [
                 {
-                  "text": "Listings"
+                  "text": "listings"
                 }
               ]
             },
             {
-              "text": " for how expansion works, and "
+              "text": " and other collection blocks. See "
             },
             {
               "type": "link",
@@ -149,7 +135,7 @@
               ]
             },
             {
-              "text": " for registering a block type. Only the fetcher below is block-specific."
+              "text": " to define the block type. Only the fetcher below is block-specific."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/rssFeed/data.json
+++ b/docs/content/content/content/docs/examples/rssFeed/data.json
@@ -45,7 +45,7 @@
           "@id": "ref-rssFeed-rendering-javascript-df4061",
           "label": "Render",
           "language": "javascript",
-          "code": "// 1. Register the fetcher when you init the bridge (keyed by block @type)\ninitBridge(origin, { blocks, fetchItems: { rssFeed: rssFetcher() } });\n\n// 2. Render — identical to any list block\nconst { items } = await expandListingBlocks([blockId], {\n  blocks: { [blockId]: block },\n  fetchItems: { rssFeed: rssFetcher() },\n  itemTypeField: 'variation',\n});\nitems.forEach((item) => renderBlock(item)); // your normal per-block renderer"
+          "code": "// One fetchItems map, keyed by @type, holds every fetch-based block you use.\nconst fetchItems = {\n  listing: ploneFetchItems({ apiUrl, contextPath }),\n  rssFeed: rssFetcher(), // ← this block — just another entry\n};\n\n// Call this on each region you render (the list of block ids in that region).\nconst { items } = await expandListingBlocks(regionBlockIds, {\n  blocks, fetchItems, itemTypeField: 'variation',\n});\nitems.forEach((item) => renderBlock(item)); // your normal per-block renderer"
         }
       ]
     },
@@ -84,13 +84,13 @@
     },
     "ref-rssFeed-description": {
       "@type": "slate",
-      "plaintext": "Renders entries from an external RSS feed, reusing the listing machinery. Each entry is rendered with a configurable item type (variation).",
+      "plaintext": "Renders entries from an external RSS feed. Its items are fetched at render time (by a fetcher you provide) and shown with a configurable item type (variation).",
       "value": [
         {
           "type": "p",
           "children": [
             {
-              "text": "Renders entries from an external RSS feed, reusing the listing machinery. Each entry is rendered with a configurable item type (variation)."
+              "text": "Renders entries from an external RSS feed. Its items are fetched at render time (by a fetcher you provide) and shown with a configurable item type (variation)."
             }
           ]
         }
@@ -101,27 +101,13 @@
       "templateId": "/templates/block-reference-layout",
       "templateInstanceId": "tpl-inst-rssFeed",
       "slotId": "rendering",
-      "plaintext": "This block has no bespoke renderer — register the fetcher below, then render its items exactly like any list block. See the Listing example for the render component in React, Vue and Svelte, Listings for how expansion works, and Custom Blocks for registering a block type. Only the fetcher below is block-specific.",
+      "plaintext": "This block has no bespoke renderer. Add its fetcher to your fetchItems map (keyed by @type) and expandListingBlocks expands it in any region you render — the same seam that powers listings and other collection blocks. See Custom Blocks to define the block type. Only the fetcher below is block-specific.",
       "value": [
         {
           "type": "p",
           "children": [
             {
-              "text": "This block has no bespoke renderer — register the fetcher below, then render its items exactly like any list block. See the "
-            },
-            {
-              "type": "link",
-              "data": {
-                "url": "/docs/examples/listing"
-              },
-              "children": [
-                {
-                  "text": "Listing example"
-                }
-              ]
-            },
-            {
-              "text": " for the render component in React, Vue and Svelte, "
+              "text": "This block has no bespoke renderer. Add its fetcher to your fetchItems map (keyed by @type) and expandListingBlocks expands it in any region you render — the same seam that powers "
             },
             {
               "type": "link",
@@ -130,12 +116,12 @@
               },
               "children": [
                 {
-                  "text": "Listings"
+                  "text": "listings"
                 }
               ]
             },
             {
-              "text": " for how expansion works, and "
+              "text": " and other collection blocks. See "
             },
             {
               "type": "link",
@@ -149,7 +135,7 @@
               ]
             },
             {
-              "text": " for registering a block type. Only the fetcher below is block-specific."
+              "text": " to define the block type. Only the fetcher below is block-specific."
             }
           ]
         }

--- a/docs/content/content/content/docs/examples/searchShortcuts/data.json
+++ b/docs/content/content/content/docs/examples/searchShortcuts/data.json
@@ -45,7 +45,7 @@
           "@id": "ref-searchShortcuts-rendering-javascript-ab7111",
           "label": "Render",
           "language": "javascript",
-          "code": "// 1. Register the fetcher when you init the bridge (keyed by block @type)\ninitBridge(origin, { blocks, fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) } });\n\n// 2. Render — identical to any list block\nconst { items } = await expandListingBlocks([blockId], {\n  blocks: { [blockId]: block },\n  fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) },\n  itemTypeField: 'variation',\n});\nitems.forEach((item) => renderBlock(item)); // your normal per-block renderer"
+          "code": "// One fetchItems map, keyed by @type, holds every fetch-based block you use.\nconst fetchItems = {\n  listing: ploneFetchItems({ apiUrl, contextPath }),\n  searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }), // ← this block\n};\n\n// Call this on each region you render (the list of block ids in that region).\nconst { items } = await expandListingBlocks(regionBlockIds, {\n  blocks, fetchItems, itemTypeField: 'variation',\n});\nitems.forEach((item) => renderBlock(item)); // your normal per-block renderer"
         }
       ]
     },
@@ -103,27 +103,13 @@
       "templateId": "/templates/block-reference-layout",
       "templateInstanceId": "tpl-inst-searchShortcuts",
       "slotId": "rendering",
-      "plaintext": "This block has no bespoke renderer — register the fetcher below, then render its items exactly like any list block. See the Listing example for the render component in React, Vue and Svelte, Listings for how expansion works, and Custom Blocks for registering a block type. Only the fetcher below is block-specific.",
+      "plaintext": "This block has no bespoke renderer. Add its fetcher to your fetchItems map (keyed by @type) and expandListingBlocks expands it in any region you render — the same seam that powers listings and other collection blocks. See Custom Blocks to define the block type. Only the fetcher below is block-specific.",
       "value": [
         {
           "type": "p",
           "children": [
             {
-              "text": "This block has no bespoke renderer — register the fetcher below, then render its items exactly like any list block. See the "
-            },
-            {
-              "type": "link",
-              "data": {
-                "url": "/docs/examples/listing"
-              },
-              "children": [
-                {
-                  "text": "Listing example"
-                }
-              ]
-            },
-            {
-              "text": " for the render component in React, Vue and Svelte, "
+              "text": "This block has no bespoke renderer. Add its fetcher to your fetchItems map (keyed by @type) and expandListingBlocks expands it in any region you render — the same seam that powers "
             },
             {
               "type": "link",
@@ -132,12 +118,12 @@
               },
               "children": [
                 {
-                  "text": "Listings"
+                  "text": "listings"
                 }
               ]
             },
             {
-              "text": " for how expansion works, and "
+              "text": " and other collection blocks. See "
             },
             {
               "type": "link",
@@ -151,7 +137,7 @@
               ]
             },
             {
-              "text": " for registering a block type. Only the fetcher below is block-specific."
+              "text": " to define the block type. Only the fetcher below is block-specific."
             }
           ]
         }

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -34,8 +34,8 @@ These blocks demonstrate common patterns. Register them via `initBridge({ blocks
 | [Form Block](./form.md) | A multi-field form with configurable field types, validation, and email submission. Fields are stored as a typed `object_list` — each field has a `field_type` that maps to a sub-block schema. |
 | [Hero Block](./hero.md) | A full-width hero section with heading, subheading, image, rich text description, and a call-to-action button. Demonstrates multiple field types in a single block: `string`, `textarea`, `slate`, `image`, and `object_browser`. |
 | [Highlight Block](./highlight.md) | A prominent content section with a background image, overlay, title, rich text body, and an optional call-to-action link. Used for feature callouts and banners. |
-| [Related Items Block](./relatedItemsListing.md) | Renders the current page's *related items* relation field (default `relatedItems`) as a list, reusing the listing machinery — each related item is rendered with a configurable item type (variation). |
-| [RSS Feed Block](./rssFeed.md) | Renders entries from an external RSS feed, reusing the listing machinery. Each entry is rendered with a configurable item type (variation). |
+| [Related Items Block](./relatedItemsListing.md) | Renders the current page's *related items* relation field (default `relatedItems`). Its items are fetched at render time and shown with a configurable item type (variation). |
+| [RSS Feed Block](./rssFeed.md) | Renders entries from an external RSS feed. Its items are fetched at render time (by a fetcher you provide) and shown with a configurable item type (variation). |
 | [Search Shortcuts Block](./searchShortcuts.md) | Renders a set of values as links into a faceted search — a "tag cloud" of shortcuts. Each value links to a search page with `?facet.<index>=<value>` pre-set, which a [Search block](./search.md) reads from the URL. |
 | [Slider Block](./slider.md) | A carousel/slider that cycles through slides. Slides are stored as an `object_list` — each slide has a title, description, image, and optional button. |
 ## Page Structure

--- a/docs/examples/relatedItemsListing.md
+++ b/docs/examples/relatedItemsListing.md
@@ -1,8 +1,8 @@
 # Related Items Block
 
-Renders the current page's *related items* relation field (default `relatedItems`) as a list, reusing the listing machinery — each related item is rendered with a configurable item type (variation).
+Renders the current page's *related items* relation field (default `relatedItems`). Its items are fetched at render time and shown with a configurable item type (variation).
 
-This is a **custom** example block — register its fetcher via `initBridge` (see below).
+It's a custom block type whose items come from a fetcher; `expandListingBlocks` expands it in any region (see Rendering).
 
 ## Schema
 
@@ -78,19 +78,20 @@ The optional field picker (`schemaFieldSelect`, `fieldType: 'relation'`) lists t
 
 ## Rendering
 
-Register the fetcher (keyed by the block's `@type`), then render **exactly like any list block**: `expandListingBlocks` returns ready-to-render item blocks — map each through your normal block renderer. Only the fetcher above is block-specific.
+There's no bespoke renderer. Add this block's fetcher to your `fetchItems` map (keyed by `@type`) alongside any other fetch-based blocks, then expand each region with `expandListingBlocks` — it turns every block whose `@type` is in the map into ready-to-render item blocks. Only the fetcher above is block-specific.
 
 ```javascript
-// 1. Register the fetcher when you init the bridge (keyed by block @type)
-initBridge(origin, { blocks, fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) } });
+// One fetchItems map, keyed by @type, holds every fetch-based block you use.
+const fetchItems = {
+  listing: ploneFetchItems({ apiUrl, contextPath }),
+  relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }), // ← this block
+};
 
-// 2. Render — identical to any list block
-const { items } = await expandListingBlocks([blockId], {
-  blocks: { [blockId]: block },
-  fetchItems: { relatedItemsListing: relatedItemsFetcher({ apiUrl, contextPath }) },
-  itemTypeField: 'variation',
+// Call this on each region you render (the list of block ids in that region).
+const { items } = await expandListingBlocks(regionBlockIds, {
+  blocks, fetchItems, itemTypeField: 'variation',
 });
 items.forEach((item) => renderBlock(item)); // your normal per-block renderer
 ```
 
-See the [Listing block](./listing.md#rendering) for the full per-stack (React / Vue / Svelte / Astro) render components.
+See the [Listing block](./listing.md#rendering) for full per-stack (React / Vue / Svelte / Astro) render components, and [Listings](../listings.md) for the expand pattern.

--- a/docs/examples/rssFeed.md
+++ b/docs/examples/rssFeed.md
@@ -1,8 +1,8 @@
 # RSS Feed Block
 
-Renders entries from an external RSS feed, reusing the listing machinery. Each entry is rendered with a configurable item type (variation).
+Renders entries from an external RSS feed. Its items are fetched at render time (by a fetcher you provide) and shown with a configurable item type (variation).
 
-This is a **custom** example block — register its fetcher via `initBridge` (see below).
+It's a custom block type whose items come from a fetcher; `expandListingBlocks` expands it in any region (see Rendering).
 
 ## Schema
 
@@ -101,19 +101,20 @@ Because this fetch runs in the browser, the feed must send an `Access-Control-Al
 
 ## Rendering
 
-Register the fetcher (keyed by the block's `@type`), then render **exactly like any list block**: `expandListingBlocks` returns ready-to-render item blocks — map each through your normal block renderer. Only the fetcher above is block-specific.
+There's no bespoke renderer. Add this block's fetcher to your `fetchItems` map (keyed by `@type`) alongside any other fetch-based blocks, then expand each region with `expandListingBlocks` — it turns every block whose `@type` is in the map into ready-to-render item blocks. Only the fetcher above is block-specific.
 
 ```javascript
-// 1. Register the fetcher when you init the bridge (keyed by block @type)
-initBridge(origin, { blocks, fetchItems: { rssFeed: rssFetcher() } });
+// One fetchItems map, keyed by @type, holds every fetch-based block you use.
+const fetchItems = {
+  listing: ploneFetchItems({ apiUrl, contextPath }),
+  rssFeed: rssFetcher(), // ← this block — just another entry
+};
 
-// 2. Render — identical to any list block
-const { items } = await expandListingBlocks([blockId], {
-  blocks: { [blockId]: block },
-  fetchItems: { rssFeed: rssFetcher() },
-  itemTypeField: 'variation',
+// Call this on each region you render (the list of block ids in that region).
+const { items } = await expandListingBlocks(regionBlockIds, {
+  blocks, fetchItems, itemTypeField: 'variation',
 });
 items.forEach((item) => renderBlock(item)); // your normal per-block renderer
 ```
 
-See the [Listing block](./listing.md#rendering) for the full per-stack (React / Vue / Svelte / Astro) render components.
+See the [Listing block](./listing.md#rendering) for full per-stack (React / Vue / Svelte / Astro) render components, and [Listings](../listings.md) for the expand pattern.

--- a/docs/examples/searchShortcuts.md
+++ b/docs/examples/searchShortcuts.md
@@ -2,7 +2,7 @@
 
 Renders a set of values as links into a faceted search — a "tag cloud" of shortcuts. Each value links to a search page with `?facet.<index>=<value>` pre-set, which a [Search block](./search.md) reads from the URL.
 
-This is a **custom** example block — register its fetcher via `initBridge` (see below).
+It's a custom block type whose items come from a fetcher; `expandListingBlocks` expands it in any region (see Rendering).
 
 ## Schema
 
@@ -108,19 +108,20 @@ Pick the `index` with the existing `select_querystring_field` widget (e.g. `Subj
 
 ## Rendering
 
-Register the fetcher (keyed by the block's `@type`), then render **exactly like any list block**: `expandListingBlocks` returns ready-to-render item blocks — map each through your normal block renderer. Only the fetcher above is block-specific.
+There's no bespoke renderer. Add this block's fetcher to your `fetchItems` map (keyed by `@type`) alongside any other fetch-based blocks, then expand each region with `expandListingBlocks` — it turns every block whose `@type` is in the map into ready-to-render item blocks. Only the fetcher above is block-specific.
 
 ```javascript
-// 1. Register the fetcher when you init the bridge (keyed by block @type)
-initBridge(origin, { blocks, fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) } });
+// One fetchItems map, keyed by @type, holds every fetch-based block you use.
+const fetchItems = {
+  listing: ploneFetchItems({ apiUrl, contextPath }),
+  searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }), // ← this block
+};
 
-// 2. Render — identical to any list block
-const { items } = await expandListingBlocks([blockId], {
-  blocks: { [blockId]: block },
-  fetchItems: { searchShortcuts: searchShortcutsFetcher({ apiUrl, contextPath }) },
-  itemTypeField: 'variation',
+// Call this on each region you render (the list of block ids in that region).
+const { items } = await expandListingBlocks(regionBlockIds, {
+  blocks, fetchItems, itemTypeField: 'variation',
 });
 items.forEach((item) => renderBlock(item)); // your normal per-block renderer
 ```
 
-See the [Listing block](./listing.md#rendering) for the full per-stack (React / Vue / Svelte / Astro) render components.
+See the [Listing block](./listing.md#rendering) for full per-stack (React / Vue / Svelte / Astro) render components, and [Listings](../listings.md) for the expand pattern.

--- a/docs/sync.mjs
+++ b/docs/sync.mjs
@@ -886,17 +886,15 @@ for (const mdFile of mdFiles) {
   const isFetchingPage = sections.fetcher != null;
   let renderRegionIds;
   if (isFetchingPage) {
-    // The render is identical to any list block, so instead of repeating the
-    // per-framework render code we link to the Listing example (which shows it in
-    // React / Vue / Svelte) and the explanation pages. Only the fetcher is specific.
+    // This is a fetch/expand block: you provide a fetcher for its @type and
+    // expandListingBlocks expands it in any region — the same seam that powers
+    // listings and other collection blocks. Only the fetcher is block-specific.
     const intro = slateParagraph([
-      'This block has no bespoke renderer — register the fetcher below, then render its items exactly like any list block. See the ',
-      { url: '/docs/examples/listing', text: 'Listing example' },
-      ' for the render component in React, Vue and Svelte, ',
-      { url: '/docs/listings', text: 'Listings' },
-      ' for how expansion works, and ',
+      'This block has no bespoke renderer. Add its fetcher to your fetchItems map (keyed by @type) and expandListingBlocks expands it in any region you render — the same seam that powers ',
+      { url: '/docs/listings', text: 'listings' },
+      ' and other collection blocks. See ',
       { url: '/docs/custom-blocks', text: 'Custom Blocks' },
-      ' for registering a block type. Only the fetcher below is block-specific.',
+      ' to define the block type. Only the fetcher below is block-specific.',
     ]);
     if (ensureSlateBlock(data, renderIntroId, instanceId, 'rendering',
       intro.plaintext, intro.value)) contentChanged = true;


### PR DESCRIPTION
Corrections from review of the three data-fetching example pages (#263 follow-up).

- **No `initBridge` registration exists** — `fetchItems` is only an option to `expandListingBlocks`. Removed the invented `initBridge(...)` call from the render snippets.
- The render snippet now shows the real pattern: **one** `fetchItems` map (keyed by `@type`) holding every fetch-based block, passed to `expandListingBlocks(regionBlockIds, ...)` for each region you render. This block is just another entry in that map.
- Reframed descriptions + intro away from "reuses the listing machinery" / "render like a list block" (confusing) to: a block whose items come from a fetcher, expanded in any region by the same seam that powers listings and other collection blocks.

Idempotent; content validator passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
