### PR TITLE
feat(copy-from-target): on by default + edit-start pull + tests

### DIFF
--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -274,7 +274,10 @@ import {
   convertBlockType,
   validateFieldMappings,
 } from '../../utils/schemaInheritance';
-import { installCopyFromTargetEnhancers } from '../../utils/copyFromTarget';
+import {
+  installCopyFromTargetEnhancers,
+  markEditedLinkedFieldsCustom,
+} from '../../utils/copyFromTarget';
 import ChildBlocksWidget from '../Sidebar/ChildBlocksWidget';
 import ParentBlocksWidget from '../Sidebar/ParentBlocksWidget';
 
@@ -2237,17 +2240,27 @@ const Iframe = (props) => {
           const isNewEdit = incomingSequence > preMessageSeq;
 
           if (isNewEdit) {
-            // New edit from iframe - update everything
+            // New edit from iframe - update everything.
+            // Copy-from-target: turn any LINKED field edited inline CUSTOM, by the
+            // same value-compare used for image/link edits — the inline message
+            // carries the whole formData with no clue which field changed. Applied
+            // synchronously (part of THIS update) so it doesn't re-render mid-type
+            // and move the cursor.
             inlineEditCounterRef.current += 1;
+            const editedData = markEditedLinkedFieldsCustom(
+              event.data.data,
+              properties,
+              config.blocks.blocksConfig,
+            );
             // Debug: log full children structure to diagnose missing "w" bug
-            const debugBlock = event.data.data?.blocks?.['block-1-uuid'];
+            const debugBlock = editedData?.blocks?.['block-1-uuid'];
             if (debugBlock?.value?.[0]?.children) {
               log('INLINE_EDIT_DATA: full children structure:', JSON.stringify(debugBlock.value[0].children));
             }
             setIframeSyncState(prev => ({
               ...prev,
-              formData: event.data.data,
-              blockPathMap: buildBlockPathMap(event.data.data, config.blocks.blocksConfig, intl),
+              formData: editedData,
+              blockPathMap: buildBlockPathMap(editedData, config.blocks.blocksConfig, intl),
               selection: event.data.selection || null,
               _selectionSource: 'INLINE_EDIT_DATA:new',
               ...(event.data.flushRequestId ? { completedFlushRequestId: event.data.flushRequestId } : {}),
@@ -2255,7 +2268,7 @@ const Iframe = (props) => {
             // Strip _editSequence when updating Redux - sequence numbers are for iframe
             // echo detection only. Redux data doesn't need sequences since admin-side echo
             // prevention uses content comparison (processedInlineEditCounterRef + formDataContentEqual).
-            const { _editSequence: _, ...formDataWithoutSeq } = event.data.data;
+            const { _editSequence: _, ...formDataWithoutSeq } = editedData;
             log('INLINE_EDIT_DATA: calling onChangeFormData prop to update Redux (without _editSequence)');
             onChangeFormData(formDataWithoutSeq);
           } else {
@@ -5224,6 +5237,17 @@ const Iframe = (props) => {
                 }
                 // Use updateBlockById to handle both top-level and container blocks
                 updatedProperties = updateBlockById(properties, iframeSyncState.blockPathMap, selectedBlock, updatedBlock);
+                // Turn a LINKED image/link destination CUSTOM via the SAME
+                // value-compare used everywhere else. Applied synchronously here
+                // (not left to the `properties` effect) because this handler also
+                // writes iframeSyncState.formData below and sends FORM_DATA — the
+                // flipped form must be the one that goes out, or the round-trip
+                // would clobber the async flip.
+                updatedProperties = markEditedLinkedFieldsCustom(
+                  updatedProperties,
+                  properties,
+                  config.blocks.blocksConfig,
+                );
               }
 
               // Update Redux via onChangeFormData

--- a/packages/volto-hydra/src/components/Widgets/CopyFromTargetField.jsx
+++ b/packages/volto-hydra/src/components/Widgets/CopyFromTargetField.jsx
@@ -16,9 +16,12 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { defineMessages, useIntl } from 'react-intl';
+import { Icon } from '@plone/volto/components';
 import config from '@plone/volto/registry';
 import { searchContent } from '@plone/volto/actions/search/search';
 import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers/Url/Url';
+import linkSVG from '@plone/volto/icons/link.svg';
+import unlinkSVG from '@plone/volto/icons/unlink.svg';
 import { useHydraSchemaContext, getLiveBlockData } from '../../context';
 import {
   getTargetId,
@@ -183,8 +186,12 @@ const CopyFromTargetField = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [linked, JSON.stringify(targetValue), props.id]);
 
-  // EDIT: a user edit to a LINKED field flips it to custom (and keeps the typed
-  // value). A custom field edits normally.
+  // EDIT: a user edit to a LINKED field turns it CUSTOM (keeping the typed value).
+  // The sidebar edit is only visible HERE (the widget lives in the sidebar form,
+  // not View), and the flip must be part of THIS update — a reactive after-the-fact
+  // flip re-renders mid-type and moves the cursor. It's the same rule the inline
+  // and image/link paths apply by value-compare; the widget just already knows the
+  // field. A custom field edits normally.
   const onFieldChange = (id, value) => {
     if (linked) {
       updateBlock({ ...withFieldCustom(blockData, props.id), [props.id]: value });
@@ -193,7 +200,8 @@ const CopyFromTargetField = (props) => {
     }
   };
 
-  // TOGGLE: linked ⇄ custom. custom → linked re-pulls the target value.
+  // TOGGLE: linked ⇄ custom. Explicit untick (not a value edit) marks custom;
+  // re-tick re-pulls the target value.
   const onToggle = () => {
     if (linked) {
       updateBlock(withFieldCustom(blockData, props.id));
@@ -214,35 +222,47 @@ const CopyFromTargetField = (props) => {
   };
   const BaseWidget = resolveWidget(baseProps);
 
-  const label = intl.formatMessage(messages.linked);
+  // Icon-only toggle: a checkbox + 🔗, the meaning carried by the hover tooltip.
+  // Ticked = linked (pulls from the linked content); untick to customise.
+  const hint = intl.formatMessage(messages.linkedHint);
   // Offer the toggle only for a supported (internal) target — an external URL
   // can't be pulled from, so the field is just a normal editable field.
   const showToggle = targetSupported;
 
+  // The toggle sits at the top-right of the field row (the end of the input line),
+  // not on a line of its own — a single click-to-toggle icon (no checkbox), using
+  // Volto's own link / unlink icons: linked = tracking the target, unlinked =
+  // custom. Meaning in the tooltip; `aria-pressed` exposes the state to AT/tests.
   return (
-    <>
+    <div style={{ position: 'relative' }} className="copy-from-target-field">
       <BaseWidget {...baseProps} />
       {showToggle ? (
-        <p
-          className="help copy-from-target-toggle"
-          style={{ marginTop: baseWidget?.description ? '2px' : '-6px' }}
+        <button
+          type="button"
+          className="copy-from-target-toggle copy-from-target-linked"
+          aria-pressed={linked}
+          onClick={onToggle}
+          title={hint}
+          aria-label={hint}
+          style={{
+            position: 'absolute',
+            top: '0',
+            right: '0',
+            border: 'none',
+            background: 'none',
+            padding: '2px',
+            cursor: 'pointer',
+            lineHeight: 0,
+          }}
         >
-          <label
-            style={{ display: 'inline-flex', alignItems: 'center', gap: '5px', cursor: 'pointer', color: '#64748b' }}
-            title={intl.formatMessage(messages.linkedHint)}
-          >
-            <input
-              type="checkbox"
-              className="copy-from-target-linked"
-              checked={linked}
-              onChange={onToggle}
-              style={{ margin: 0, cursor: 'pointer' }}
-            />
-            🔗 {label}
-          </label>
-        </p>
+          <Icon
+            name={linked ? linkSVG : unlinkSVG}
+            size="18px"
+            color={linked ? '#684cc9' : '#999'}
+          />
+        </button>
       ) : null}
-    </>
+    </div>
   );
 };
 

--- a/packages/volto-hydra/src/utils/copyFromTarget.js
+++ b/packages/volto-hydra/src/utils/copyFromTarget.js
@@ -215,6 +215,71 @@ export function withFieldLinked(blockData, field) {
   return out;
 }
 
+/** Mapped destination field names a @target mapping writes to, or []. */
+function targetDestFields(blockConfig) {
+  const mapping = getTargetMapping(blockConfig);
+  if (!mapping) return [];
+  return [...new Set(Object.values(mapping).map(getMappingTarget).filter(Boolean))];
+}
+
+function isEqualJson(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Turn a LINKED field CUSTOM the moment its value is edited — the ONE mechanism
+ * for EVERY edit path (sidebar, inline canvas, image, link). Rather than hook each
+ * path, compare by value: diff `incoming` against `previous` and flip any @target
+ * destination whose value changed. This runs on every committed formData change,
+ * so three guards keep it correct:
+ *   1. it was LINKED in the previous (pre-edit) state — typing into a not-yet-
+ *      linked field (no target) doesn't flip it, so a later link still pulls it;
+ *   2. its value actually changed;
+ *   3. the NEW value differs from the TARGET value — this is what distinguishes a
+ *      user edit (writes something other than the target) from the PULL itself
+ *      (writes exactly the target). Without it, the pull would flip the very field
+ *      it just synced.
+ * Recurses into nested container blocks. Returns a shallow clone (=== previous
+ * content when nothing flipped, so callers can cheaply skip a no-op write).
+ */
+export function markEditedLinkedFieldsCustom(incoming, previous, blocksConfig) {
+  if (!incoming?.blocks || !previous?.blocks || !blocksConfig) return incoming;
+  let anyFlipped = false;
+
+  const visit = (inBlocks, prevBlocks) => {
+    for (const id of Object.keys(inBlocks)) {
+      let block = inBlocks[id];
+      const prevBlock = prevBlocks?.[id];
+      if (!block || typeof block !== 'object') continue;
+
+      const cfg = blocksConfig[block['@type']];
+      if (cfg && prevBlock) {
+        for (const field of targetDestFields(cfg)) {
+          if (
+            isFieldLinked(field, cfg, prevBlock) && // was linked BEFORE the edit
+            !isFieldCustom(field, block) && // not already flipped (idempotent)
+            !isEqualJson(block[field], prevBlock[field]) && // its value changed
+            !isEqualJson(block[field], getTargetValueForField(field, cfg, block)) // not the pull
+          ) {
+            block = withFieldCustom(block, field);
+            inBlocks[id] = block;
+            anyFlipped = true;
+          }
+        }
+      }
+      if (block.blocks) {
+        block = { ...block, blocks: { ...block.blocks } };
+        inBlocks[id] = block;
+        visit(block.blocks, prevBlock?.blocks);
+      }
+    }
+  };
+
+  const cloned = { ...incoming, blocks: { ...incoming.blocks } };
+  visit(cloned.blocks, previous.blocks);
+  return anyFlipped ? cloned : incoming;
+}
+
 /**
  * A block schemaEnhancer that applies the copy-from-target field-widget swap.
  * Bound to the block's config at install time (so this module stays free of the

--- a/packages/volto-hydra/src/utils/copyFromTarget.js
+++ b/packages/volto-hydra/src/utils/copyFromTarget.js
@@ -29,10 +29,43 @@ import { getMappingTarget, getFieldType } from './schemaInheritance';
 /** Widget name the mapped destination fields are swapped to (the wrapper). */
 export const COPY_FROM_TARGET_WIDGET = 'copyFromTargetField';
 
-/** The `@target` mapping ({ sourceAttr: destField | {field,type} }) or null. */
+// Canonical `@default` source keys (the lowercase listing/conversion shape) →
+// the keys the LINK snapshot (selectedItemAttrs) actually carries. @default and
+// a link snapshot are both catalog-shaped but historically cased differently: a
+// listing result serializes `title`, a link brain carries `Title`. So to reuse
+// `@default` as the target mapping we translate each canonical source to its
+// snapshot key. `@id` is the link itself (it populates the url field), not a
+// pulled display field, so it is intentionally omitted.
+const DEFAULT_SOURCE_TO_SNAPSHOT = {
+  title: { src: 'Title' },
+  description: { src: 'Description' },
+  image: { src: 'image_scales', type: 'image' },
+};
+
+/**
+ * The `@target` mapping ({ sourceAttr: destField | {field,type} }) or null.
+ *
+ * Copy-from-target is ON BY DEFAULT: a block with a link field but no explicit
+ * `@target` falls back to a normalized `@default` — so any link-bearing block
+ * that already declares its canonical content shape pulls from the link without
+ * extra wiring (the teaser case). An explicit `@target` always wins. A block
+ * with no link field (nothing to pull from) returns null.
+ */
 export function getTargetMapping(blockConfig) {
-  const m = blockConfig?.fieldMappings?.['@target'];
-  return m && Object.keys(m).length > 0 ? m : null;
+  const explicit = blockConfig?.fieldMappings?.['@target'];
+  if (explicit && Object.keys(explicit).length > 0) return explicit;
+
+  const def = blockConfig?.fieldMappings?.['@default'];
+  if (!def || !getUrlField(blockConfig)) return null;
+
+  const synthesized = {};
+  for (const [canonical, dest] of Object.entries(def)) {
+    const norm = DEFAULT_SOURCE_TO_SNAPSHOT[canonical]; // skips @id + unknowns
+    const destField = norm && getMappingTarget(dest);
+    if (!destField) continue;
+    synthesized[norm.src] = norm.type ? { field: destField, type: norm.type } : destField;
+  }
+  return Object.keys(synthesized).length > 0 ? synthesized : null;
 }
 
 /** Destination (block) field names the @target mapping writes to. */

--- a/packages/volto-hydra/src/utils/copyFromTarget.test.js
+++ b/packages/volto-hydra/src/utils/copyFromTarget.test.js
@@ -19,6 +19,7 @@ import {
   isFieldLinked,
   withFieldCustom,
   withFieldLinked,
+  markEditedLinkedFieldsCustom,
   installCopyFromTargetEnhancers,
   getTargetId,
   COPY_FROM_TARGET_WIDGET,
@@ -209,6 +210,51 @@ describe('linked vs custom per-field state (_customFields)', () => {
 
     const d = withFieldLinked(c, 'description');
     expect(d._customFields).toBeUndefined(); // key removed when empty
+  });
+});
+
+describe('markEditedLinkedFieldsCustom — inline edit turns a linked field custom (value-compare)', () => {
+  const cfg = { teaser: teaserConfig };
+  const linkedBlock = () => ({ '@type': 'teaser', href: [targetSnapshot], title: 'Big News' });
+
+  it('flips a linked field whose value changed (typed on canvas)', () => {
+    const current = { blocks: { t1: linkedBlock() } };
+    const incoming = { blocks: { t1: { ...linkedBlock(), title: 'Typed on canvas' } } };
+    const out = markEditedLinkedFieldsCustom(incoming, current, cfg);
+    expect(out.blocks.t1.title).toBe('Typed on canvas'); // value kept
+    expect(out.blocks.t1._customFields).toContain('title'); // flipped custom
+  });
+
+  it('does NOT flip an unchanged linked field', () => {
+    const current = { blocks: { t1: linkedBlock() } };
+    const incoming = { blocks: { t1: linkedBlock() } };
+    const out = markEditedLinkedFieldsCustom(incoming, current, cfg);
+    expect(out).toBe(incoming); // untouched reference (cheap no-op)
+    expect(out.blocks.t1._customFields).toBeUndefined();
+  });
+
+  it('does NOT flip when the value changed TO the target (the pull, not an edit)', () => {
+    // A stale value being pulled up to the target must stay LINKED, not flip.
+    const current = { blocks: { t1: { '@type': 'teaser', href: [targetSnapshot], title: 'stale' } } };
+    const incoming = { blocks: { t1: { '@type': 'teaser', href: [targetSnapshot], title: 'Big News' } } };
+    const out = markEditedLinkedFieldsCustom(incoming, current, cfg);
+    expect(out.blocks.t1._customFields).toBeUndefined(); // pull → still linked
+  });
+
+  it('does NOT flip a field that was NOT linked pre-edit (no target → typing before a link)', () => {
+    // No href yet → not linked → typing the title must not turn it custom, so a
+    // later link still pulls it.
+    const current = { blocks: { t1: { '@type': 'teaser', title: '' } } };
+    const incoming = { blocks: { t1: { '@type': 'teaser', title: 'Typed before link' } } };
+    const out = markEditedLinkedFieldsCustom(incoming, current, cfg);
+    expect(out.blocks.t1._customFields).toBeUndefined();
+  });
+
+  it('flips linked fields inside nested container blocks', () => {
+    const current = { blocks: { grid: { '@type': 'grid', blocks: { t1: linkedBlock() } } } };
+    const incoming = { blocks: { grid: { '@type': 'grid', blocks: { t1: { ...linkedBlock(), title: 'Edited' } } } } };
+    const out = markEditedLinkedFieldsCustom(incoming, current, cfg);
+    expect(out.blocks.grid.blocks.t1._customFields).toContain('title');
   });
 });
 

--- a/packages/volto-hydra/src/utils/copyFromTarget.test.js
+++ b/packages/volto-hydra/src/utils/copyFromTarget.test.js
@@ -341,3 +341,64 @@ describe('copy-from-target × fieldRules — conditional (optional) mapped field
     expect(withDate.properties.image).toBeUndefined();
   });
 });
+
+/**
+ * On-by-default: a link-bearing block with a `@default` mapping (but no explicit
+ * `@target`) pulls from the link. The synthesized mapping normalizes @default's
+ * canonical keys (title/description/image) to the link snapshot's brain keys
+ * (Title/Description/image_scales); `@id` (the link itself) is not pulled.
+ */
+describe('copy-from-target — on by default via @default (link-bearing blocks)', () => {
+  const linkCard = {
+    id: 'linkcard',
+    fieldMappings: {
+      '@default': {
+        '@id': 'href',
+        title: 'heading',
+        description: 'summary',
+        image: 'picture',
+      },
+    },
+    blockSchema: {
+      properties: {
+        href: { title: 'Link', widget: 'object_browser', mode: 'link' },
+        heading: { title: 'Heading' },
+        summary: { title: 'Summary' },
+        picture: { title: 'Picture', widget: 'object_browser', mode: 'image' },
+      },
+    },
+  };
+
+  it('synthesizes a @target from @default (canonical → snapshot keys, @id skipped)', () => {
+    const m = getTargetMapping(linkCard);
+    expect(m).toEqual({
+      Title: 'heading',
+      Description: 'summary',
+      image_scales: { field: 'picture', type: 'image' },
+    });
+    // @id → href is the link itself, not pulled
+    expect(m['@id']).toBeUndefined();
+  });
+
+  it('a block with @default but NO link field is not default-on', () => {
+    const noLink = {
+      id: 'x',
+      fieldMappings: { '@default': { title: 'heading' } },
+      blockSchema: { properties: { heading: { title: 'Heading' } } },
+    };
+    expect(getTargetMapping(noLink)).toBeNull();
+  });
+
+  it('an explicit @target still wins over @default', () => {
+    const both = { ...linkCard, fieldMappings: { ...linkCard.fieldMappings, '@target': { Title: 'heading' } } };
+    expect(getTargetMapping(both)).toEqual({ Title: 'heading' });
+  });
+
+  it('pulls the target value through the synthesized mapping', () => {
+    const blockData = {
+      href: [{ '@id': '/p', Title: 'Live Title', Description: 'Live Desc' }],
+    };
+    expect(getTargetValueForField('heading', linkCard, blockData)).toBe('Live Title');
+    expect(getTargetValueForField('summary', linkCard, blockData)).toBe('Live Desc');
+  });
+});

--- a/tests-playwright/fixtures/content/copy-target-page/data.json
+++ b/tests-playwright/fixtures/content/copy-target-page/data.json
@@ -24,9 +24,17 @@
       "title": "External label",
       "href": [{ "@id": "https://example.com", "title": "Example" }],
       "inneralign": "left"
+    },
+    "hero-linked": {
+      "@type": "hero",
+      "heading": "Author Heading",
+      "subheading": "",
+      "buttonText": "Go",
+      "buttonLink": [{ "@id": "/news/big" }],
+      "description": [{ "type": "p", "children": [{ "text": "" }] }]
     }
   },
   "blocks_layout": {
-    "items": ["title-block", "btn-linked", "btn-custom", "btn-external"]
+    "items": ["title-block", "btn-linked", "btn-custom", "btn-external", "hero-linked"]
   }
 }

--- a/tests-playwright/integration/copy-from-target.spec.ts
+++ b/tests-playwright/integration/copy-from-target.spec.ts
@@ -27,7 +27,7 @@ test.describe('Copy-from-target — linked/custom toggle', () => {
     await expect
       .poll(async () => helper.getSidebarFieldValue('title'), { timeout: 5000 })
       .toBe('Target Title');
-    await expect(page.locator(linkedToggle)).toBeChecked();
+    await expect(page.locator(linkedToggle)).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('a custom field keeps its own value, toggle unchecked', async ({ page }) => {
@@ -40,7 +40,7 @@ test.describe('Copy-from-target — linked/custom toggle', () => {
 
     // Custom → NOT pulled; keeps the editor's value.
     expect(await helper.getSidebarFieldValue('title')).toBe('My own label');
-    await expect(page.locator(linkedToggle)).not.toBeChecked();
+    await expect(page.locator(linkedToggle)).toHaveAttribute('aria-pressed', 'false');
   });
 
   test('editing a linked field flips it to custom (toggle unchecks)', async ({ page }) => {
@@ -53,14 +53,69 @@ test.describe('Copy-from-target — linked/custom toggle', () => {
     await expect
       .poll(async () => helper.getSidebarFieldValue('title'), { timeout: 5000 })
       .toBe('Target Title');
-    await expect(page.locator(linkedToggle)).toBeChecked();
+    await expect(page.locator(linkedToggle)).toHaveAttribute('aria-pressed', 'true');
 
     // Type into the (linked) field → it becomes custom.
     await page.locator(titleInput).fill('Hand typed');
-    await expect(page.locator(linkedToggle)).not.toBeChecked();
+    await expect(page.locator(linkedToggle)).toHaveAttribute('aria-pressed', 'false');
     await expect
       .poll(async () => helper.getSidebarFieldValue('title'), { timeout: 5000 })
       .toBe('Hand typed');
+  });
+
+  test('typing inline turns off sync (flips the field to custom)', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/copy-target-page');
+
+    // The hero's `heading` is a copy-from-target LINKED text field, inline-editable
+    // on the canvas. Typing into it must turn off sync (flip to custom) — detected
+    // by value-compare, since the inline message doesn't say which field changed.
+    const headingToggle =
+      '#sidebar-properties .field-wrapper-heading + .copy-from-target-toggle';
+    await helper.clickBlockInIframe('hero-linked');
+    await helper.waitForSidebarOpen();
+    await expect(page.locator(headingToggle)).toHaveAttribute('aria-pressed', 'true');
+
+    const editor = await helper.enterEditMode('hero-linked', 'heading');
+    await helper.selectAllTextInEditor(editor);
+    await editor.pressSequentially('Typed inline', { delay: 10 });
+
+    // Confirm the edit landed (value drifted) — that is what turns it custom.
+    await expect
+      .poll(async () => helper.getSidebarFieldValue('heading'), { timeout: 5000 })
+      .toBe('Typed inline');
+    await expect(page.locator(headingToggle)).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('inline-editing an IMAGE field flips it to custom (image/link edit path)', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/copy-target-page');
+
+    // The hero's `image` is a copy-from-target LINKED destination (its buttonLink
+    // is an internal target) and is edited inline via the toolbar image overlay —
+    // the same `onFieldLinkChange` path that image AND link fields use. Editing it
+    // must flip it to custom, exactly like a sidebar edit; otherwise the next pull
+    // would clobber the chosen image. The toggle renders after the field wrapper.
+    const imageToggle =
+      '#sidebar-properties .field-wrapper-image + .copy-from-target-toggle';
+    await helper.clickBlockInIframe('hero-linked');
+    await helper.waitForSidebarOpen();
+    await expect(page.locator(imageToggle)).toHaveAttribute('aria-pressed', 'true');
+
+    // Set the image via a typed URL in the overlay (no object browser).
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="hero-linked"] [data-edit-media="image"]').click();
+    const imageButton = helper.getQuantaToolbarFormatButton('image');
+    await expect(imageButton).toBeVisible({ timeout: 5000 });
+    await imageButton.click();
+    const overlay = page.locator('.empty-image-overlay');
+    await expect(overlay).toBeVisible({ timeout: 5000 });
+    await overlay.locator('input[name="link"]').fill('https://picsum.photos/400/300');
+    await overlay.locator('button[aria-label="Submit"]').click();
+
+    await expect(page.locator(imageToggle)).toHaveAttribute('aria-pressed', 'false');
   });
 
   test('an external link offers no toggle and cannot pull (plain editable field)', async ({ page }) => {
@@ -94,8 +149,34 @@ test.describe('Copy-from-target — linked/custom toggle', () => {
       .toBe('Target Title');
 
     // Untick → custom; value is retained, no longer pulled.
-    await page.locator(linkedToggle).uncheck();
-    await expect(page.locator(linkedToggle)).not.toBeChecked();
+    await page.locator(linkedToggle).click();
+    await expect(page.locator(linkedToggle)).toHaveAttribute('aria-pressed', 'false');
     expect(await helper.getSidebarFieldValue('title')).toBe('Target Title');
+  });
+
+  test('re-linking (re-tick) wipes the custom value and pulls the target again', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/copy-target-page');
+
+    await helper.clickBlockInIframe('btn-linked');
+    await helper.waitForSidebarOpen();
+    await expect
+      .poll(async () => helper.getSidebarFieldValue('title'), { timeout: 5000 })
+      .toBe('Target Title');
+
+    // Edit → custom (keeps the typed value).
+    await page.locator(titleInput).fill('Hand typed');
+    await expect(page.locator(linkedToggle)).toHaveAttribute('aria-pressed', 'false');
+    await expect
+      .poll(async () => helper.getSidebarFieldValue('title'), { timeout: 5000 })
+      .toBe('Hand typed');
+
+    // Re-tick → re-links AND re-pulls the target, discarding the custom value.
+    await page.locator(linkedToggle).click();
+    await expect(page.locator(linkedToggle)).toHaveAttribute('aria-pressed', 'true');
+    await expect
+      .poll(async () => helper.getSidebarFieldValue('title'), { timeout: 5000 })
+      .toBe('Target Title');
   });
 });


### PR DESCRIPTION
Follow-up to #256. Makes copy-from-target **on by default** (no explicit `@target` opt-in needed) + (WIP) adds the pull-on-edit-start and the missing coverage flagged in review.

## On by default (this commit)
`getTargetMapping` falls back to a **normalized `@default`** when a block has a link field but no `@target`. So any link-bearing block that already declares its canonical content shape pulls from the link — the teaser/navItem case — with no extra wiring. Explicit `@target` still wins.

`@default` and a link snapshot are both catalog-shaped but cased differently (a listing serializes `title`; a link brain carries `Title`), so the synthesized mapping normalizes canonical → snapshot keys (`title→Title`, `description→Description`, `image→image_scales`, `@id` skipped — it's the link itself).

**Scope (confirmed):** every block whose `@default` declares a link field defaults on — `navItem` (href) and `hero` (its `@default` declares `buttonLink` as `@id`, so it pulls from the CTA link). +4 unit tests (30 total pass).

## Still to come on this branch
- Eager **pull on edit-start** (page-level pass; dirty-on-open accepted).
- Integration test: **change the link target → linked fields re-pull**.
- Strengthen the **typing → auto-custom** test (read-only fallback if the flip can't be made reliable — it can, so likely not needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
