### PR TITLE
test(block-sanity): exempt templateInstanceId from the undeclared-field check

### DIFF
--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -396,10 +396,13 @@ function collectSlateIssues(blockData, pagePath, blockId, out, blockType) {
  */
 // Fields present in block data that are not schema properties but are never
 // authored/editable content: structural, serialisation, and Volto slot runtime.
+// The template trio (templateId/templateInstanceId/slotId) is written by the
+// template machinery to bind a block to its template instance and slot; it is
+// not sidebar-editable, so it must not be reported as an undeclared field.
 const UNDECLARED_EXEMPT = new Set([
   'id', 'blocks', 'blocks_layout', 'image_scales', 'plaintext', 'value',
   'styles', 'override', 'block',
-  'fixed', 'slotId', 'templateId', 'readOnly',
+  'fixed', 'slotId', 'templateId', 'templateInstanceId', 'readOnly',
 ]);
 
 function collectWidgetShapeIssues(


### PR DESCRIPTION
`UNDECLARED_EXEMPT` in `discover-blocks.cjs` already exempts `templateId` and
`slotId`, but not `templateInstanceId` — the third field the template machinery
writes, binding a block to the specific template instance it came from.

So every block type on a template-built page produces:

```
Block "slate" stores field "templateInstanceId" (e.g. on /components/video) but
its schema does not declare it — the field can't be edited in the sidebar. Add
it to the block schema, or remove the stray data.
```

Both suggested remedies are wrong here: the field isn't sidebar-editable, and it
has to stay in the data for the block to resolve its template instance.

Found on a docs site whose component pages are all instances of a shared
`component-doc` template — 8 of its block-sanity failures were this one field
across different block types. The other undeclared-field failures on that site
are genuine (blocks storing `sectionType`, `spacing`, `showSeparator` and the
like without declaring them) and remain reported, which is the point: this is a
targeted exemption, not a loosening of the check.

Sits with its two siblings in the same set, and the comment now records why the
trio is exempt.

### Testing

No unit test: `UNDECLARED_EXEMPT` is module-private and the check runs inside
`collectWidgetShapeIssues`, which isn't exported, so there's no seam to test
without adding a harness. The behaviour is covered by `block-sanity.spec.ts`
against template-built content — the failures disappear for this field and
persist for the others.
