### PR TITLE
fix(copy-from-target): fill on load from the link snapshot, drop @search

### DIFF
--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -279,8 +279,10 @@ import {
   markEditedLinkedFieldsCustom,
   getUrlField,
   pullLinkedFields,
+  pullAllLinkedFields,
 } from '../../utils/copyFromTarget';
 import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers/Url/Url';
+import { searchContent } from '@plone/volto/actions/search/search';
 import ChildBlocksWidget from '../Sidebar/ChildBlocksWidget';
 import ParentBlocksWidget from '../Sidebar/ParentBlocksWidget';
 
@@ -3522,12 +3524,16 @@ const Iframe = (props) => {
           }
 
           // 6. Apply schema defaults (handles schemaEnhancer-computed defaults like fieldMapping)
-          const formWithDefaults = applySchemaDefaultsToFormData(
+          let formWithDefaults = applySchemaDefaultsToFormData(
             formWithPageFields,
             initialBlockPathMap,
             config.blocks.blocksConfig,
             intl,
           );
+          // 6b. On-load pull: every linked field fills from its stored snapshot
+          // when the page opens for editing (canvas-pick snapshots carry the data;
+          // sidebar `[{@id}]` links have nothing to pull).
+          formWithDefaults = pullAllLinkedFields(formWithDefaults, config.blocks.blocksConfig);
 
           setIframeSyncState(prev => ({
             ...prev,
@@ -3932,12 +3938,15 @@ const Iframe = (props) => {
     // This ensures fields like fieldMapping get smart defaults even on initial load.
     // IMPORTANT: Must apply before equality check so we compare apples-to-apples
     // (both formWithDefaults and iframeSyncState.formData have defaults applied)
-    const formWithDefaults = applySchemaDefaultsToFormData(
+    let formWithDefaults = applySchemaDefaultsToFormData(
       formToUse,
       newBlockPathMap,
       config.blocks.blocksConfig,
       intl,
     );
+    // On-load pull: fill every linked block from its (full-metadata) snapshot when
+    // the page opens. The widget's reactive pull covers editing the selected block.
+    formWithDefaults = pullAllLinkedFields(formWithDefaults, config.blocks.blocksConfig);
 
     // Also skip if content is identical (ignoring _editSequence metadata)
     // Compare defaults-applied versions to avoid infinite loops
@@ -5198,6 +5207,19 @@ const Iframe = (props) => {
             onFieldLinkChange={(fieldName, url, metadata) => {
               let updatedProperties;
 
+              // ONE finalize for every path (page-field, pick, typed, fetched):
+              // push the updated form data to Redux + the iframe, rebuild pathMap.
+              const finalizeLink = (up) => {
+                onChangeFormData(up);
+                const newBlockPathMap = buildBlockPathMap(up, config.blocks.blocksConfig, intl);
+                setIframeSyncState(prev => ({
+                  ...prev,
+                  formData: up,
+                  blockPathMap: newBlockPathMap,
+                  toolbarRequestDone: `field-link-${Date.now()}`,
+                }));
+              };
+
               if (selectedBlock === PAGE_BLOCK_UID) {
                 // Page-level field - update directly on properties
                 // For image fields with metadata, construct NamedBlobImage format
@@ -5231,56 +5253,55 @@ const Iframe = (props) => {
                 const block = getBlockById(properties, iframeSyncState.blockPathMap, selectedBlock);
                 if (!block) return;
 
-                // An object_browser link field holds the object_browser array shape
-                // `[{ '@id': … }]` (selectedItemAttrs), NOT a bare URL string — the
-                // inline link editor otherwise stores just the URL, so getTargetId
-                // (and copy-from-target's live @search of the target) can't resolve
-                // it and the linked title/description never fill. Wrap it here.
                 const blockCfg = config.blocks.blocksConfig[block['@type']];
+                const isUrlField = blockCfg && getUrlField(blockCfg) === fieldName;
+
+                // Store a link `value` (object_browser array shape) and its metadata,
+                // pull every linked field from the (now full) snapshot, flip edited
+                // fields custom, then push FORM_DATA. Shared by pick / typed / fetched.
+                const applyLinkValue = (value, extraMeta) => {
+                  let updatedBlock = setFieldValue(block, fieldName, value);
+                  const meta = extraMeta || metadata;
+                  if (meta?.image_scales) {
+                    updatedBlock = { ...updatedBlock, image_field: meta.image_field, image_scales: meta.image_scales };
+                  }
+                  // No pull here — storing the link (full snapshot) is enough; the
+                  // copy-from-target widget's reactive pull fills the mapped fields.
+                  let up = updateBlockById(properties, iframeSyncState.blockPathMap, selectedBlock, updatedBlock);
+                  up = markEditedLinkedFieldsCustom(up, properties, config.blocks.blocksConfig);
+                  finalizeLink(up);
+                };
+
+                // A TYPED internal URL carries no metadata (unlike a pick). Resolve
+                // the target's brain (metadata_fields:'_all') so the stored snapshot
+                // carries the full data — the same fetch the sidebar's manual-link
+                // input does — then every mapped field pulls from it. No copy-from-
+                // target @search: the data lives on the link field afterwards.
+                if (typeof url === 'string' && url && isUrlField && isInternalURL(url)) {
+                  const path = flattenToAppURL(url);
+                  Promise.resolve(
+                    dispatch(searchContent(path, { 'path.depth': 0, metadata_fields: '_all', b_size: 1 }, `copy-from-target-${path}`)),
+                  )
+                    .then((resp) => {
+                      const item = (resp?.items || []).find((i) => flattenToAppURL(i['@id']) === path);
+                      applyLinkValue([{ ...(item || {}), '@id': path }]);
+                    })
+                    .catch(() => applyLinkValue([{ '@id': path }]));
+                  return;
+                }
+
+                // Pick (value already an array with metadata) or an external typed
+                // URL (wrap the bare string into the array shape).
                 let value = url;
-                if (typeof url === 'string' && url && blockCfg && getUrlField(blockCfg) === fieldName) {
-                  value = [{ '@id': isInternalURL(url) ? flattenToAppURL(url) : url }];
+                if (typeof url === 'string' && url && isUrlField) {
+                  value = [{ '@id': url }];
                 }
-                // For blocks, store url and image_scales separately (like Image block does).
-                // setFieldValue writes the url at its (possibly object-nested) /-path;
-                // image_field/image_scales stay at the block top level (Image-block shape).
-                let updatedBlock = setFieldValue(block, fieldName, value);
-                if (metadata?.image_scales) {
-                  updatedBlock = { ...updatedBlock, image_field: metadata.image_field, image_scales: metadata.image_scales };
-                }
-                // Setting the SOURCE link (pick/type) pulls every linked mapped
-                // field in ONE write — a multi-field @default block (hero) fills
-                // heading/subheading/image atomically instead of racing per-field
-                // widget pulls that clobber all but the last-written field.
-                if (blockCfg && getUrlField(blockCfg) === fieldName) {
-                  updatedBlock = pullLinkedFields(blockCfg, updatedBlock);
-                }
-                // Use updateBlockById to handle both top-level and container blocks
-                updatedProperties = updateBlockById(properties, iframeSyncState.blockPathMap, selectedBlock, updatedBlock);
-                // Turn a LINKED image/link destination CUSTOM via the SAME
-                // value-compare used everywhere else. Applied synchronously here
-                // (not left to the `properties` effect) because this handler also
-                // writes iframeSyncState.formData below and sends FORM_DATA — the
-                // flipped form must be the one that goes out, or the round-trip
-                // would clobber the async flip.
-                updatedProperties = markEditedLinkedFieldsCustom(
-                  updatedProperties,
-                  properties,
-                  config.blocks.blocksConfig,
-                );
+                applyLinkValue(value);
+                return;
               }
 
-              // Update Redux via onChangeFormData
-              onChangeFormData(updatedProperties);
-
-              // Rebuild blockPathMap and send FORM_DATA to iframe
-              const newBlockPathMap = buildBlockPathMap(updatedProperties, config.blocks.blocksConfig, intl);
-              setIframeSyncState(prev => ({
-                ...prev,
-                formData: updatedProperties,
-                blockPathMap: newBlockPathMap,
-                toolbarRequestDone: `field-link-${Date.now()}`,
-              }));
+              // Page-level field path finalizes here (block-field path returned above).
+              finalizeLink(updatedProperties);
             }}
             onOpenObjectBrowser={(fieldName, blockUid) => {
               // Set pending state to trigger object browser via OpenObjectBrowser component

--- a/packages/volto-hydra/src/components/Toolbar/SyncedSlateToolbar.jsx
+++ b/packages/volto-hydra/src/components/Toolbar/SyncedSlateToolbar.jsx
@@ -1769,13 +1769,12 @@ const SyncedSlateToolbar = ({
             }}
             onSelectItem={isObjectBrowserLink ? (url, item) => {
               if (onFieldLinkChange) {
-                // Use full item metadata for object_browser link fields
-                const linkValue = [{
-                  '@id': item?.['@id'] || url,
-                  title: item?.title || item?.Title || '',
-                  description: item?.description || item?.Description || '',
-                  hasPreviewImage: item?.hasPreviewImage ?? false,
-                }];
+                // Store the FULL picked-item metadata (the object browser fetches
+                // metadata_fields:'_all', so `item` carries image_scales/image_field,
+                // description, Subject, dates, …). Copy-from-target pulls every mapped
+                // field from this snapshot — dropping keys here is exactly what forced
+                // a redundant live @search before.
+                const linkValue = [{ ...item, '@id': item?.['@id'] || url }];
                 onFieldLinkChange(fieldLinkEditorField, linkValue);
               }
               setFieldLinkEditorOpen(false);

--- a/packages/volto-hydra/src/components/Widgets/CopyFromTargetField.jsx
+++ b/packages/volto-hydra/src/components/Widgets/CopyFromTargetField.jsx
@@ -13,13 +13,11 @@
  * and resolve the real widget with Volto's own resolution order so the base
  * renders exactly as it always would.
  */
-import React, { useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useEffect } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Icon } from '@plone/volto/components';
 import config from '@plone/volto/registry';
-import { searchContent } from '@plone/volto/actions/search/search';
-import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers/Url/Url';
+import { isInternalURL } from '@plone/volto/helpers/Url/Url';
 import linkSVG from '@plone/volto/icons/link.svg';
 import unlinkSVG from '@plone/volto/icons/unlink.svg';
 import { useHydraSchemaContext, getLiveBlockData } from '../../context';
@@ -29,74 +27,11 @@ import {
   isFieldLinked,
   withFieldCustom,
   withFieldLinked,
+  pullLinkedFields,
 } from '../../utils/copyFromTarget';
 
-// Session cache of live targets, keyed by @id, so a linked field pulls the
-// CURRENT target — not the stale link-field snapshot. Lazy: fetched the first
-// time a @target block is edited this session; refreshed after the TTL.
-// Module-level so all fields of a block share one fetch.
-const LIVE_TARGET_TTL = 5 * 60 * 1000; // 5 minutes
-const liveTargetCache = new Map(); // id -> { brain, fetchedAt, promise }
-
-/**
- * Lazily fetch the live target once per session (TTL-refreshed). We use the
- * catalog **search** (metadata_fields: '_all') rather than getContent: the
- * link-field snapshot (selectedItemAttrs) is itself a catalog brain, so the
- * search result is already in the same shape — no transform, guaranteed field
- * alignment. Undefined until the first fetch resolves (callers fall back to the
- * stored snapshot). Never mutates formData directly (no dirty state).
- */
-function useLiveTarget(targetId) {
-  const dispatch = useDispatch();
-  const [live, setLive] = useState(() => liveTargetCache.get(targetId)?.brain);
-
-  useEffect(() => {
-    if (!targetId) {
-      setLive(undefined);
-      return undefined;
-    }
-    const cached = liveTargetCache.get(targetId);
-    if (cached?.brain && Date.now() - cached.fetchedAt < LIVE_TARGET_TTL) {
-      setLive(cached.brain);
-      return undefined;
-    }
-    let cancelled = false;
-    const path = flattenToAppURL(targetId);
-    const promise =
-      cached?.promise ||
-      Promise.resolve(
-        dispatch(
-          searchContent(
-            path,
-            { 'path.depth': 0, metadata_fields: '_all', b_size: 1 },
-            `copy-from-target-${targetId}`,
-          ),
-        ),
-      )
-        .then((resp) => {
-          const items = resp?.items || [];
-          // ONLY the exact target — never fall back to some other result
-          // (e.g. a missing target would otherwise pick a wrong item and
-          // corrupt divergence). No match → undefined → use the stored snapshot.
-          const brain = items.find((i) => flattenToAppURL(i['@id']) === path);
-          liveTargetCache.set(targetId, { brain, fetchedAt: Date.now(), promise: null });
-          return brain;
-        })
-        .catch(() => {
-          liveTargetCache.delete(targetId); // let a later select retry
-          return undefined;
-        });
-    liveTargetCache.set(targetId, { ...(cached || {}), promise });
-    promise.then((brain) => {
-      if (!cancelled) setLive(brain);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [targetId, dispatch]);
-
-  return live;
-}
+// No live @search: the pick stores the full item metadata (metadata_fields:'_all')
+// into the link snapshot, so every mapped field pulls straight from that snapshot.
 
 const messages = defineMessages({
   linked: {
@@ -151,40 +86,34 @@ const CopyFromTargetField = (props) => {
     : null;
   const updateBlock = (newData) => ctx.onChangeBlock?.(ctx.currentBlockId, newData);
 
-  // Fresh target (lazy, session-cached) — the value a linked field is pulled to.
+  // The target snapshot lives on the link field (metadata_fields:'_all' at pick
+  // time), so the value a linked field pulls to comes straight from it.
   const targetId = blockConfig && blockData && getTargetId(blockConfig, blockData);
-  // Only an INTERNAL link is a pull source: an external URL has no catalog item
-  // to @search, so we can't pull from it. Such a field falls back to a plain
-  // editable field (no toggle). (External unfurl via OpenGraph is a follow-up.)
+  // Only an INTERNAL link is a pull source: an external URL has no catalog item,
+  // so the field falls back to a plain editable field (no toggle).
   const targetSupported = !!targetId && isInternalURL(targetId);
-  const liveTarget = useLiveTarget(targetSupported ? targetId : undefined);
 
   const linked =
     targetSupported &&
     !!blockConfig &&
     !!blockData &&
     isFieldLinked(props.id, blockConfig, blockData);
-  const targetValue = getTargetValueForField(props.id, blockConfig, blockData, liveTarget);
+  const targetValue = getTargetValueForField(props.id, blockConfig, blockData);
 
-  // PULL: while linked, keep the field's stored value in sync with the target —
-  // on first block select (mount) and when the target changes (href / TTL
-  // refresh). Only writes when the value actually differs, so a settled linked
-  // field is a no-op (no spurious dirty state). Not a user edit: uses the raw
-  // field onChange (so it does NOT flip the field to custom, and is field-scoped
-  // so multiple linked fields never clobber each other).
-  //
-  // Deferred one frame: a synchronous onChange during the block's form mount is
-  // discarded (the form re-derives from its `data` prop on initial commit), so
-  // we write after that commit settles. cancelled on unmount/target change.
+  // PULL (reactive): when the SELECTED block's link changes (canvas or sidebar) or
+  // a field is re-linked, fill every linked field from the snapshot in ONE
+  // block-level, idempotent write (settled block → same ref → no-op). Page open is
+  // handled by the `pullAllLinkedFields` pass in View; this covers editing. The
+  // snapshot already carries full metadata (the pick/type stored it) — no @search.
+  // Deferred a frame so the form's initial data re-derivation doesn't discard it.
   useEffect(() => {
-    if (!linked || targetValue === undefined) return undefined;
-    if (JSON.stringify(blockData?.[props.id]) === JSON.stringify(targetValue)) {
-      return undefined;
-    }
-    const raf = requestAnimationFrame(() => props.onChange?.(props.id, targetValue));
+    if (!targetSupported || !blockConfig || !blockData) return undefined;
+    const pulled = pullLinkedFields(blockConfig, blockData);
+    if (pulled === blockData) return undefined;
+    const raf = requestAnimationFrame(() => updateBlock(pulled));
     return () => cancelAnimationFrame(raf);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [linked, JSON.stringify(targetValue), props.id]);
+  }, [targetSupported, JSON.stringify(blockData)]);
 
   // EDIT: a user edit to a LINKED field turns it CUSTOM (keeping the typed value).
   // The sidebar edit is only visible HERE (the widget lives in the sidebar form,

--- a/packages/volto-hydra/src/utils/copyFromTarget.js
+++ b/packages/volto-hydra/src/utils/copyFromTarget.js
@@ -29,9 +29,33 @@
  */
 import { getMappingTarget, getFieldType, widgetToTargetType } from './schemaInheritance';
 import { convertFieldValue, normalizeCatalogImage } from '@volto-hydra/helpers';
+import { isInternalURL } from '@plone/volto/helpers/Url/Url';
 
 /** Widget name the mapped destination fields are swapped to (the wrapper). */
 export const COPY_FROM_TARGET_WIDGET = 'copyFromTargetField';
+
+/**
+ * Catalog-brain keys a copy-from-target block could ever pull. The link field's
+ * object_browser widget keeps exactly these on a pick (its `selectedItemAttrs`),
+ * so the stored snapshot carries the full set — any mapped field pulls from it,
+ * and a field toggled custom stays re-pullable — without a live @search. `image`
+ * is the raw `image_scales` + `image_field` pair (normalizeCatalogImage folds
+ * them into a single `image` object at pull time).
+ */
+export const CANONICAL_SNAPSHOT_KEYS = [
+  'title',
+  'description',
+  'image_scales',
+  'image_field',
+  'hasPreviewImage',
+  'Subject',
+  'created',
+  'modified',
+  'effective',
+  'expires',
+  'start',
+  'end',
+];
 
 /**
  * The `@target` mapping ({ sourceAttr: destField | {field,type} }) or null.
@@ -108,6 +132,22 @@ export function applyCopyFromTargetToSchema(schema, blockConfig) {
       // Preserve the ORIGINAL field def so the wrapper can re-resolve the
       // real widget (object_browser/textarea/select/…) exactly as Volto would.
       baseWidget: def,
+    };
+    changed = true;
+  }
+
+  // Tell the link field's object_browser widget to KEEP every field we COULD ever
+  // pull when it stores a pick — not just the ones this block's mapping uses today
+  // (the widget projects the picked item to `[...selectedItemAttrs, '@id', 'title']`,
+  // and the object browser fetches metadata_fields:'_all', so the data is there).
+  // A block may map any of these; a field toggled custom must still be re-pullable.
+  // So the snapshot carries the full canonical set and every field pulls from it —
+  // no live @search.
+  const urlField = getUrlField(blockConfig);
+  if (urlField && properties[urlField]) {
+    properties[urlField] = {
+      ...properties[urlField],
+      selectedItemAttrs: [...CANONICAL_SNAPSHOT_KEYS],
     };
     changed = true;
   }
@@ -191,7 +231,10 @@ export function isFieldCustom(field, blockData) {
 export function isFieldLinked(field, blockConfig, blockData) {
   if (!getTargetMapping(blockConfig)) return false;
   if (!mappingEntryFor(field, getTargetMapping(blockConfig))) return false;
-  if (!getTargetId(blockConfig, blockData)) return false;
+  const targetId = getTargetId(blockConfig, blockData);
+  // Only an INTERNAL link is a pull source: an external URL has no catalog item
+  // to pull from, so its fields stay plain editable (no linked state, no pull).
+  if (!targetId || !isInternalURL(targetId)) return false;
   return !isFieldCustom(field, blockData);
 }
 
@@ -300,6 +343,46 @@ export function markEditedLinkedFieldsCustom(incoming, previous, blocksConfig) {
   const cloned = { ...incoming, blocks: { ...incoming.blocks } };
   visit(cloned.blocks, previous.blocks);
   return anyFlipped ? cloned : incoming;
+}
+
+/**
+ * Pull EVERY linked field of EVERY block from its stored snapshot — the on-load
+ * pass that fills all blocks when the page is opened for editing. Snapshot-based
+ * (no live @search): a canvas pick stores the full selectedItemAttrs, so its
+ * linked fields fill; a sidebar link that stored only `[{@id}]` has no metadata
+ * to pull from (the unsupported path). Custom fields are left untouched. Recurses
+ * nested container blocks. Returns the same formData when nothing changed, so a
+ * settled document is a no-op.
+ */
+export function pullAllLinkedFields(formData, blocksConfig) {
+  if (!formData?.blocks || !blocksConfig) return formData;
+  let anyPulled = false;
+
+  const visit = (blocks) => {
+    for (const id of Object.keys(blocks)) {
+      let block = blocks[id];
+      if (!block || typeof block !== 'object') continue;
+
+      const cfg = blocksConfig[block['@type']];
+      if (cfg) {
+        const pulled = pullLinkedFields(cfg, block);
+        if (pulled !== block) {
+          block = pulled;
+          blocks[id] = block;
+          anyPulled = true;
+        }
+      }
+      if (block.blocks) {
+        block = { ...block, blocks: { ...block.blocks } };
+        blocks[id] = block;
+        visit(block.blocks);
+      }
+    }
+  };
+
+  const cloned = { ...formData, blocks: { ...formData.blocks } };
+  visit(cloned.blocks);
+  return anyPulled ? cloned : formData;
 }
 
 /**

--- a/tests-playwright/fixtures/content/copy-target-page/data.json
+++ b/tests-playwright/fixtures/content/copy-target-page/data.json
@@ -58,9 +58,34 @@
         }
       },
       "blocks_layout": { "items": ["nested-btn"] }
+    },
+    "hero-onload": {
+      "@type": "hero",
+      "heading": "Stale heading",
+      "subheading": "",
+      "buttonText": "Go",
+      "buttonLink": [
+        {
+          "@id": "/_test_data/another-page",
+          "title": "Another Page",
+          "description": "Another test page for linking",
+          "image_field": "preview_image",
+          "image_scales": {
+            "preview_image": [
+              {
+                "content-type": "image/svg+xml",
+                "download": "@@images/preview_image/preview",
+                "width": 400,
+                "height": 300
+              }
+            ]
+          }
+        }
+      ],
+      "description": [{ "type": "p", "children": [{ "text": "" }] }]
     }
   },
   "blocks_layout": {
-    "items": ["title-block", "btn-linked", "btn-custom", "btn-external", "hero-linked", "btn-pick", "hero-pick", "section-cft"]
+    "items": ["title-block", "btn-linked", "btn-custom", "btn-external", "hero-linked", "btn-pick", "hero-pick", "section-cft", "hero-onload"]
   }
 }

--- a/tests-playwright/integration/copy-from-target.spec.ts
+++ b/tests-playwright/integration/copy-from-target.spec.ts
@@ -38,13 +38,24 @@ test.describe('Copy-from-target — linked/custom toggle', () => {
     // The decided behaviour: all blocks update when the page opens for editing.
     // btn-linked stores title 'Stale label' but its href snapshot carries the
     // target's 'Target Title' — on open it must fill from the snapshot with NO
-    // click (the sidebar/widget pull only runs on select; this is the on-load pass).
+    // click (the widget pull only runs on select; this is the on-load pass).
     const iframe = helper.getIframe();
     await expect(iframe.locator('[data-block-uid="btn-linked"]')).toContainText('Target Title', {
       timeout: 8000,
     });
     // btn-custom is _customFields:['title'] → NOT pulled, keeps its own label.
     await expect(iframe.locator('[data-block-uid="btn-custom"]')).toContainText('My own label');
+
+    // hero-onload has a FULL saved snapshot (the shape a real pick stores: title,
+    // description, image_scales) with stale/empty fields. On open, EVERY mapped
+    // field fills from that snapshot — heading, subheading AND the image — with no
+    // click. This is what the single-field button above can't prove.
+    const heroOnload = iframe.locator('[data-block-uid="hero-onload"]');
+    await expect(heroOnload).toContainText('Another Page', { timeout: 8000 }); // heading (was 'Stale heading')
+    await expect(heroOnload).toContainText('Another test page for linking'); // subheading (was empty)
+    await expect(heroOnload.locator('img').first()).toHaveAttribute('src', /another-page/, {
+      timeout: 8000,
+    }); // image (from image_scales in the snapshot)
   });
 
   test('a custom field keeps its own value, toggle unchecked', async ({ page }) => {

--- a/tests-playwright/integration/copy-from-target.spec.ts
+++ b/tests-playwright/integration/copy-from-target.spec.ts
@@ -30,6 +30,23 @@ test.describe('Copy-from-target — linked/custom toggle', () => {
     await expect(page.locator(linkedToggle)).toHaveAttribute('aria-pressed', 'true');
   });
 
+  test('on load, every linked field is pulled from its snapshot WITHOUT selecting', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/copy-target-page');
+
+    // The decided behaviour: all blocks update when the page opens for editing.
+    // btn-linked stores title 'Stale label' but its href snapshot carries the
+    // target's 'Target Title' — on open it must fill from the snapshot with NO
+    // click (the sidebar/widget pull only runs on select; this is the on-load pass).
+    const iframe = helper.getIframe();
+    await expect(iframe.locator('[data-block-uid="btn-linked"]')).toContainText('Target Title', {
+      timeout: 8000,
+    });
+    // btn-custom is _customFields:['title'] → NOT pulled, keeps its own label.
+    await expect(iframe.locator('[data-block-uid="btn-custom"]')).toContainText('My own label');
+  });
+
   test('a custom field keeps its own value, toggle unchecked', async ({ page }) => {
     const helper = new AdminUIHelper(page);
     await helper.login();
@@ -217,6 +234,68 @@ test.describe('Copy-from-target — linked/custom toggle', () => {
     await expect(
       iframe.locator('[data-block-uid="hero-pick"] [data-edit-media="image"]'),
     ).toHaveAttribute('src', /another-page/, { timeout: 8000 });
+  });
+
+  test('TYPING a relative URL on a @default block fills EVERY mapped field (no async race)', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/copy-target-page');
+
+    // No pick — TYPE the URL, so NO snapshot metadata rides along. Every mapped
+    // field (heading, subheading, image) must still fill, resolved via the live
+    // @search of the typed @id. The multi-field pull must be atomic here too —
+    // per-field async pulls would race and clobber all but one field.
+    const iframe = helper.getIframe();
+    await iframe.locator('[data-block-uid="hero-pick"] [data-edit-link="buttonLink"]').click();
+    await helper.waitForSidebarOpen();
+    await page.locator('.quanta-toolbar button[title*="Edit link"]').click();
+    const form = page.locator('.field-link-editor .link-form-container');
+    await expect(form).toBeVisible({ timeout: 5000 });
+    await form.locator('input[name="link"]').fill('/_test_data/another-page');
+    await form.locator('button[aria-label="Submit"]').click();
+
+    await expect
+      .poll(async () => helper.getSidebarFieldValue('heading'), { timeout: 8000 })
+      .toBe('Another Page');
+    await expect
+      .poll(async () => helper.getSidebarFieldValue('subheading'), { timeout: 8000 })
+      .toBe('Another test page for linking');
+    await expect(
+      iframe.locator('[data-block-uid="hero-pick"] [data-edit-media="image"]'),
+    ).toHaveAttribute('src', /another-page/, { timeout: 8000 });
+  });
+
+  test('changing the URL in the SIDEBAR object browser re-pulls the linked field', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/copy-target-page');
+
+    // btn-linked → /news/big → title 'Target Title'. Change its href in the
+    // SIDEBAR object browser to a different target → the linked title must
+    // re-pull to the NEW target's title.
+    await helper.clickBlockInIframe('btn-linked');
+    await helper.waitForSidebarOpen();
+    await expect
+      .poll(async () => helper.getSidebarFieldValue('title'), { timeout: 5000 })
+      .toBe('Target Title');
+
+    const linkField = page.locator('#sidebar-properties .field-wrapper-href');
+    const browseButton = linkField.locator('button[aria-label="Open object browser"]');
+    await expect(browseButton).toBeVisible({ timeout: 5000 });
+    await browseButton.click();
+    let ob;
+    try {
+      ob = await helper.waitForObjectBrowser(3000);
+    } catch {
+      await browseButton.click();
+      ob = await helper.waitForObjectBrowser();
+    }
+    await helper.objectBrowserNavigateToFolder(ob, /Test Data/);
+    await helper.objectBrowserSelectItem(ob, /Another Page/);
+
+    await expect
+      .poll(async () => helper.getSidebarFieldValue('title'), { timeout: 8000 })
+      .toBe('Another Page');
   });
 
   test('an external link offers no toggle and cannot pull (plain editable field)', async ({ page }) => {


### PR DESCRIPTION
## What

Makes copy-from-target **snapshot-based**: all blocks fill when the page opens for editing, and the per-field live `@search` (`useLiveTarget`) is removed.

The link/url widget is the single place the target metadata is captured:
- **canvas** link editor `onSelectItem` now stores the **full** picked item (it was hardcoding `@id`/`title`/`description` and dropping `image_scales`/`Subject`/dates);
- a **typed** internal URL resolves its brain (`metadata_fields:'_all'`) the same way the sidebar's manual-link input already did;
- the link field declares `selectedItemAttrs = CANONICAL_SNAPSHOT_KEYS`, so the object_browser keeps every field we *could* pull, not just today's mapping.

So the saved block's link field always carries the data, and every mapped field (title, description, image, tags, dates) pulls straight from it — no lookup in copy-from-target:
- `pullAllLinkedFields` runs on **load** (View) → every block fills from its snapshot;
- the widget's reactive pull fills the **selected** block while editing.

Consolidation: one `finalizeLink` (was copy-pasted), redundant `onFieldLinkChange` pull removed, `isFieldLinked` gates on an INTERNAL target.

## Tests
- copy-from-target integration **15/15** (adds: fill-on-load-without-select, sidebar URL change re-pulls, typed relative URL fills, hero pick fills the image) — verified locally on admin-mock.
- copyFromTarget unit **40/40**.

## Review notes
Touches `onFieldLinkChange` (View) and the canvas link editor (`SyncedSlateToolbar`), so CI's inline-link/media + admin-nuxt jobs are the ones to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTYzaaivqmGsem6U49yatY
