### PR TITLE
fix(widgets): make the url widget array-aware

### DIFF
--- a/packages/volto-hydra/src/components/Widgets/ArrayAwareUrlWidget.jsx
+++ b/packages/volto-hydra/src/components/Widgets/ArrayAwareUrlWidget.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { UrlWidget as VoltoUrlWidget } from '@plone/volto/components/manage/Widgets/UrlWidget';
+import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
+
+/**
+ * Array-aware UrlWidget.
+ *
+ * A url field's value in hydra can be the object-browser link shape —
+ * `[{ '@id': url, ...}]`, holding either an internal content reference or an
+ * external URL — because `getFieldType` classifies `widget: 'url'` as a link and
+ * the link/media editor writes that array (View.jsx `onFieldLinkChange`). Volto's
+ * stock UrlWidget is string-only: it does `useState(flattenToAppURL(props.value))`,
+ * so an array value throws `url.replace is not a function` and takes the sidebar
+ * form down. The custom ImageWidget already normalizes this same shape
+ * (`value?.[0]?.['@id'] || value?.['@id'] || value`); this does the symmetric
+ * thing for urls so every `widget: 'url'` field survives the array.
+ *
+ * Registered as the `url` widget in the addon's applyConfig.
+ */
+export const ArrayAwareUrlWidget = (props) => {
+  const value =
+    props.value?.[0]?.['@id'] ?? props.value?.['@id'] ?? props.value;
+  return <VoltoUrlWidget {...props} value={value} />;
+};
+
+export default withObjectBrowser(ArrayAwareUrlWidget);

--- a/packages/volto-hydra/src/components/Widgets/ArrayAwareUrlWidget.test.jsx
+++ b/packages/volto-hydra/src/components/Widgets/ArrayAwareUrlWidget.test.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-intl-redux';
+import configureStore from 'redux-mock-store';
+import { UrlWidget as VoltoUrlWidget } from '@plone/volto/components/manage/Widgets/UrlWidget';
+import { ArrayAwareUrlWidget } from './ArrayAwareUrlWidget';
+
+const store = configureStore()({
+  intl: { locale: 'en', messages: {} },
+});
+
+// The shape the link/media editor writes for a `widget: 'url'` field: an
+// object-browser link array holding an external URL (or an internal ref).
+const ARRAY_VALUE = [{ '@id': 'https://www.youtube.com/embed/aqz-KE-bpKQ' }];
+
+const widgetProps = {
+  id: 'url',
+  title: 'URL',
+  onChange: vi.fn(),
+  onBlur: vi.fn(),
+  onClick: vi.fn(),
+};
+
+describe('url field with the object-browser array value', () => {
+  // Shows the problem: Volto's stock UrlWidget is string-only. It runs
+  // `flattenToAppURL(props.value)` on mount, which does `url.replace(...)` — and
+  // an array has no `.replace`, so rendering the widget throws and the sidebar
+  // form dies. This is what broke setting a video's url in the editor.
+  it("Volto's UrlWidget throws on the array value (the bug)", () => {
+    expect(() =>
+      render(
+        <Provider store={store}>
+          <VoltoUrlWidget {...widgetProps} value={ARRAY_VALUE} />
+        </Provider>,
+      ),
+    ).toThrow();
+  });
+
+  // The fix: normalize the array to its url string before delegating, so the
+  // widget renders the url instead of crashing.
+  it('ArrayAwareUrlWidget renders the url from the array value', () => {
+    render(
+      <Provider store={store}>
+        <ArrayAwareUrlWidget {...widgetProps} value={ARRAY_VALUE} />
+      </Provider>,
+    );
+    expect(screen.getByRole('textbox')).toHaveValue(
+      'https://www.youtube.com/embed/aqz-KE-bpKQ',
+    );
+  });
+
+  // A plain string value still works unchanged.
+  it('ArrayAwareUrlWidget still renders a plain string value', () => {
+    render(
+      <Provider store={store}>
+        <ArrayAwareUrlWidget
+          {...widgetProps}
+          value="https://example.com/video.mp4"
+        />
+      </Provider>,
+    );
+    expect(screen.getByRole('textbox')).toHaveValue(
+      'https://example.com/video.mp4',
+    );
+  });
+});

--- a/packages/volto-hydra/src/index.js
+++ b/packages/volto-hydra/src/index.js
@@ -45,6 +45,7 @@ import {
   getAllowedBlocksList,
   subscribeToAllowedBlocksListChanges,
 } from './utils/allowedBlockList';
+import ArrayAwareUrlWidget from './components/Widgets/ArrayAwareUrlWidget';
 import HiddenBlocksWidget from './components/Widgets/HiddenBlocksWidget';
 import HiddenObjectListWidget from './components/Widgets/HiddenObjectListWidget';
 import FieldMappingWidget from './components/Widgets/FieldMappingWidget';
@@ -159,6 +160,12 @@ const applyConfig = (config) => {
     { match: '/', component: SidebarToggleToolbarPlug },
     { match: '/', component: MobileSubmenuClose },
   ];
+
+  // Array-aware url widget. A `widget: 'url'` field's value is the object-browser
+  // link array ([{ '@id': url }], internal or external) — the shape the link/media
+  // editor writes. Volto's stock UrlWidget is string-only and throws on it; this
+  // one normalizes the array to its url string first.
+  config.widgets.widget.url = ArrayAwareUrlWidget;
 
   // Hide container block fields - ChildBlocksWidget handles their UI
   config.widgets.widget.blocks_layout = HiddenBlocksWidget;

--- a/tests-playwright/helpers/AdminUIHelper.ts
+++ b/tests-playwright/helpers/AdminUIHelper.ts
@@ -1194,6 +1194,40 @@ export class AdminUIHelper {
   }
 
   /**
+   * Set a media field's source via the inline canvas editor — the flow every
+   * media object (image, video) shares: click the block's `data-edit-media`
+   * element, open the media editor from the quanta toolbar, type a URL and
+   * submit. Consolidates what was duplicated inline across the media tests.
+   *
+   * @param blockUid The block whose media field to edit.
+   * @param field    The media field name (the `data-edit-media` value, e.g. "image" or "url").
+   * @param url      The media source URL to enter.
+   */
+  async setMediaFieldUrlInline(blockUid: string, field: string, url: string): Promise<void> {
+    const iframe = this.getIframe();
+    const media = iframe.locator(`[data-block-uid="${blockUid}"] [data-edit-media="${field}"]`);
+    await media.click();
+
+    // Focusing the media field reveals the "image" button in the quanta toolbar.
+    const imageButton = this.getQuantaToolbarFormatButton('image');
+    await expect(imageButton).toBeVisible({ timeout: 5000 });
+    await imageButton.click();
+
+    // The inline image editor overlay appears over the media element.
+    const overlay = this.page.locator('.empty-image-overlay');
+    await expect(overlay).toBeVisible({ timeout: 5000 });
+
+    // Enter the URL and submit (the arrow button); the overlay closes on success.
+    const urlInput = overlay.locator('input[name="link"]');
+    await expect(urlInput).toBeVisible({ timeout: 5000 });
+    await urlInput.fill(url);
+    const submit = overlay.locator('button[aria-label="Submit"]');
+    await expect(submit).toBeEnabled({ timeout: 5000 });
+    await submit.click();
+    await expect(overlay).not.toBeVisible({ timeout: 5000 });
+  }
+
+  /**
    * Check if a format button is visible in the Quanta toolbar.
    */
   async isFormatButtonVisible(formatName: string): Promise<boolean> {

--- a/tests-playwright/integration/inline-media-link-editing.spec.ts
+++ b/tests-playwright/integration/inline-media-link-editing.spec.ts
@@ -103,31 +103,10 @@ test.describe('Inline image editing', () => {
     const iframe = helper.getIframe();
     const heroImage = iframe.locator('[data-block-uid="block-4-hero"] [data-edit-media="image"]');
     await expect(heroImage).toBeVisible();
-    await heroImage.click();
 
-    // Wait for toolbar to appear with the image button
-    const imageButton = helper.getQuantaToolbarFormatButton('image');
-    await expect(imageButton).toBeVisible({ timeout: 5000 });
-
-    // Click the image button to open the image editor overlay (shown at image position)
-    await imageButton.click();
-
-    // Wait for the image editor overlay to appear (replaces image with ImageInput)
-    const imageEditorOverlay = page.locator('.empty-image-overlay');
-    await expect(imageEditorOverlay).toBeVisible({ timeout: 5000 });
-
-    // Wait for URL input to be visible and ready
-    const urlInput = imageEditorOverlay.locator('input[name="link"]');
-    await expect(urlInput).toBeVisible({ timeout: 5000 });
-    await urlInput.fill('https://picsum.photos/400/300');
-
-    // Click the submit button (arrow icon)
-    const submitButton = imageEditorOverlay.locator('button[aria-label="Submit"]');
-    await expect(submitButton).toBeEnabled({ timeout: 5000 });
-    await submitButton.click();
-
-    // Wait for overlay to close (indicates submission completed)
-    await expect(imageEditorOverlay).not.toBeVisible({ timeout: 5000 });
+    // Set the image via a typed URL through the shared inline media editor
+    // (click media → toolbar image button → overlay → type URL → submit).
+    await helper.setMediaFieldUrlInline('block-4-hero', 'image', 'https://picsum.photos/400/300');
 
     // Verify the image src was updated to the external URL
     // Use regex to match since Nuxt may transform the URL


### PR DESCRIPTION
## Problem

A `widget: 'url'` field's value in hydra is the **object-browser link array** — `[{ '@id': url }]`, holding either an internal content reference or an external URL. `getFieldType` classifies `widget: 'url'` as a `link`, and the link/media editor writes that array (`View.jsx` `onFieldLinkChange`).

But Volto's stock `UrlWidget` is **string-only**: on mount it runs `flattenToAppURL(props.value)`, which does `url.replace(...)`. Given the array it throws:

```
TypeError: url.replace is not a function
```

…and takes the whole sidebar form down. This breaks **any** block using `widget: 'url'` once its value is set through the editor — e.g. setting a video's URL, and the built-in teaser `href` / summary `image` fields.

The custom `ImageWidget` already normalizes this exact shape (`value?.[0]?.['@id'] || value?.['@id'] || value`); url fields had no such guard.

## Fix

Register a symmetric **array-aware url widget** (`config.widgets.widget.url`) that normalizes the object-browser array to its url string before delegating to Volto's `UrlWidget`. A plain string value passes through unchanged.

## Test

`ArrayAwareUrlWidget.test.jsx` renders **Volto's stock widget** on the array and asserts it **throws** (documents the bug), then the new widget renders the url (the fix), plus a plain-string case.

Full volto-hydra vitest suite: 140/140 green.

## Related

Also adds a `setMediaFieldUrlInline` test helper (the inline media-url flow was duplicated across several media specs) and uses it in the canonical media test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr
