### PR TITLE
Ensure paging UI computations always have a valid object

### DIFF
--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -400,6 +400,16 @@ function computePagingUI(paging) {
       paging.currentPage < paging.totalPages - 1
         ? paging.currentPage + 1
         : null;
+  } else {
+    // No results (or no page size): leave a well-formed empty paging object so
+    // consumers can rely on `pages`/`totalPages` always being present rather
+    // than `undefined` (which would throw on `paging.pages.map`).
+    paging.currentPage = 0;
+    paging.totalPages = 0;
+    paging.totalItems = total || 0;
+    paging.pages = [];
+    paging.prev = null;
+    paging.next = null;
   }
 }
 


### PR DESCRIPTION
This ensures that if 0 results are returned for a paging response, we can still use the object as if there were results rather than having to handle the undefined response differently, making it clearer as a consumer of the function what the returned value was