### PR TITLE
feat(fieldRules): @index position surface (block index within its object_list region)

### DIFF
--- a/docs/custom-blocks.md
+++ b/docs/custom-blocks.md
@@ -243,7 +243,24 @@ schemaEnhancer: {
 }
 ```
 
-Field paths: `../field` for the parent block's field, `/field` for a page metadata field.
+To condition on a block's **position** rather than a field value, use the virtual field **`@index`** — a block's ordinal index within its parent `object_list` region (a `number` surface). It composes with the block-step grammar, so `../@index` is the parent block's index. Unlike the region's numeric ops (which *count* children), `@index` is *where this block sits*:
+
+```javascript
+schemaEnhancer: {
+    fieldRules: {
+        // a table cell's blocks region: cap at one block when this cell is in the
+        // first row (a header row) — `../@index` is the cell's ROW index
+        blocks: [
+            { when: { '../../headerMode': { oneOf: ['row', 'both'] }, '../@index': { lt: 1 } }, set: { maxLength: 1 } },
+            { when: { '../../headerMode': { oneOf: ['col', 'both'] }, '@index':    { lt: 1 } }, set: { maxLength: 1 } },
+        ],
+    },
+}
+```
+
+A block that isn't an `object_list` item yields an unset `@index`, so comparisons are simply false (never an error). `lt: 1` is "first"; `lt: 2` is "first two", etc.
+
+Field paths: `../field` for the parent block's field (and `@index` / `../@index` for position), `/field` for a page metadata field.
 
 ## Block Conversion & fieldMappings
 

--- a/packages/volto-hydra/src/utils/blockSync.js
+++ b/packages/volto-hydra/src/utils/blockSync.js
@@ -1828,6 +1828,13 @@ function evaluateFieldRule(rule, formData, args) {
  *                   ordered list of its child block TYPES (`getBlockType`, so
  *                   `contains: 'image'` means "has an image block").
  *
+ * The virtual field `@index` is special: instead of field data it reads the
+ * block's ordinal POSITION within its parent object_list region (from the
+ * blockPathMap path) as a `'number'` surface — so `{ '@index': { lt: 1 } }` is
+ * "first in my region" and `../@index` is the parent block's index. Distinct
+ * from the region surface's numeric ops (which COUNT children); a non-object_list
+ * block yields an unset number (comparisons false, never a throw).
+ *
  * Only the current block carries a schema here (`args.schema`); a `../`/`/` ref
  * has none, so its non-region value defaults to the string surface.
  * @private
@@ -1842,6 +1849,27 @@ function resolveWhenField(fieldPath, formData, args) {
     curBlockId,
     blockPathMap,
   );
+
+  // Position surface — `@index` is a block's ordinal index within its parent
+  // object_list region, sourced from the blockPathMap PATH (its last element is
+  // the numeric array index for an object_list item), NOT from field data. It
+  // composes with the block-step grammar, so `../@index` is the parent block's
+  // index (a cell reading its row's position). This is what lets a rule key off
+  // POSITION rather than a field value — e.g. a table cell that is a header when
+  // its row is first (`../@index` < 1) or it is first in its row (`@index` < 1).
+  // It's a number surface, distinct from (and non-colliding with) the region
+  // surface's numeric ops, which COUNT a region's children. A non-object_list
+  // block (path with no numeric tail) yields an unset number, so comparisons are
+  // false rather than throwing.
+  if (fieldName === '@index') {
+    const p = blockPathMap?.[targetBlockId]?.path;
+    const last = Array.isArray(p) && p.length ? p[p.length - 1] : undefined;
+    return {
+      kind: 'number',
+      value: typeof last === 'number' ? last : undefined,
+      fieldPath,
+    };
+  }
 
   // Which block owns the field, and (only for the current block) its schema.
   let block;

--- a/packages/volto-hydra/src/utils/blockSync.test.js
+++ b/packages/volto-hydra/src/utils/blockSync.test.js
@@ -665,6 +665,77 @@ describe('fieldRules — number surface', () => {
   });
 });
 
+describe('fieldRules — @index position surface', () => {
+  // `@index` is a block's ordinal index within its parent object_list region,
+  // sourced from the blockPathMap path (its last element is the numeric array
+  // index for an object_list item), NOT from field data. `../@index` steps up to
+  // the parent block first. This is what lets a rule key off POSITION — e.g. a
+  // table cell that becomes a header when its row is first (`../@index` < 1) or
+  // when it is the first cell in its row (`@index` < 1).
+  //
+  // A cell at rows[0].cells[2] and its neighbours; each object_list item's path
+  // ends in the numeric index (buildBlockPathMap builds it that way).
+  const map = {
+    'cell-0':  { path: ['tbl', 'table', 'rows', 0, 'cells', 0], parentId: 'row-0', region: 'cells' },
+    'cell-2':  { path: ['tbl', 'table', 'rows', 0, 'cells', 2], parentId: 'row-0', region: 'cells' },
+    'cell-r1': { path: ['tbl', 'table', 'rows', 1, 'cells', 0], parentId: 'row-1', region: 'cells' },
+    'row-0':   { path: ['tbl', 'table', 'rows', 0], parentId: 'tbl', region: 'rows' },
+    'row-1':   { path: ['tbl', 'table', 'rows', 1], parentId: 'tbl', region: 'rows' },
+  };
+  const runPos = (blockId, when) => {
+    const recipe = { fieldRules: { target: { when, else: false } } };
+    const enhancer = createSchemaEnhancerFromRecipe(recipe);
+    const schema = {
+      fieldsets: [{ id: 'default', title: 'Default', fields: ['target'] }],
+      properties: { target: { title: 'Target' } },
+      required: [],
+    };
+    return (
+      enhancer({ schema, formData: {}, blockId, blockPathMap: map }).properties
+        .target !== undefined
+    );
+  };
+
+  test('@index — the block’s own index in its parent region (numeric ops)', () => {
+    expect(runPos('cell-0', { '@index': { lt: 1 } })).toBe(true); // first column
+    expect(runPos('cell-2', { '@index': { lt: 1 } })).toBe(false); // third column
+    expect(runPos('cell-2', { '@index': { gte: 2 } })).toBe(true);
+    expect(runPos('cell-0', { '@index': { is: 0 } })).toBe(true);
+  });
+
+  test('../@index — the parent block’s index (row position, read from a cell)', () => {
+    expect(runPos('cell-0', { '../@index': { lt: 1 } })).toBe(true); // row 0
+    expect(runPos('cell-r1', { '../@index': { lt: 1 } })).toBe(false); // row 1
+  });
+
+  test('compound AND — own column AND parent row position together', () => {
+    // first cell of the first row (the header corner)
+    const corner = { '@index': { lt: 1 }, '../@index': { lt: 1 } };
+    expect(runPos('cell-0', corner)).toBe(true);
+    expect(runPos('cell-2', corner)).toBe(false); // right column
+    expect(runPos('cell-r1', corner)).toBe(false); // second row
+  });
+
+  test('@index is a number surface (unset when the path has no numeric tail)', () => {
+    // A block-only pathMap entry (no numeric index) yields an unset number → all
+    // comparisons false, never a throw.
+    const recipe = { fieldRules: { target: { when: { '@index': { gte: 0 } }, else: false } } };
+    const enhancer = createSchemaEnhancerFromRecipe(recipe);
+    const schema = {
+      fieldsets: [{ id: 'default', title: 'Default', fields: ['target'] }],
+      properties: { target: { title: 'Target' } },
+      required: [],
+    };
+    const out = enhancer({
+      schema,
+      formData: {},
+      blockId: 'x',
+      blockPathMap: { x: { path: ['x'], parentId: null } },
+    });
+    expect(out.properties.target).toBeUndefined(); // gte:0 false → hidden
+  });
+});
+
 describe('fieldRules — boolean surface', () => {
   const run = (value, when) => runField({ type: 'boolean' }, value, when);
 


### PR DESCRIPTION
## What

Adds a virtual **`@index`** field to the `fieldRules` `when` grammar. Instead of reading field data, it resolves to a block's **ordinal index within its parent `object_list` region** (from the `blockPathMap` path — an object_list item's path ends in its numeric array index) as a `number` surface. It composes with the block-step grammar, so **`../@index`** is the parent block's index.

## Why

`fieldRules` conditions could key off field *values* and region *counts* (`{ rows: { gte: 2 } }`), but not a block's **position**. This unlocks position-driven rules — the motivating case being a container **table** where a cell is a header when its **row** is first (`../@index` < 1) or it's **first in its row** (`@index` < 1), combined (AND) with the table's own header-mode variation read via `../../headerMode`:

```javascript
blocks: [
  { when: { '../../headerMode': { oneOf: ['row', 'both'] }, '../@index': { lt: 1 } }, set: { maxLength: 1 } },
  { when: { '../../headerMode': { oneOf: ['col', 'both'] }, '@index':    { lt: 1 } }, set: { maxLength: 1 } },
]
```

## Notes

- **Non-colliding with the region surface's numeric ops** (which *count* children): `rows` = count, an item's `@index` = position. Different addressing, no overload.
- A block that isn't an `object_list` item yields an **unset** number → comparisons are false, never a throw.
- `lt: 1` = "first", `lt: 2` = "first two", etc. — numeric, so it generalises beyond a boolean "first".

## Tests / docs

- `blockSync.test.js`: 4 new tests (own index, `../` parent index, compound AND, unset-safe). Full utils suite **170 passing**.
- `docs/custom-blocks.md`: author-facing `@index` section + example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr
