### PR TITLE
refactor(fieldRules): offline evaluator (schemaInheritance → blockSync) + offline discover-blocks

### DIFF
--- a/_internal-docs/carousel-test-analysis.md
+++ b/_internal-docs/carousel-test-analysis.md
@@ -94,5 +94,5 @@ The test-frontend should track carousel state and restore it after re-renders.
 
 - `packages/hydra-js/hydra.js` - `tryMakeBlockVisible`, `isElementHidden`, FORM_DATA handling
 - `packages/volto-hydra/src/components/Iframe/View.jsx` - FORM_DATA sync, `formDataContentEqual` check
-- `packages/volto-hydra/src/utils/schemaInheritance.js` - `applySchemaDefaultsToFormData`
+- `packages/volto-hydra/src/utils/blockSync.js` - `applySchemaDefaultsToFormData`
 - `tests-playwright/fixtures/test-frontend/renderer.js` - Slider rendering, slide transitions

--- a/docs/superpowers/plans/2026-07-18-dnd-paste-via-conversion.md
+++ b/docs/superpowers/plans/2026-07-18-dnd-paste-via-conversion.md
@@ -20,8 +20,8 @@
 - `tests-playwright/integration/dnd-convert.spec.ts` — integration coverage.
 
 **Modify:**
-- `packages/volto-hydra/src/utils/schemaInheritance.js` — add `getConversionMap(blocksConfig)` next to `getConvertibleTypes` (~2012).
-- `packages/volto-hydra/src/utils/schemaInheritance.test.js` (or the existing vitest file) — unit test `getConversionMap`.
+- `packages/volto-hydra/src/utils/blockSync.js` — add `getConversionMap(blocksConfig)` next to `getConvertibleTypes` (~2012).
+- `packages/volto-hydra/src/utils/blockSync.test.js` (or the existing vitest file) — unit test `getConversionMap`.
 - `packages/hydra-js/hydra.src.js` — store `this.conversionMap` from `INITIAL_DATA` (~3776); use `acceptableAt` at the drag gate (~9073).
 - `packages/volto-hydra/src/components/Iframe/View.jsx` — send `conversionMap` on the three `INITIAL_DATA` posts (~2021/3696/3784); extract `convertBlockInPlace` helper from `commitChooser` (~4236-4255); convert-on-drop in `MOVE_BLOCKS` (~2799); convert-on-paste in `handlePaste` (~951); add `pendingMove` handling to `commitChooser` (~4224).
 - `tests-playwright/fixtures/shared-block-schemas.js` — a small conversion graph + a container restricted to a convert-target.
@@ -34,13 +34,13 @@
 ## Task 1: `getConversionMap` (admin, pure)
 
 **Files:**
-- Modify: `packages/volto-hydra/src/utils/schemaInheritance.js` (add export near `getConvertibleTypes:2012`)
-- Test: `packages/volto-hydra/src/utils/schemaInheritance.test.js`
+- Modify: `packages/volto-hydra/src/utils/blockSync.js` (add export near `getConvertibleTypes:2012`)
+- Test: `packages/volto-hydra/src/utils/blockSync.test.js`
 
 - [ ] **Step 1: Write the failing test** (append to the vitest file)
 
 ```js
-import { getConversionMap } from './schemaInheritance';
+import { getConversionMap } from './blockSync';
 
 describe('getConversionMap', () => {
   const cfg = {
@@ -64,10 +64,10 @@ describe('getConversionMap', () => {
 
 - [ ] **Step 2: Run — expect FAIL** (`getConversionMap` undefined)
 
-Run: `pnpm exec vitest run packages/volto-hydra/src/utils/schemaInheritance.test.js -t getConversionMap`
+Run: `pnpm exec vitest run packages/volto-hydra/src/utils/blockSync.test.js -t getConversionMap`
 Expected: FAIL (not exported).
 
-- [ ] **Step 3: Implement** (in `schemaInheritance.js`, after `getConvertibleTypes`)
+- [ ] **Step 3: Implement** (in `blockSync.js`, after `getConvertibleTypes`)
 
 ```js
 /**
@@ -88,13 +88,13 @@ export function getConversionMap(blocksConfig) {
 
 - [ ] **Step 4: Run — expect PASS**
 
-Run: `pnpm exec vitest run packages/volto-hydra/src/utils/schemaInheritance.test.js -t getConversionMap`
+Run: `pnpm exec vitest run packages/volto-hydra/src/utils/blockSync.test.js -t getConversionMap`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add packages/volto-hydra/src/utils/schemaInheritance.js packages/volto-hydra/src/utils/schemaInheritance.test.js
+git add packages/volto-hydra/src/utils/blockSync.js packages/volto-hydra/src/utils/blockSync.test.js
 git commit -m "feat(conversion): getConversionMap — static reachable-type map from fieldMappings"
 ```
 
@@ -206,7 +206,7 @@ const conversionMap = useMemo(
 );
 ```
 
-Add `getConversionMap` to the `schemaInheritance` import. On EACH of the three `type: 'INITIAL_DATA'` postMessages (~2021, ~3696, ~3784), add `conversionMap,` to the message object.
+Add `getConversionMap` to the `blockSync` import. On EACH of the three `type: 'INITIAL_DATA'` postMessages (~2021, ~3696, ~3784), add `conversionMap,` to the message object.
 
 - [ ] **Step 2: Iframe — store it.** In `hydra.src.js` constructor (~246) add `this.conversionMap = {};`. In the `INITIAL_DATA` handler (~3776, alongside `setFormDataFromAdmin(...)`):
 
@@ -504,7 +504,7 @@ Expected: PASS (esp. `:461`, `:496`, `:26`).
 
 - [ ] **Step 2: Unit suites**
 
-Run: `cd packages/hydra-js && NODE_OPTIONS='--experimental-vm-modules' npx jest conversionMap` and `pnpm exec vitest run packages/volto-hydra/src/utils/schemaInheritance.test.js`
+Run: `cd packages/hydra-js && NODE_OPTIONS='--experimental-vm-modules' npx jest conversionMap` and `pnpm exec vitest run packages/volto-hydra/src/utils/blockSync.test.js`
 Expected: PASS.
 
 - [ ] **Step 3: Rebuild the distributable bundle** (for bridge/react/nuxt CI which loads built `hydra.js`):
@@ -539,7 +539,7 @@ git commit -m "docs(conversion): DnD/paste offer convert-reachable destinations"
 ## Verification (whole feature)
 
 1. `cd packages/hydra-js && NODE_OPTIONS='--experimental-vm-modules' npx jest conversionMap` — green.
-2. `pnpm exec vitest run packages/volto-hydra/src/utils/schemaInheritance.test.js` — green.
+2. `pnpm exec vitest run packages/volto-hydra/src/utils/blockSync.test.js` — green.
 3. `pnpm exec playwright test tests-playwright/integration/dnd-convert.spec.ts --project=admin-mock` — all green.
 4. `pnpm exec playwright test tests-playwright/integration/drag-and-drop.spec.ts --project=admin-mock` — no regression.
 5. Bundle rebuilt; push branch, open PR (separate from #256). Full suite on CI (don't run large suites locally — memory `feedback_ci_for_large_suites`).

--- a/docs/superpowers/specs/2026-07-18-dnd-paste-via-conversion-design.md
+++ b/docs/superpowers/specs/2026-07-18-dnd-paste-via-conversion-design.md
@@ -47,7 +47,7 @@ reachable via an existing `fieldMappings` conversion.
   re-checks `allowedBlocks` and breaks (hard reject) on a disallowed type.
 - **Paste re-validation (admin):** `View.jsx` `handlePaste` `:959` — same gate.
 - **Conversion graph:** `getConvertibleTypes(sourceType, blocksConfig,
-  allowedTypes)` (`schemaInheritance.js:2012`) BFS's `fieldMappings` and returns
+  allowedTypes)` (`blockSync.js:2012`) BFS's `fieldMappings` and returns
   the allowed types a source can convert into.
 - **Conversion op:** `convertContainerBlock(formData, blockPathMap, blockId,
   targetType, blocksConfig, intl)` (`blockPath.js:1178`).

--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -1540,6 +1540,35 @@ function generateUUID() {
 }
 
 /**
+ * Deterministic UUID-format id derived from a seed string: the same seed always
+ * yields the same id. Used to mint a template instance id from a stable data key
+ * (the region's first block id) so a server render and the client hydration agree
+ * on `${instanceId}::${tplChildId}` block uids — a random id would differ between
+ * the two passes and trigger a React hydration mismatch (and, because that id is
+ * the block's edit identity, confuse block selection). xfnv1a hash → mulberry32
+ * PRNG, so it's pure/deterministic (no Math.random, no crypto).
+ * @param {string} seed
+ * @returns {string} UUID v4 format string
+ */
+function deterministicUUID(seed) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 16777619);
+  }
+  const rand = () => {
+    h = (h + 0x6d2b79f5) | 0;
+    let t = Math.imul(h ^ (h >>> 15), 1 | h);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (rand() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
  * Extract content field values from a block to use as fieldPlaceholders.
  * Skips system/template fields. Only includes fields with actual content.
  * @param {Object} block - The block data
@@ -3314,7 +3343,12 @@ export function expandTemplatesSync(inputItems, options = {}) {
     if (idemKey && templateState.generatedInstanceIds?.[idemKey]) {
       instanceId = templateState.generatedInstanceIds[idemKey];
     } else {
-      instanceId = generateUUID();
+      // Derive the id deterministically from the region's first block id so the
+      // server render and the client hydration mint the SAME instance id (and so
+      // the same `${instanceId}::tplChildId` block uids) — a random id differs
+      // between the two passes and causes a hydration mismatch. Fall back to a
+      // random id only when there's no stable seed (an empty forced layout).
+      instanceId = idemKey ? deterministicUUID(idemKey) : generateUUID();
       if (idemKey) {
         if (!templateState.generatedInstanceIds)
           templateState.generatedInstanceIds = {};
@@ -3545,7 +3579,7 @@ export function expandTemplatesSync(inputItems, options = {}) {
       // covers blocks_layout regions AND object_list array fields, so an object_list slot
       // container (a slider's `slides`) gets an anchor too — not just blocks_layout containers.
       // Keyed by the consumer's `field`: the shared 'blocks' dict for blocks_layout, or the
-      // object_list field name (e.g. 'slides') — schemaInheritance reads childSlotIds[field].
+      // object_list field name (e.g. 'slides') — blockSync reads childSlotIds[field].
       let childSlotIds = undefined;
       for (const field of getChildFields(tplBlock)) {
         const key = field.isObjectList

--- a/packages/hydra-js/applyLayoutTemplate.test.js
+++ b/packages/hydra-js/applyLayoutTemplate.test.js
@@ -1228,7 +1228,7 @@ describe('nextSlotId and childSlotIds on fixed blocks', () => {
   // Same as above, but the container's slot lives in an OBJECT_LIST region (a slider's `slides`),
   // not blocks_layout. The childSlotIds add-path anchor was computed via blocksLayoutRegions only,
   // so an object_list slot container got no anchor. It must be keyed by the field name (`slides`),
-  // matching schemaInheritance's parentBlock.childSlotIds[field] lookup.
+  // matching blockSync's parentBlock.childSlotIds[field] lookup.
   test('childSlotIds set on a fixed container whose slot lives in an object_list region (slider slides)', async () => {
     const pageData = { blocks: {}, blocks_layout: { items: [] } };
 

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -274,7 +274,7 @@ import {
   getConversionMap,
   convertBlockType,
   validateFieldMappings,
-} from '../../utils/schemaInheritance';
+} from '../../utils/blockSync';
 import {
   installCopyFromTargetEnhancers,
   markEditedLinkedFieldsCustom,
@@ -3413,7 +3413,7 @@ const Iframe = (props) => {
           installVariationFieldEnhancers(config.blocks.blocksConfig);
 
           // 1d.1. Auto-apply hideParentOwnedFields to every block. Any block can
-          // be a child of a parent that uses schema inheritance (typeField +
+          // be a child of a parent that uses block sync (typeField +
           // mappingField); installing this enhancer for all blocks makes
           // parent-owned fields automatically hide on the child sidebar form
           // when the parent has a type selected. Blocks don't need to opt in

--- a/packages/volto-hydra/src/components/Sidebar/ParentBlocksWidget.jsx
+++ b/packages/volto-hydra/src/components/Sidebar/ParentBlocksWidget.jsx
@@ -38,7 +38,7 @@ import DropdownMenu from '../Toolbar/DropdownMenu';
 import ReadOnlyForm from './ReadOnlyForm';
 import { getBlockById, updateBlockById, getResolvedSchema, getCommonAncestor } from '../../utils/blockPath';
 import { HydraSchemaProvider } from '../../context';
-import { getConvertibleTypes, convertBlockType, findTypeField } from '../../utils/schemaInheritance';
+import { getConvertibleTypes, convertBlockType, findTypeField } from '../../utils/blockSync';
 import { PAGE_BLOCK_UID } from '@volto-hydra/hydra-js';
 import { isBlockReadonly } from '@volto-hydra/helpers';
 import { flattenToAppURL } from '@plone/volto/helpers';
@@ -245,7 +245,7 @@ const ParentBlockSection = ({
   // Get schema for fallback rendering (when no Edit component or disableCustomSidebarEditForm)
   const schema = !BlockEdit ? getFilteredBlockSchema(blockType, intl, blockPathMap, blockId, blockData) : null;
 
-  // Compute a key suffix that changes when parent's schema inheritance state changes.
+  // Compute a key suffix that changes when parent's block sync state changes.
   // This forces BlockEdit to remount when parent's typeField changes, ensuring child gets fresh schema.
   // Without this, Volto's BlockEdit caches its internal form and doesn't re-render with new schema.
   const parentSchemaKey = React.useMemo(() => {
@@ -434,7 +434,7 @@ const ParentBlockSection = ({
         <HydraSchemaProvider value={{ blockPathMap, currentBlockId: blockId, formData, blocksConfig: config.blocks?.blocksConfig, liveBlockDataRef, onChangeBlock }}>
           <SidebarPortalTargetContext.Provider value={targetId}>
             {/* Hidden container - Edit component's center content is hidden, only sidebar renders */}
-            {/* Key includes parentSchemaKey to force remount when parent's schema inheritance changes */}
+            {/* Key includes parentSchemaKey to force remount when parent's block sync changes */}
             <div key={`${blockId}${parentSchemaKey}`} style={{ display: 'none' }}>
               <BlockEdit
                 type={blockType}

--- a/packages/volto-hydra/src/components/Widgets/BlockTypeSelectWidget.jsx
+++ b/packages/volto-hydra/src/components/Widgets/BlockTypeSelectWidget.jsx
@@ -27,7 +27,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import config from '@plone/volto/registry';
-import { getBlockTypeChoices } from '../../utils/schemaInheritance';
+import { getBlockTypeChoices } from '../../utils/blockSync';
 import { useHydraSchemaContext } from '../../context/HydraSchemaContext';
 import { getBlockById } from '../../utils/blockPath';
 

--- a/packages/volto-hydra/src/components/Widgets/FieldMappingWidget.jsx
+++ b/packages/volto-hydra/src/components/Widgets/FieldMappingWidget.jsx
@@ -20,7 +20,7 @@ import {
   computeSmartDefaults,
   getFieldType,
   findTypeField,
-} from '../../utils/schemaInheritance';
+} from '../../utils/blockSync';
 import { useHydraSchemaContext } from '../../context/HydraSchemaContext';
 import { getBlockById } from '../../utils/blockPath';
 

--- a/packages/volto-hydra/src/context/HydraSchemaContext.js
+++ b/packages/volto-hydra/src/context/HydraSchemaContext.js
@@ -9,6 +9,11 @@
  * updated synchronously when forms change (before React state propagates).
  */
 import React from 'react';
+// Static import (not a lazy `require`) so this module loads under bare-Node ESM —
+// block-sanity's offline discovery reuses getLiveBlockData for `../` parent
+// lookups in the fieldRules evaluator. No cycle: blockPath.js does not import
+// this context module.
+import { getBlockById } from '../utils/blockPath.js';
 
 const HydraSchemaContext = React.createContext(null);
 
@@ -85,14 +90,12 @@ export const getLiveBlockData = (blockId, fallback) => {
 
     // Fall back to formData (page-level state)
     if (formData && blockPathMap) {
-      const { getBlockById } = require('../utils/blockPath');
       return getBlockById(formData, blockPathMap, blockId);
     }
   }
 
   // Last resort: caller-provided formData + blockPathMap (no React context)
   if (fallback?.formData && fallback?.blockPathMap) {
-    const { getBlockById } = require('../utils/blockPath');
     return getBlockById(fallback.formData, fallback.blockPathMap, blockId);
   }
 

--- a/packages/volto-hydra/src/context/index.js
+++ b/packages/volto-hydra/src/context/index.js
@@ -4,4 +4,4 @@ export {
   getHydraSchemaContext,
   setHydraSchemaContext,
   getLiveBlockData,
-} from './HydraSchemaContext';
+} from './HydraSchemaContext.js';

--- a/packages/volto-hydra/src/index.js
+++ b/packages/volto-hydra/src/index.js
@@ -64,7 +64,7 @@ import { ImageSchema } from '@plone/volto/components/manage/Blocks/Image/schema'
 import {
   QUERY_RESULT_FIELDS,
   createSchemaEnhancerFromRecipe,
-} from './utils/schemaInheritance';
+} from './utils/blockSync';
 import rowBeforeSVG from '@plone/volto/icons/row-before.svg';
 import rowAfterSVG from '@plone/volto/icons/row-after.svg';
 import rowDeleteSVG from '@plone/volto/icons/row-delete.svg';
@@ -72,8 +72,20 @@ import columnBeforeSVG from '@plone/volto/icons/column-before.svg';
 import './components/mobile-tablet.css';
 import columnAfterSVG from '@plone/volto/icons/column-after.svg';
 import columnDeleteSVG from '@plone/volto/icons/column-delete.svg';
+import { applyBlockDefaults } from '@plone/volto/helpers';
+import { setInjectedVoltoConfig } from './utils/injectedVoltoConfig';
 
 const applyConfig = (config) => {
+  // Inject the Volto-config-derived values the pure block-path / schema utils
+  // need, so those modules carry NO static `@plone/volto/registry` import and can
+  // be loaded (bare Node) by block-sanity's offline discovery. Lazy getters so a
+  // later addon that changes a setting is still honoured. See injectedVoltoConfig.
+  setInjectedVoltoConfig({
+    applyBlockDefaults,
+    getDefaultBlockType: () => config.settings.defaultBlockType,
+    getBlocksConfig: () => config.blocks.blocksConfig,
+  });
+
   // Patch setTimeout to catch focus errors from AddLinkForm
   // AddLinkForm does: setTimeout(() => this.input.focus(), 50)
   // But if component unmounts before 50ms, this.input is null and focus() throws
@@ -405,7 +417,7 @@ const applyConfig = (config) => {
   //
   // Fully declarative schemaEnhancer composed from recipe parts:
   // - existingListingSchemaEnhancer: Volto's core listing enhancer (handles variations)
-  // - inheritSchemaFrom: type selector + schema inheritance
+  // - inheritSchemaFrom: type selector + block sync
   // - fieldRules: admin-only field modifications (hide b_size, add fieldMapping)
   const existingListingSchemaEnhancer =
     config.blocks.blocksConfig.listing?.schemaEnhancer;
@@ -457,7 +469,7 @@ const applyConfig = (config) => {
     ],
   };
 
-  // Configure image block with blockSchema for schema inheritance
+  // Configure image block with blockSchema for block sync
   // The default image block only has 'schema' (settings), not 'blockSchema' (data schema)
   // We add 'url' field here (not in schemaEnhancer) so a frontend-supplied
   // schemaEnhancer recipe doesn't lose it when it replaces the schemaEnhancer.

--- a/packages/volto-hydra/src/utils/blockPath.js
+++ b/packages/volto-hydra/src/utils/blockPath.js
@@ -5,8 +5,10 @@
 
 import { produce } from 'immer';
 import { get } from 'lodash';
-import { applyBlockDefaults } from '@plone/volto/helpers';
-import config from '@plone/volto/registry';
+import {
+  getApplyBlockDefaults,
+  getDefaultBlockType,
+} from './injectedVoltoConfig.js';
 import { PAGE_BLOCK_UID } from '@volto-hydra/hydra-js';
 import {
   isBlockReadonly,
@@ -655,7 +657,7 @@ export function getAllContainerFields(
   // restrict types). Without this a generic section would auto-fill its
   // empty state with the 'empty' picker placeholder, even though the
   // container is happy to accept the page's typing-friendly default.
-  const pageDefaultBlockType = config.settings.defaultBlockType || null;
+  const pageDefaultBlockType = getDefaultBlockType();
 
   // Helper to get current count for a container field
   const getFieldCount = (region, isObjectList = false, regionPath = []) => {
@@ -1837,7 +1839,7 @@ function getPageDefaults(blocksConfig, formData) {
     allowedBlocks: getPageAllowedBlocksFromRestricted(blocksConfig, {
       properties: formData,
     }),
-    defaultBlockType: config.settings.defaultBlockType || null,
+    defaultBlockType: getDefaultBlockType(),
   };
 }
 
@@ -2003,7 +2005,7 @@ export function ensureEmptyBlockIfEmpty(
       const emptyId = uuidGenerator();
       let emptyBlock = { '@type': 'empty' };
       if (intl && blocksConfig) {
-        emptyBlock = applyBlockDefaults(
+        emptyBlock = getApplyBlockDefaults()(
           { data: emptyBlock, intl, metadata, properties },
           blocksConfig,
         );
@@ -2309,7 +2311,7 @@ function seedTemplateChild(
   // in a template being edited directly, where inheriting readOnly would freeze inline editing.
   const { intl, metadata, properties, inheritFixed } = options;
   if (intl) {
-    childData = applyBlockDefaults(
+    childData = getApplyBlockDefaults()(
       { data: childData, intl, metadata, properties },
       blocksConfig,
     );

--- a/packages/volto-hydra/src/utils/blockSync.js
+++ b/packages/volto-hydra/src/utils/blockSync.js
@@ -1,7 +1,12 @@
 /**
- * Schema Inheritance Utilities
+ * Block Sync Utilities
  *
- * Helpers for blocks that reference other block types and inherit their schemas.
+ * How a container block SYNCS schema + data with its child blocks: a grid/listing
+ * fixing its children's item type, inheriting shared defaults, hiding the fields
+ * the parent owns, and gating a child's fields on the parent's settings
+ * (`fieldRules`). Formerly "schemaInheritance" — the through-line is keeping
+ * parent and child blocks in sync, not inheritance per se.
+ *
  * Used by listing blocks, grid blocks, and other containers that need to show
  * editable fields from a referenced block type.
  *
@@ -32,8 +37,8 @@
  * inject `blockId` into the args at every Volto call site, the `hydraContext`
  * branch can be removed — until then, both branches are load-bearing.
  */
-import config from '@plone/volto/registry';
-import { getBlockTypeSchema, getBlockById, updateBlockById, getChildBlockIds, getChildField, getChildBlockIdsInField } from './blockPath';
+import { getInjectedBlocksConfig } from './injectedVoltoConfig.js';
+import { getBlockTypeSchema, getBlockById, updateBlockById, getChildBlockIds, getChildField, getChildBlockIdsInField } from './blockPath.js';
 import { addableSiblingTypes } from '../../../hydra-js/buildBlockPathMap.js';
 import { PAGE_BLOCK_UID } from '@volto-hydra/hydra-js';
 import {
@@ -47,7 +52,7 @@ import {
   isSlateFieldType,
   slateNodesText,
 } from '@volto-hydra/helpers';
-import { getHydraSchemaContext, setHydraSchemaContext, getLiveBlockData } from '../context';
+import { getHydraSchemaContext, setHydraSchemaContext, getLiveBlockData } from '../context/index.js';
 // Pure validation/default-application logic lives in schemaValidation.js
 // (no dependencies — safe to import from CI scripts and test runners).
 // Re-exported here for backward compat; schemaValidation.js is the SSOT.
@@ -597,7 +602,8 @@ export function inheritSchemaFrom(typeField, mappingField, defaultsField, typeFi
   return (args) => {
     let { formData, schema, intl } = args;
 
-    const blocksConfig = config.blocks.blocksConfig;
+    const blocksConfig =
+      getHydraSchemaContext?.()?.blocksConfig || getInjectedBlocksConfig();
 
     // Read typeField from block-level config if not provided directly.
     // Uses the standard lookup (recipe → schema walk).
@@ -964,7 +970,7 @@ export function hideParentOwnedFields() {
     const hydraContext = getHydraSchemaContext();
     const blockPathMap = passedBlockPathMap || hydraContext?.blockPathMap;
     const blockId = passedBlockId ?? hydraContext?.currentBlockId;
-    const blocksConfig = hydraContext?.blocksConfig || config.blocks.blocksConfig;
+    const blocksConfig = hydraContext?.blocksConfig || getInjectedBlocksConfig();
     // For getLiveBlockData below: pageFormData + pathMap let getBlockById
     // resolve siblings/parents during buildBlockPathMap pass 2 (no React).
     const liveFallback = { formData: args.pageFormData, blockPathMap };
@@ -1289,6 +1295,86 @@ export function computeSmartDefaults(sourceFields, targetSchema, declaredMapping
  * @param {Object} intl - React Intl object for translations
  * @returns {Object} - FormData with defaults applied to blocks (or original if no changes)
  */
+/**
+ * Resolve a block's EFFECTIVE schema — the base schema with its schemaEnhancer
+ * applied (fieldRules visibility, hideParentOwnedFields, inheritSchemaFrom). This
+ * is the schema the editor actually renders and validates against, so its
+ * `required` is the DYNAMIC required set: a field hidden by a `when` rule (a
+ * card's `image`, shown only when the grid enables it) is dropped from `required`.
+ *
+ * Recipe-object enhancers ARE converted here (via createSchemaEnhancerFromRecipe),
+ * unlike buildBlockPathMap's pass which skips them — so callers get the fully
+ * resolved schema for recipe-based blocks too. Enhancers that compose
+ * `hideParentOwnedFields` must already be installed (installChildBlockEnhancers).
+ *
+ * Extracted from applySchemaDefaultsToFormData (its per-block resolution) so
+ * block-sanity's offline required check can reuse the exact same resolution.
+ *
+ * @returns {Object|null} the enhanced schema, or null if the block has no schema.
+ */
+export function resolveEffectiveBlockSchema(blockId, formData, blockPathMap, blocksConfig, intl) {
+  const blockData = getBlockById(formData, blockPathMap, blockId);
+  if (!blockData) return null;
+
+  // Use blockPathMap for type lookup (single source of truth).
+  // Don't use blockData['@type'] as object_list items don't store @type.
+  const blockType = blockPathMap?.[blockId]?.blockType;
+  if (!blockType) return null;
+
+  const blockConfig = blocksConfig?.[blockType];
+  if (!blockConfig) return null;
+
+  // Get base schema
+  let schema = null;
+  if (typeof blockConfig.blockSchema === 'function') {
+    schema = blockConfig.blockSchema({ formData: blockData, intl });
+  } else if (blockConfig.blockSchema) {
+    schema = blockConfig.blockSchema;
+  } else if (typeof blockConfig.schema === 'function') {
+    schema = blockConfig.schema({ formData: blockData, intl });
+  } else if (blockConfig.schema) {
+    schema = blockConfig.schema;
+  }
+
+  if (!schema) return null;
+
+  // Apply schemaEnhancer if present (fieldRules/hideParentOwnedFields/inheritSchemaFrom).
+  if (blockConfig.schemaEnhancer) {
+    // schemaEnhancer can be a function or a recipe object
+    let enhancer = blockConfig.schemaEnhancer;
+    if (typeof enhancer !== 'function') {
+      // It's a recipe object - create enhancer from it
+      enhancer = createSchemaEnhancerFromRecipe(enhancer);
+    }
+    if (enhancer) {
+      // Set context so schemaEnhancer can access currentBlockId and blockPathMap
+      // (Volto HOC call sites that pass only {schema,formData,intl}); also pass
+      // them in args (the buildBlockPathMap contract) so `../` lookups resolve
+      // even without an active context.
+      const restoreContext = setHydraSchemaContext({
+        blockPathMap,
+        currentBlockId: blockId,
+        blocksConfig,
+        formData,
+      });
+      try {
+        schema = enhancer({
+          formData: blockData,
+          schema: { ...schema, properties: { ...schema.properties } },
+          intl,
+          pageFormData: formData,
+          blockId,
+          blockPathMap,
+        });
+      } finally {
+        restoreContext();
+      }
+    }
+  }
+
+  return schema;
+}
+
 export function applySchemaDefaultsToFormData(formData, blockPathMap, blocksConfig, intl) {
   if (!blockPathMap) return formData;
 
@@ -1299,55 +1385,14 @@ export function applySchemaDefaultsToFormData(formData, blockPathMap, blocksConf
     const blockData = getBlockById(result, blockPathMap, blockId);
     if (!blockData) continue;
 
-    // Use blockPathMap for type lookup (single source of truth)
-    // Don't use blockData['@type'] as object_list items don't store @type
-    const blockType = blockPathMap[blockId]?.blockType;
-    if (!blockType) continue;
-
-    const blockConfig = blocksConfig?.[blockType];
-    if (!blockConfig) continue;
-
-    // Get base schema
-    let schema = null;
-    if (typeof blockConfig.blockSchema === 'function') {
-      schema = blockConfig.blockSchema({ formData: blockData, intl });
-    } else if (blockConfig.blockSchema) {
-      schema = blockConfig.blockSchema;
-    } else if (typeof blockConfig.schema === 'function') {
-      schema = blockConfig.schema({ formData: blockData, intl });
-    } else if (blockConfig.schema) {
-      schema = blockConfig.schema;
-    }
-
+    const schema = resolveEffectiveBlockSchema(
+      blockId,
+      result,
+      blockPathMap,
+      blocksConfig,
+      intl,
+    );
     if (!schema) continue;
-
-    // Apply schemaEnhancer if present (this sets the `default` values)
-    if (blockConfig.schemaEnhancer) {
-      // schemaEnhancer can be a function or a recipe object
-      let enhancer = blockConfig.schemaEnhancer;
-      if (typeof enhancer !== 'function') {
-        // It's a recipe object - create enhancer from it
-        enhancer = createSchemaEnhancerFromRecipe(enhancer);
-      }
-      if (enhancer) {
-        // Set context so schemaEnhancer can access currentBlockId and blockPathMap
-        const restoreContext = setHydraSchemaContext({
-          blockPathMap,
-          currentBlockId: blockId,
-          blocksConfig,
-          formData: result,
-        });
-        try {
-          schema = enhancer({
-            formData: blockData,
-            schema: { ...schema, properties: { ...schema.properties } },
-            intl,
-          });
-        } finally {
-          restoreContext();
-        }
-      }
-    }
 
     // Apply defaults from enhanced schema
     const updatedBlock = applySchemaDefaultsToBlock(blockData, schema);

--- a/packages/volto-hydra/src/utils/blockSync.test.js
+++ b/packages/volto-hydra/src/utils/blockSync.test.js
@@ -15,7 +15,7 @@ import {
   getConversionMap,
   validateFieldMappings,
   getBlockTypeChoices,
-} from './schemaInheritance';
+} from './blockSync';
 import config from '@plone/volto/registry';
 
 describe('validateFieldMappings — @default accepts any search-metadata field', () => {

--- a/packages/volto-hydra/src/utils/copyFromTarget.js
+++ b/packages/volto-hydra/src/utils/copyFromTarget.js
@@ -27,7 +27,7 @@
  * The enhancer that installs it on every block and the `copyFromTargetField`
  * wrapper widget build on these.
  */
-import { getMappingTarget, getFieldType, widgetToTargetType } from './schemaInheritance';
+import { getMappingTarget, getFieldType, widgetToTargetType } from './blockSync';
 import { convertFieldValue, normalizeCatalogImage } from '@volto-hydra/helpers';
 import { isInternalURL } from '@plone/volto/helpers/Url/Url';
 

--- a/packages/volto-hydra/src/utils/copyFromTarget.test.js
+++ b/packages/volto-hydra/src/utils/copyFromTarget.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 
 // HydraSchemaContext.js is JSX inside a .js file (the admin build uses babel;
-// vitest/vite can't transform JSX in .js). copyFromTarget → schemaInheritance
-// imports '../context', so stub it — same convention as schemaInheritance.test.js.
+// vitest/vite can't transform JSX in .js). copyFromTarget → blockSync
+// imports '../context', so stub it — same convention as blockSync.test.js.
 vi.mock('../context', () => ({
   getHydraSchemaContext: () => ({}),
   setHydraSchemaContext: () => {},
@@ -25,7 +25,7 @@ import {
   pullLinkedFields,
   COPY_FROM_TARGET_WIDGET,
 } from './copyFromTarget';
-import { createSchemaEnhancerFromRecipe } from './schemaInheritance';
+import { createSchemaEnhancerFromRecipe } from './blockSync';
 
 // A teaser-like block: `href` is the link/url field carrying the target
 // snapshot (selectedItemAttrs), and fieldMappings['@target'] maps target

--- a/packages/volto-hydra/src/utils/injectedVoltoConfig.js
+++ b/packages/volto-hydra/src/utils/injectedVoltoConfig.js
@@ -1,0 +1,53 @@
+/**
+ * Injected Volto config accessors — pure, dependency-free.
+ *
+ * `blockPath.js` and `blockSync.js` hold the block-path traversal and the
+ * fieldRules evaluator that block-sanity's discovery reuses OFFLINE (bare Node,
+ * no Volto). Two values those modules need come from Volto's global registry —
+ * `config.settings.defaultBlockType` and the `applyBlockDefaults` helper — plus
+ * `config.blocks.blocksConfig` as a last-resort fallback. A static
+ * `import config from '@plone/volto/registry'` at the top of either module makes
+ * the WHOLE file un-loadable in bare Node (the specifier doesn't resolve), which
+ * is why the pure `schemaValidation.mjs` had to be split out.
+ *
+ * Instead of splitting, inject those accessors ONCE. The hydra addon calls
+ * `setInjectedVoltoConfig(...)` at init (where `config` is in scope); the pure
+ * modules read them lazily via the getters below. No `@plone/volto` import in
+ * either module → the offline discovery can load them and call the real evaluator.
+ *
+ * The values are process-stable (the same lifetime as the `config` singleton they
+ * replace), so a module-level holder is no weaker than reaching for `config`.
+ * Getters are lazy (`() => config.settings.defaultBlockType`) so a later addon
+ * that changes a setting is still honoured. NO imports here — keep it that way.
+ */
+
+let injected = {};
+
+/**
+ * Inject the Volto-config-derived accessors the pure block-path utils need.
+ * Called once by the hydra addon (src/index.js). Merges, so partial injections
+ * (e.g. the offline discovery supplying only `getBlocksConfig`) are fine.
+ *
+ * @param {Object} accessors
+ * @param {Function} [accessors.applyBlockDefaults] - @plone/volto/helpers applyBlockDefaults
+ * @param {Function} [accessors.getDefaultBlockType] - () => config.settings.defaultBlockType
+ * @param {Function} [accessors.getBlocksConfig] - () => config.blocks.blocksConfig
+ */
+export function setInjectedVoltoConfig(accessors) {
+  injected = { ...injected, ...accessors };
+}
+
+/** The injected applyBlockDefaults, or undefined if not injected (offline). */
+export function getApplyBlockDefaults() {
+  return injected.applyBlockDefaults;
+}
+
+/** config.settings.defaultBlockType (via the injected getter), or null. */
+export function getDefaultBlockType() {
+  return injected.getDefaultBlockType?.() ?? null;
+}
+
+/** config.blocks.blocksConfig (via the injected getter), or undefined. */
+export function getInjectedBlocksConfig() {
+  return injected.getBlocksConfig?.();
+}

--- a/packages/volto-hydra/src/utils/offlineBlockSyncApi.js
+++ b/packages/volto-hydra/src/utils/offlineBlockSyncApi.js
@@ -1,0 +1,25 @@
+/**
+ * Offline Block-Sync API — the surface block-sanity's bare-Node discovery needs.
+ *
+ * NOT used by the editor. block-sanity's `discover-blocks.cjs` esbuild-bundles
+ * THIS entry (which pulls in blockSync.js + blockPath.js + the injected-config
+ * seam) into one self-contained module, so the discovery can run Hydra's REAL
+ * schema resolver offline to compute a block's DYNAMIC `required` set — instead
+ * of a hand-rolled approximation. Bundling one entry keeps a single module
+ * instance, so `setInjectedVoltoConfig` here and the seam blockPath.js reads are
+ * the same holder.
+ *
+ * Why a bundle at all: blockSync.js / blockPath.js are idiomatic Volto source
+ * (JSX in the context module, `import {get} from 'lodash'`, extensionless
+ * imports) that bare Node can't load — esbuild transpiles them. The registry
+ * coupling was already removed (injectedVoltoConfig), which is what makes a
+ * clean bundle possible.
+ */
+
+export { setInjectedVoltoConfig } from './injectedVoltoConfig.js';
+export {
+  installChildBlockEnhancers,
+  installVariationFieldEnhancers,
+  populateTypeSchemaCache,
+  resolveEffectiveBlockSchema,
+} from './blockSync.js';

--- a/packages/volto-hydra/src/utils/schemaValidation.mjs
+++ b/packages/volto-hydra/src/utils/schemaValidation.mjs
@@ -2,12 +2,12 @@
  * Schema Validation Utilities — pure, dependency-free.
  *
  * These mirror the per-block validation Hydra runs in
- * `applySchemaDefaultsToFormData` (schemaInheritance.js). Extracted here as
+ * `applySchemaDefaultsToFormData` (blockSync.js). Extracted here as
  * pure functions so they can be reused from test runners, CI gates, and any
  * other tool that needs to know "would Hydra strip this value on load?"
  * without pulling in Volto's registry / React contexts / blockPath helpers.
  *
- * Originally lived inline in `./schemaInheritance.js`; that module now
+ * Originally lived inline in `./blockSync.js`; that module now
  * re-exports from here. Single source of truth.
  *
  * NO imports. Keep it that way — that's the whole point.
@@ -34,6 +34,13 @@ export function isValidValue(value, fieldDef) {
       }),
     );
     return validValues.has(value);
+  }
+
+  // Button-bar widgets (ButtonsWidget: size/align/layout) declare their options
+  // in `actions` (the array of button values). Same contract as `choices` — the
+  // editor only offers these, so a stored value outside them can't be authored.
+  if (Array.isArray(fieldDef.actions)) {
+    return fieldDef.actions.includes(value);
   }
 
   // For enum fields (JSON Schema style)

--- a/proposals/unified-block-path.md
+++ b/proposals/unified-block-path.md
@@ -56,7 +56,7 @@ traversed by *id* (it has named fields). A value is terminal.
 `..` **always means "up to the parent BLOCK"** — never up an object or region
 level. Rationale:
 
-- It matches what `..` means **today** (`schemaInheritance` fieldRules,
+- It matches what `..` means **today** (`blockSync` fieldRules,
   `resolveFieldPath`), so **no migration** of existing `../field` references.
 - It keeps the axes asymmetric but simple: `/` descends *down* through objects
   and regions; `..` only ever crosses *block* boundaries going up. Within-block

--- a/tests-playwright/fixtures/shared-block-schemas.js
+++ b/tests-playwright/fixtures/shared-block-schemas.js
@@ -584,12 +584,12 @@ export const sharedBlocksConfig = {
             required: [],
         },
     },
-    // Grid block: schema inheritance recipe
+    // Grid block: block sync recipe
     // variation field is created by inheritSchemaFrom with computed choices
     // allowedBlocks on config controls what children can be added
     // blocksField: 'blocks_layout' tells inheritSchemaFrom to derive choices from it
     // When variation is set, BlockChooser only shows that type
-    // Listing block: schema inheritance for item types (summary, default, teaser)
+    // Listing block: block sync for item types (summary, default, teaser)
     // filterConvertibleFrom: '@default' means only show types whose fieldMappings
     // include @default as a source (i.e., can convert from catalog brain fields)
     listing: {

--- a/tests-playwright/helpers/BlockVerificationHelper.ts
+++ b/tests-playwright/helpers/BlockVerificationHelper.ts
@@ -596,25 +596,20 @@ export async function verifyBlockRendering(
   }
   await expect(block.first()).toBeVisible({ timeout: 15000 });
 
-  // A data-block-uid may match several elements. That is legitimate for a
-  // listing/container block whose expanded items carry the parent uid
-  // (expandListingBlocks — see listing-links.tsx), but ONLY when the matches are
-  // contiguous: the container element contains all the rest. The same block
-  // rendered twice in separate DOM subtrees is a real bug. Discovery flags the
-  // literal `listing` type (handled above); this covers the container blocks
-  // that hold one (footer/tags/linkList, search results).
+  // A data-block-uid may legitimately match several elements, in two shapes that
+  // hydra both supports:
+  //  - NESTED: a listing/container block whose expanded items carry the parent
+  //    uid (expandListingBlocks — see listing-links.tsx), the items inside it; and
+  //  - SIBLING: a multi-element block whose uid rides more than one peer element
+  //    (e.g. accordion/tabs: the panel uid is on both the header and its content
+  //    panel), which hydra's selection unions into one outline — see
+  //    tests-playwright/integration/multi-element-blocks.spec.ts.
+  // We don't assert DOM shape (nested vs sibling): both are intended, and the DOM
+  // alone can't tell an intentional multi-element block from an accidental
+  // duplicate anyway. Verify the block renders + carries its edit annotations via
+  // the first match, then return — the assertions below use the multi-match
+  // `block` locator and would trip Playwright strict mode on >1 element.
   if ((await block.count()) > 1) {
-    const contiguous = await block.first().evaluate(
-      (first, uid) =>
-        Array.from(document.querySelectorAll(`[data-block-uid="${uid}"]`)).every(
-          (el) => el === first || first.contains(el),
-        ),
-      blockId,
-    );
-    expect(
-      contiguous,
-      `data-block-uid="${blockId}" appears on unrelated elements (a block rendered twice); a shared uid is only valid for a listing/container whose items nest inside it`,
-    ).toBe(true);
     await checkEditAnnotations(block.first(), blockData);
     return;
   }
@@ -670,6 +665,25 @@ export async function verifyBlockRendering(
     for (const { id, data } of subBlocks) {
       const loc = iframe.locator(`[data-block-uid="${id}"]`).first();
       await expect(loc).toBeAttached({ timeout: 5000 });
+      // Content gated behind a reveal control — an accordion header, a tab, a
+      // carousel nav — is display:none until revealed. That's by design: the
+      // editor reveals it when the admin selects the nested block, and hydra.js
+      // does so by clicking the element whose [data-block-selector] references
+      // that block's uid. Mirror that here so a legitimately-collapsed block is
+      // verified in its revealed state instead of being falsely failed for being
+      // hidden by design. (data-block-selector holds a space-separated uid list,
+      // hence the ~= match.)
+      if (!(await loc.isVisible())) {
+        const revealer = iframe
+          .locator(`[data-block-selector~="${id}"]`)
+          .first();
+        if ((await revealer.count()) > 0) {
+          await revealer.click();
+          await loc
+            .waitFor({ state: 'visible', timeout: 2000 })
+            .catch(() => {});
+        }
+      }
       if (await loc.isVisible()) {
         anyVisible = true;
         await checkEditAnnotations(loc, data);

--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -403,6 +403,10 @@ const UNDECLARED_EXEMPT = new Set([
   'id', 'blocks', 'blocks_layout', 'image_scales', 'plaintext', 'value',
   'styles', 'override', 'block',
   'fixed', 'slotId', 'templateId', 'templateInstanceId', 'readOnly',
+  // Deep-link anchors hydra harvests + persists on the owning block (#273/#281).
+  // Not sidebar-authored — a consumer (in-page nav) reads them; exempt like the
+  // other serialisation/runtime fields above.
+  '_linkableAnchors',
 ]);
 
 function collectWidgetShapeIssues(

--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -409,8 +409,89 @@ const UNDECLARED_EXEMPT = new Set([
   '_linkableAnchors',
 ]);
 
+// Block-level slate STYLES a person can actually choose from the editor's style
+// menu (Volto's slate styleName plugin). There is no slate style menu yet, so
+// this is EMPTY: any `styleName` on a slate node is content a person cannot
+// author — it was hand-injected — and block-sanity must flag it. When a style
+// menu is added, list its style values here (or derive from the slate config).
+const AUTHORABLE_SLATE_STYLES = new Set([]);
+
+// Hydra's own value validator (packages/volto-hydra/.../schemaValidation.mjs) —
+// the SAME `isValidValue` Hydra runs to strip un-authorable values on load, so
+// block-sanity and the editor agree on "is this a valid value?". Loaded lazily
+// via dynamic import (it's ESM but dependency-free by design) in discoverBlocks.
+let isValidValueFn = null;
+
+// Hydra's REAL schema resolver, run offline. resolveEffectiveBlockSchema(blockId,
+// pageFormData, blockPathMap, blocksConfig, intl) returns a block's schema with
+// its schemaEnhancer applied — so `.required` is the DYNAMIC required set (a
+// card's `image` is required only when its grid enables it). blockSync.js /
+// blockPath.js are idiomatic Volto source (JSX, lodash CJS, extensionless imports)
+// that bare Node can't load, so we esbuild-bundle the offline API once (see
+// loadOfflineBlockSyncApi). null until loaded.
+let resolveEffectiveSchemaFn = null;
+
+// Offline stub intl: block schemas call intl.formatMessage for titles; we only
+// need field NAMES/required, not translations.
+const STUB_INTL = { formatMessage: (m) => (m && (m.defaultMessage || m.id)) || '' };
+
+// Evaluate one `when` operator against a resolved surface value. Mirrors the
+// operators our schemaEnhancer.fieldRules use (see volto-hydra blockSync).
+function condMatches(cond, val) {
+  if (cond && typeof cond === 'object' && !Array.isArray(cond)) {
+    if ('gte' in cond && !(val >= cond.gte)) return false;
+    if ('gt' in cond && !(val > cond.gt)) return false;
+    if ('lte' in cond && !(val <= cond.lte)) return false;
+    if ('lt' in cond && !(val < cond.lt)) return false;
+    if ('isSet' in cond && (cond.isSet ? val == null : val != null)) return false;
+    if ('isNot' in cond && val === cond.isNot) return false;
+    if ('eq' in cond && val !== cond.eq) return false;
+    return true;
+  }
+  return val === cond;
+}
+
+// Resolve a field def against a block's data when it's driven by
+// `schemaEnhancer.fieldRules` — so we validate against the ACTUAL option set the
+// editor would show (e.g. columns `layout` gains "wide-middle" at 3+ columns via
+// `{ when: { items: { gte: 3 } }, set: columnsLayoutField(3) }`). The `set` values
+// are pre-computed defs in the served config, so we only need to pick the first
+// matching rule. Region operators (a blocks_layout field in `when`) compare the
+// region's child count. Returns the resolved def, or `false` if the field is
+// hidden (no validation), or the base def when no rule applies.
+function resolveFieldDef(field, def, blockData, blockConfig, props) {
+  const rules = blockConfig?.schemaEnhancer?.fieldRules?.[field];
+  if (!rules) return def;
+  const childCount =
+    (Array.isArray(blockData?.blocks_layout?.items) && blockData.blocks_layout.items.length) ||
+    (blockData?.blocks && typeof blockData.blocks === 'object' ? Object.keys(blockData.blocks).length : 0);
+  const surface = (name) =>
+    props?.[name]?.widget === 'blocks_layout' ? childCount : blockData?.[name];
+  const list = Array.isArray(rules) ? rules : [rules];
+  for (const r of list) {
+    if (r === false) return false;
+    const when = r && r.when;
+    const ok = !when || Object.entries(when).every(([n, c]) => condMatches(c, surface(n)));
+    if (ok) return 'set' in r ? r.set : def;
+  }
+  return def;
+}
+
+// Recursively collect any `styleName` on a slate value's nodes that isn't an
+// authorable style. Catches hand-injected styles a person can't reproduce.
+function unauthorableSlateStyles(nodes, seen = new Set()) {
+  for (const n of Array.isArray(nodes) ? nodes : []) {
+    if (n && typeof n === 'object') {
+      if (n.styleName && !AUTHORABLE_SLATE_STYLES.has(n.styleName)) seen.add(n.styleName);
+      if (Array.isArray(n.children)) unauthorableSlateStyles(n.children, seen);
+    }
+  }
+  return seen;
+}
+
 function collectWidgetShapeIssues(
-  blockData, blockSchema, pagePath, blockId, out, blockType, undeclaredFields, blockConfig,
+  blockData, blockSchema, pagePath, blockId, out, blockType, undeclaredFields, blockConfig, blocksConfig,
+  effectiveRequired,
 ) {
   const props = blockSchema?.properties;
   if (!props || !blockData || typeof blockData !== 'object') return;
@@ -519,14 +600,74 @@ function collectWidgetShapeIssues(
       issues.push(
         `field "${field}": image content must use \`widget: 'image'\`, not \`widget: 'file'\`.`,
       );
-    } else if (widget === 'select' || widget === 'choice' || def?.factory === 'Choice') {
-      const choices = def.choices || [];
-      const allowed = choices.map(c => (Array.isArray(c) ? c[0] : c));
-      if (allowed.length && !allowed.includes(value)) {
-        issues.push(`field "${field}": value ${JSON.stringify(value)} not in declared choices ${JSON.stringify(allowed)}`);
+    } else if (
+      widget === 'select' || widget === 'choice' || def?.factory === 'Choice' ||
+      Array.isArray(def?.actions) || widget === 'blockTypeSelect'
+    ) {
+      // Resolve the field against this block's data first, so a fieldRules-driven
+      // field (columns `layout`, which gains "wide-middle" at 3+ columns) is
+      // checked against its ACTUAL option set. Then reuse Hydra's `isValidValue`
+      // — the SAME check Hydra strips content with — so block-sanity flags exactly
+      // what the editor can't produce (a size:"xxl", a tags variation:"card").
+      // blockTypeSelect derives its options from the container's `allowedBlocks`,
+      // so hand isValidValue an explicit `choices` set for it.
+      const eff = resolveFieldDef(field, def, blockData, blockConfig, props);
+      if (eff !== false) {
+        let checkDef = eff;
+        let skip = false;
+        if (widget === 'blockTypeSelect') {
+          // A blockTypeSelect's valid values are the container's addable item
+          // types — hydra resolves them in getBlockTypeChoices, which needs the
+          // bridge's blockPathMap/registry and can't run offline. Mirror only the
+          // two OFFLINE-decidable forms:
+          //   • region-synced (grid / tags): a sibling region field carries
+          //     itemTypeField===field, so its `allowedBlocks` is the set.
+          //   • region-less convertible (listing): the field declares
+          //     `filterConvertibleFrom`, and the set is every block type whose
+          //     config has `fieldMappings[that source]` — the SAME filter
+          //     getBlockTypeChoices applies.
+          // Any other form (parent `allowedSiblingTypes`, blocksField '..') needs
+          // the pathMap — skip rather than guess (guessing choices=[] was flagging
+          // every valid listing variation).
+          const region = Object.values(props).find((p) => p && p.itemTypeField === field);
+          if (region) {
+            checkDef = { ...eff, choices: region.allowedBlocks || [] };
+          } else if (eff.filterConvertibleFrom && blocksConfig) {
+            checkDef = {
+              ...eff,
+              choices: Object.keys(blocksConfig).filter(
+                (t) => blocksConfig[t]?.fieldMappings?.[eff.filterConvertibleFrom],
+              ),
+            };
+          } else {
+            skip = true; // unresolvable offline
+          }
+        }
+        if (!skip && isValidValueFn && !isValidValueFn(value, checkDef)) {
+          issues.push(
+            `field "${field}": value ${JSON.stringify(value)} is not an allowed value — the ` +
+              `editor can't produce it (Hydra would strip it on load).`,
+          );
+        }
       }
     } else if (widget === 'slate') {
-      if (!Array.isArray(value)) issues.push(describe('slate array', value));
+      if (!Array.isArray(value)) {
+        issues.push(describe('slate array', value));
+      } else {
+        // The value being an array isn't enough: a slate node's block-level
+        // `styleName` must be a style the editor's style menu can apply. Any
+        // other styleName is content nobody can author — hand-injected to fake a
+        // rendering. Flag each one (this is what caught a fabricated nsw-intro).
+        const bad = unauthorableSlateStyles(value);
+        for (const s of bad) {
+          issues.push(
+            `field "${field}": slate node styleName ${JSON.stringify(s)} is not an ` +
+              `authorable style — no such option exists in the editor's style menu, so ` +
+              `this content can't be reproduced by hand. Register the style (add it to ` +
+              `the slate style menu) or remove it.`,
+          );
+        }
+      }
     } else if (widget === 'object_list') {
       // object_list stores an array of items; an idField (default '@id')
       // identifies each. If data is nested (dataPath), value may be an
@@ -569,6 +710,67 @@ function collectWidgetShapeIssues(
     }
   }
 
+  // Required fields: a `required` field must hold a value — the editor blocks
+  // saving a block with an empty required field, so content that omits one is
+  // data nobody could have authored (an untitled card, a link with no href).
+  //
+  // `required` is DYNAMIC: hydra drops hidden fields from it, so a card's `image`
+  // is required only when its grid enables the image element (its `fieldRules`
+  // read the parent grid's `../itemDefaults_elements` with `contains`). We resolve
+  // that with Hydra's REAL evaluator offline: `effectiveRequired` is the resolved
+  // set (hidden fields already dropped), so we check it directly — no guessing.
+  // Fallback (resolver unavailable): enforce only fields with NO fieldRules entry,
+  // never a conditional one (under-enforce, never false-flag).
+  const usingResolved = Array.isArray(effectiveRequired);
+  const requiredFields = usingResolved
+    ? effectiveRequired
+    : Array.isArray(blockSchema.required)
+      ? blockSchema.required
+      : [];
+  const fieldRules = blockConfig?.schemaEnhancer?.fieldRules || {};
+  const isEmptyRequired = (v) =>
+    v == null ||
+    (typeof v === 'string' && v.trim() === '') ||
+    (Array.isArray(v) && v.length === 0) ||
+    (typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0);
+  for (const field of requiredFields) {
+    if (!props[field]) continue; // required names an undeclared field — a schema bug, not a value issue
+    if (!usingResolved && field in fieldRules) continue; // no resolver: defer conditional fields
+    if (isEmptyRequired(blockData[field])) {
+      issues.push(
+        `field "${field}": required but empty — the editor won't let a block save without ` +
+          `it, so this content can't be authored. Provide a value, or drop the field from \`required\`.`,
+      );
+    }
+  }
+
+  // Synced container: a container with an `itemTypeField` (a blockTypeSelect —
+  // grid, tags, …) fixes ONE item type, so every child must be that type. A
+  // `listing` child is the one structural exception (it expands into the synced
+  // type). allowedBlocks permits several types at once, so THIS is the check that
+  // catches a MIXED synced container — e.g. a tags variation="link" holding a
+  // textItem — which allowedBlocks alone can't.
+  const regionEntry = Object.entries(props).find(([, p]) => p && p.itemTypeField);
+  if (regionEntry) {
+    const variation = blockData[regionEntry[1].itemTypeField];
+    const kids =
+      blockData.blocks && typeof blockData.blocks === 'object'
+        ? Object.values(blockData.blocks)
+        : [];
+    if (typeof variation === 'string' && variation && variation !== 'default') {
+      for (const kid of kids) {
+        const kt = kid && kid['@type'];
+        if (kt && kt !== variation && kt !== 'listing') {
+          issues.push(
+            `synced container item type is ${JSON.stringify(variation)} but it holds a ` +
+              `${JSON.stringify(kt)} child — a synced container can't mix types; every child ` +
+              `must be ${JSON.stringify(variation)} (or a structural "listing").`,
+          );
+        }
+      }
+    }
+  }
+
   // Reverse check: a stored field with no schema property. Only declared fields
   // (plus blocks/blocks_layout) belong in a block's data — an undeclared field
   // means the schema is missing it (it can't be edited in the sidebar) or the
@@ -603,12 +805,72 @@ function collectWidgetShapeIssues(
   }
 }
 
+// blocksConfig objects whose child-block enhancers have already been installed
+// (installChildBlockEnhancers mutates each block's schemaEnhancer, so guard
+// against double-composing on a second discoverBlocks call).
+const _enhancersInstalledFor = new WeakSet();
+let _offlineApiModule = null;
+
+// esbuild-bundle Hydra's offline block-sync API once and wire it up: idiomatic
+// Volto source (JSX, lodash CJS, extensionless imports) can't load in bare Node,
+// so esbuild transpiles the small entry into one self-contained ESM module. Then
+// inject blocksConfig + install the child-block enhancers, exactly as the addon's
+// applyConfig does at init, so resolveEffectiveBlockSchema resolves dynamic
+// `required` (fieldRules / hideParentOwnedFields) the same way the editor does.
+async function loadOfflineBlockSyncApi(blocksConfig) {
+  if (!_offlineApiModule) {
+    const path = require('path');
+    const os = require('os');
+    const { pathToFileURL } = require('url');
+    const esbuild = require('esbuild');
+    const entry = path.resolve(
+      __dirname,
+      '../../packages/volto-hydra/src/utils/offlineBlockSyncApi.js',
+    );
+    const outfile = path.join(
+      os.tmpdir(),
+      `hydra-offline-block-sync-${process.pid}.mjs`,
+    );
+    esbuild.buildSync({
+      entryPoints: [entry],
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      outfile,
+      loader: { '.js': 'jsx' },
+      logLevel: 'silent',
+    });
+    _offlineApiModule = await import(pathToFileURL(outfile).href);
+  }
+  const api = _offlineApiModule;
+  // Inject blocksConfig (the seam blockSync.js reads instead of @plone/volto/registry).
+  api.setInjectedVoltoConfig({ getBlocksConfig: () => blocksConfig });
+  if (!_enhancersInstalledFor.has(blocksConfig)) {
+    api.populateTypeSchemaCache?.(blocksConfig, STUB_INTL);
+    api.installVariationFieldEnhancers?.(blocksConfig);
+    api.installChildBlockEnhancers?.(blocksConfig);
+    _enhancersInstalledFor.add(blocksConfig);
+  }
+  resolveEffectiveSchemaFn = api.resolveEffectiveBlockSchema;
+}
+
 async function discoverBlocks(apiUrl, maxPages = Infinity, blocksConfig = {}, frontendKeys = []) {
   // Use hydra's canonical buildBlockPathMap to walk content — it knows
   // the schema-defined container fields (blocks_layout, object_list,
   // columns, …) and distinguishes real blocks from inline sub-items.
   // Dynamically imported because the module is ESM and this helper is CJS.
   const { buildBlockPathMap } = await import('../../packages/hydra-js/buildBlockPathMap.js');
+  // Reuse Hydra's canonical value validator (choices/enum/actions) — same check
+  // it strips content with, so block-sanity flags exactly what the editor can't
+  // produce. Dependency-free ESM.
+  ({ isValidValue: isValidValueFn } = await import(
+    '../../packages/volto-hydra/src/utils/schemaValidation.mjs'
+  ));
+
+  // Load Hydra's real schema resolver offline (esbuild-bundled) and install the
+  // child-block enhancers + inject blocksConfig, exactly as the addon does at
+  // init. After this, resolveEffectiveSchemaFn gives the dynamic required set.
+  await loadOfflineBlockSyncApi(blocksConfig);
 
   const seen = new Map();
   const slateIssues = [];
@@ -738,9 +1000,24 @@ async function discoverBlocks(apiUrl, maxPages = Infinity, blocksConfig = {}, fr
         }
 
         collectSlateIssues(blockData, pagePath, blockId, slateIssues, blockType);
+        // Effective (dynamic) required set from Hydra's REAL resolver — fieldRules
+        // + hideParentOwnedFields applied, so a conditionally-hidden field (a
+        // card's `image` when its grid disables the image element) is correctly
+        // dropped. Per-block try/catch: one odd block must not abort discovery;
+        // on failure the shape check falls back to unconditional-required only.
+        let effectiveRequired = null;
+        if (resolveEffectiveSchemaFn) {
+          try {
+            effectiveRequired =
+              resolveEffectiveSchemaFn(blockId, content, pathMap, blocksConfig, STUB_INTL)
+                ?.required || null;
+          } catch {
+            effectiveRequired = null;
+          }
+        }
         collectWidgetShapeIssues(
           blockData, schema, pagePath, blockId, shapeIssues, blockType, undeclaredFields,
-          blockType ? blocksConfig[blockType] : undefined,
+          blockType ? blocksConfig[blockType] : undefined, blocksConfig, effectiveRequired,
         );
 
         // Unregistered block type: any real @type the frontend can't render is

--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -806,9 +806,15 @@ function collectWidgetShapeIssues(
 }
 
 // blocksConfig objects whose child-block enhancers have already been installed
-// (installChildBlockEnhancers mutates each block's schemaEnhancer, so guard
-// against double-composing on a second discoverBlocks call).
-const _enhancersInstalledFor = new WeakSet();
+// Maps the pristine discovery blocksConfig -> an enhanced CLONE. installChild
+// BlockEnhancers composes hideParentOwnedFields into each container-child's
+// schemaEnhancer; running it on the discovery's OWN blocksConfig would make
+// buildBlockPathMap resolve child schemas with parent-owned fields DROPPED, so
+// the undeclared-field check would then flag those legit parent-owned fields
+// (contentBlock's imagePosition/imageIsIcon/showViewMoreLink) as stray. So the
+// enhancers go on a copy — only the required check (resolveEffectiveBlockSchema)
+// uses it; buildBlockPathMap + every other check keep the pristine config.
+const _enhancedConfigFor = new WeakMap();
 let _offlineApiModule = null;
 
 // esbuild-bundle Hydra's offline block-sync API once and wire it up: idiomatic
@@ -843,15 +849,27 @@ async function loadOfflineBlockSyncApi(blocksConfig) {
     _offlineApiModule = await import(pathToFileURL(outfile).href);
   }
   const api = _offlineApiModule;
-  // Inject blocksConfig (the seam blockSync.js reads instead of @plone/volto/registry).
-  api.setInjectedVoltoConfig({ getBlocksConfig: () => blocksConfig });
-  if (!_enhancersInstalledFor.has(blocksConfig)) {
-    api.populateTypeSchemaCache?.(blocksConfig, STUB_INTL);
-    api.installVariationFieldEnhancers?.(blocksConfig);
-    api.installChildBlockEnhancers?.(blocksConfig);
-    _enhancersInstalledFor.add(blocksConfig);
+  let enhanced = _enhancedConfigFor.get(blocksConfig);
+  if (!enhanced) {
+    // Shallow-per-block clone: installChildBlockEnhancers sets each block's
+    // `schemaEnhancer`, so copy the block config objects (shared functions like
+    // blockSchema are referenced, never mutated). Enhancers + the injected
+    // getBlocksConfig all point at the clone, so hideParentOwnedFields resolves
+    // consistently against it — while the discovery's blocksConfig stays pristine.
+    enhanced = {};
+    for (const [k, v] of Object.entries(blocksConfig)) {
+      enhanced[k] = v && typeof v === 'object' && !Array.isArray(v) ? { ...v } : v;
+    }
+    api.setInjectedVoltoConfig({ getBlocksConfig: () => enhanced });
+    api.populateTypeSchemaCache?.(enhanced, STUB_INTL);
+    api.installVariationFieldEnhancers?.(enhanced);
+    api.installChildBlockEnhancers?.(enhanced);
+    _enhancedConfigFor.set(blocksConfig, enhanced);
   }
-  resolveEffectiveSchemaFn = api.resolveEffectiveBlockSchema;
+  // Resolve required against the enhanced clone (fieldRules + hideParentOwnedFields),
+  // ignoring the caller's blocksConfig arg so the pristine config never leaks in.
+  resolveEffectiveSchemaFn = (blockId, formData, pathMap, _bc, intl) =>
+    api.resolveEffectiveBlockSchema(blockId, formData, pathMap, enhanced, intl);
 }
 
 async function discoverBlocks(apiUrl, maxPages = Infinity, blocksConfig = {}, frontendKeys = []) {

--- a/tests-playwright/integration/block-sync.spec.ts
+++ b/tests-playwright/integration/block-sync.spec.ts
@@ -1,15 +1,15 @@
 /**
- * Tests for schema inheritance and type selection.
+ * Tests for block sync and type selection.
  *
  * Tests the Phase 2 features:
  * - Type selection: choosing block types for container items (via inheritSchemaFrom)
  * - FieldMappingWidget: mapping source fields to target block fields
- * - Schema inheritance: inheriting non-mapped fields from referenced type
+ * - Block sync: inheriting non-mapped fields from referenced type
  */
 import { test, expect } from '../fixtures';
 import { AdminUIHelper } from '../helpers/AdminUIHelper';
 
-test.describe('Schema Inheritance - Listing Block Item Type', () => {
+test.describe('Block Sync - Listing Block Item Type', () => {
   test('listing block shows variation selector in sidebar', async ({ page }) => {
     const helper = new AdminUIHelper(page);
 
@@ -375,7 +375,7 @@ test.describe('Schema Inheritance - Listing Block Item Type', () => {
   });
 });
 
-test.describe('Schema Inheritance - Search Block with Listing Container', () => {
+test.describe('Block Sync - Search Block with Listing Container', () => {
   test('can select search block, facet, and listing block', async ({ page }) => {
     const helper = new AdminUIHelper(page);
 

--- a/vitest-setup-hydra.js
+++ b/vitest-setup-hydra.js
@@ -5,5 +5,17 @@
 // volto-slate's setup to run too (Markdown plugin sets slate.extensions).
 import voltoSlateApplyConfig from '@plone/volto-slate';
 import config from '@plone/volto/registry';
+import { applyBlockDefaults } from '@plone/volto/helpers';
+import { setInjectedVoltoConfig } from './packages/volto-hydra/src/utils/injectedVoltoConfig.js';
 
 voltoSlateApplyConfig(config);
+
+// blockPath.js / blockSync.js no longer import `@plone/volto/registry`
+// or `applyBlockDefaults` directly (so the offline block-sanity discovery can
+// load them) — they read these via an injected seam. hydra's addon applyConfig
+// sets it at runtime; mirror that here so the unit tests do too.
+setInjectedVoltoConfig({
+  applyBlockDefaults,
+  getDefaultBlockType: () => config.settings.defaultBlockType,
+  getBlocksConfig: () => config.blocks.blocksConfig,
+});


### PR DESCRIPTION
## What

Lands the **offline `fieldRules` evaluator** onto `main`. This work had accumulated on a long-lived project integration branch (`claude/nsw-page-navigation-blocks-ui2doa`) and was never upstreamed, so `main` was missing it while a downstream frontend pinned the branch tip to get it. This PR merges that content onto a current `main` base (keeping #283) so the branch can be retired.

## Contents

- **Rename `schemaInheritance.js` → `blockSync.js`** (+ test/spec renames) — the through-line is keeping block data and schema in sync (`inheritSchemaFrom`, `fieldRules`); DI-refactor drops the `@plone/volto/registry` import so the evaluator can run outside a Volto runtime.
- **`injectedVoltoConfig.js` + `offlineBlockSyncApi.js`** — a bare-Node evaluator surface so block-sanity discovery can resolve `fieldRules` **offline** (no browser/Volto).
- **`discover-blocks.cjs`** — rewired to the real offline evaluator (+315 lines), removing the prior skip-fieldRules shortcut.
- Small supporting changes in `blockPath.js`, `HydraSchemaContext.js`, `index.js`, helpers, and test fixtures.

## Verification

- `pnpm test` (vitest): **166 unit tests pass**, including `blockSync.test.js` (55).
- Merged onto a current `main` base with **no conflicts**; #283 (mobile-admin) is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr
