### PR TITLE
fix(fieldRules): schema-declared blocks_layout region absent from data counts 0

### DIFF
--- a/packages/volto-hydra/src/utils/schemaInheritance.js
+++ b/packages/volto-hydra/src/utils/schemaInheritance.js
@@ -1816,10 +1816,15 @@ function resolveWhenField(fieldPath, formData, args) {
   const def = schema ? getFieldDef(schema, fieldName) : undefined;
 
   // REGION → array of child block TYPES. object_list via widget, blocks_layout via
-  // the shared dict (incl. empty). A typed object_list stores its type in a
-  // `typeField`; blocks_layout children carry `@type` — getBlockType handles both.
+  // the shared dict (incl. empty) OR a schema-declared blocks_layout field (so a
+  // region with no data yet — e.g. pass-1 resolution with formData={} — counts 0
+  // rather than throwing on a numeric op, mirroring object_list). A typed
+  // object_list stores its type in a `typeField`; blocks_layout children carry
+  // `@type` — getBlockType handles both.
   const isObjectList = def?.widget === 'object_list';
-  const isBlocksLayoutRegion = Array.isArray(block?.blocks_layout?.[fieldName]);
+  const isBlocksLayoutRegion =
+    def?.widget === 'blocks_layout' ||
+    Array.isArray(block?.blocks_layout?.[fieldName]);
   if (isObjectList || isBlocksLayoutRegion) {
     const entries = getChildBlockEntries(block, { isObjectList, region: fieldName });
     const types = entries.map((e) => getBlockType(e.block, def?.typeField));

--- a/packages/volto-hydra/src/utils/schemaInheritance.test.js
+++ b/packages/volto-hydra/src/utils/schemaInheritance.test.js
@@ -816,4 +816,30 @@ describe('fieldRules — numeric operators count ONE blocks_layout region', () =
       false,
     );
   });
+
+  test('a schema-declared region, absent from data, counts 0 (does not throw)', () => {
+    // A container (e.g. the columns block) declares its region in the schema as
+    // `widget: 'blocks_layout'` and drives a count-aware switch off it. In
+    // buildBlockPathMap pass-1 the enhancer runs with formData={} — the region
+    // has no data yet. Detection must fall back to the SCHEMA widget (as
+    // object_list already does), so an absent region counts 0 rather than
+    // falling through to the scalar path and throwing "numeric or list".
+    const recipe = {
+      fieldRules: { target: { when: { items: { gte: 3 } }, else: false } },
+    };
+    const enhancer = createSchemaEnhancerFromRecipe(recipe);
+    const schema = {
+      fieldsets: [{ id: 'default', title: 'Default', fields: ['items', 'target'] }],
+      properties: {
+        items: { title: 'Items', widget: 'blocks_layout', allowedBlocks: ['card'] },
+        target: { title: 'Target' },
+      },
+      required: [],
+    };
+    // No blocks_layout in the data at all (pass-1 / a freshly-added block).
+    expect(() => enhancer({ schema, formData: {} })).not.toThrow();
+    expect(
+      enhancer({ schema, formData: {} }).properties.target !== undefined,
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

A follow-up to #279. `resolveWhenField` recognised a `blocks_layout` region **only from live data** — `Array.isArray(block?.blocks_layout?.[fieldName])`. So a region that is **declared in the schema** as `widget: 'blocks_layout'` but has **no data yet** falls through to the scalar path, and a numeric operator on it throws:

```
fieldRules: gt/gte/lt/lte require a numeric or list field (field "items")
```

This happens on the very first schema resolution: `buildBlockPathMap` runs the enhancer in a pass with `formData = {}`, so the region key isn't present yet.

`object_list` regions never had this problem — they're detected from the schema widget (`def?.widget === 'object_list'`), so they count `0` when absent. `blocks_layout` was asymmetric.

## Fix

One line — detect a `blocks_layout` region from the schema widget too, mirroring `object_list`:

```js
const isBlocksLayoutRegion =
  def?.widget === 'blocks_layout' ||
  Array.isArray(block?.blocks_layout?.[fieldName]);
```

An absent-but-schema-declared region now counts `0` and the numeric switch evaluates instead of throwing.

## Test (TDD)

Added beside the existing *present-empty* region test: a schema-declared region (`items: { widget: 'blocks_layout' }`) with `formData: {}` under `{ items: { gte: 3 } }`. It **threw** on `main` (the `numeric or list` error) and now counts `0`. Reproduced red → green; full `schemaInheritance.test.js` stays green.

## Why it surfaced now

The NSW DS **columns block** is the first consumer to *declare* a `blocks_layout` region in its schema **and** drive a count-aware fieldRules switch (`{ items: { gte: N } }`) off it — so it's the first to hit pass-1 with no region data. #279's numeric region-count operators are otherwise complete; this just closes the empty/absent edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr