### PR TITLE
feat(reveal): edit empty optional block fields inline from the toolbar (#296)

### DIFF
--- a/docs/examples/examples/react/HeroBlock.jsx
+++ b/docs/examples/examples/react/HeroBlock.jsx
@@ -1,27 +1,34 @@
 import { getImageUrl } from './utils.js';
 
 function HeroBlock({ block }) {
-  const heading = block.heading || '';
   const subheading = (block.subheading || '').replace(/\n/g, '<br>');
-  const buttonText = block.buttonText || '';
   const buttonLink = block.buttonLink?.[0]?.['@id'] || '';
   const imageSrc = getImageUrl(block.image);
 
+  // Data-driven: render a field only when it has data. No data ⇒ no element, so
+  // view markup stays clean. Hydra reveals an empty optional field for editing by
+  // seeding it, which makes these same checks true — no edit-mode branch needed.
   return (
     <div data-block-uid={block['@uid']} className="hero-block">
       {imageSrc && (
         <img data-edit-media="image" src={imageSrc} alt="Hero image" />
       )}
-      <h1 data-edit-text="heading">{heading}</h1>
-      <p data-edit-text="subheading" dangerouslySetInnerHTML={{ __html: subheading }} />
-      <div className="hero-description" data-edit-text="description">
-        {(block.description || []).map((node, i) => (
-          <SlateNode key={i} node={node} />
-        ))}
-      </div>
-      <a data-edit-text="buttonText" data-edit-link="buttonLink" href={buttonLink}>
-        {buttonText}
-      </a>
+      {block.heading && <h1 data-edit-text="heading">{block.heading}</h1>}
+      {block.subheading && (
+        <p data-edit-text="subheading" dangerouslySetInnerHTML={{ __html: subheading }} />
+      )}
+      {block.description && (
+        <div className="hero-description" data-edit-text="description">
+          {block.description.map((node, i) => (
+            <SlateNode key={i} node={node} />
+          ))}
+        </div>
+      )}
+      {(block.buttonText || block.buttonLink) && (
+        <a data-edit-text="buttonText" data-edit-link="buttonLink" href={buttonLink}>
+          {block.buttonText}
+        </a>
+      )}
     </div>
   );
 }

--- a/docs/examples/examples/svelte/HeroBlock.svelte
+++ b/docs/examples/examples/svelte/HeroBlock.svelte
@@ -8,18 +8,29 @@
   $: heroImageSrc = getImageUrl(block.image);
 </script>
 
+<!-- Data-driven: render a field only when it has data. No data ⇒ no element, so
+     view markup stays clean. Hydra reveals an empty optional field for editing by
+     seeding it, which makes these same checks true — no edit-mode branch needed. -->
 <div data-block-uid={block['@uid']} class="hero-block">
   {#if block.image}
     <img data-edit-media="image" src={heroImageSrc} alt="Hero image" />
   {/if}
-  <h1 data-edit-text="heading">{block.heading}</h1>
-  <p data-edit-text="subheading">{@html subheadingHtml}</p>
-  <div class="hero-description" data-edit-text="description">
-    {#each block.description || [] as node, i (i)}
-      <SlateNode {node} />
-    {/each}
-  </div>
-  <a data-edit-text="buttonText" data-edit-link="buttonLink" href={buttonLink}>
-    {block.buttonText}
-  </a>
+  {#if block.heading}
+    <h1 data-edit-text="heading">{block.heading}</h1>
+  {/if}
+  {#if block.subheading}
+    <p data-edit-text="subheading">{@html subheadingHtml}</p>
+  {/if}
+  {#if block.description}
+    <div class="hero-description" data-edit-text="description">
+      {#each block.description as node, i (i)}
+        <SlateNode {node} />
+      {/each}
+    </div>
+  {/if}
+  {#if block.buttonText || block.buttonLink}
+    <a data-edit-text="buttonText" data-edit-link="buttonLink" href={buttonLink}>
+      {block.buttonText}
+    </a>
+  {/if}
 </div>

--- a/docs/examples/examples/vue/HeroBlock.vue
+++ b/docs/examples/examples/vue/HeroBlock.vue
@@ -1,12 +1,16 @@
 <template>
+  <!-- Data-driven: render a field only when it has data. No data ⇒ no element, so
+       view markup stays clean. Hydra reveals an empty optional field for editing by
+       seeding it, which makes these same checks true — no edit-mode branch needed. -->
   <div :data-block-uid="block['@uid']" class="hero-block">
     <img v-if="block.image" data-edit-media="image" :src="heroImageSrc" alt="Hero image" />
-    <h1 data-edit-text="heading">{{ block.heading }}</h1>
-    <p data-edit-text="subheading" v-html="subheadingHtml" />
-    <div class="hero-description" data-edit-text="description">
-      <SlateNode v-for="(node, i) in block.description || []" :key="i" :node="node" />
+    <h1 v-if="block.heading" data-edit-text="heading">{{ block.heading }}</h1>
+    <p v-if="block.subheading" data-edit-text="subheading" v-html="subheadingHtml" />
+    <div v-if="block.description" class="hero-description" data-edit-text="description">
+      <SlateNode v-for="(node, i) in block.description" :key="i" :node="node" />
     </div>
-    <a data-edit-text="buttonText" data-edit-link="buttonLink" :href="buttonLink">
+    <a v-if="block.buttonText || block.buttonLink"
+       data-edit-text="buttonText" data-edit-link="buttonLink" :href="buttonLink">
       {{ block.buttonText }}
     </a>
   </div>

--- a/docs/visual-editing.md
+++ b/docs/visual-editing.md
@@ -50,6 +50,34 @@ If you can't modify the markup (e.g., using a 3rd party component library), use 
 
 Supported attributes: `block-uid`, `block-readonly`, `edit-text`, `edit-link`, `edit-media`, `block-add`
 
+## Optional Fields — empty means absent
+
+Render optional fields **data-driven**: no data, no element. Don't render an empty
+element just to give the editor something to click — it leaks empty markup into
+your published page.
+
+<!-- codeExample: jsx -->
+```jsx
+{block.heading && <h1 data-edit-text="heading">{block.heading}</h1>}
+{block.image && <img data-edit-media="image" src={block.image} />}
+```
+
+Plain truthiness is enough — you never need `.length` or a null-safe walk. Hydra
+normalises a field the editor has cleared (widgets write `[]`, which is truthy)
+to absent before your renderer sees it.
+
+To fill an empty field from the canvas, the editor selects the block and presses
+**reveal optional fields** in the Quanta toolbar. Hydra feeds your renderer a
+placeholder value for each empty field, so your own `&&` guard produces the
+element and it becomes editable. The placeholder exists only in the data handed
+to your renderer: it is never stored, so fields left unfilled leave no trace in
+saved content and render nothing in view. Your renderer needs no code for this.
+
+Reveal is best-effort. Hydra offers any field whose type could be edited inline,
+which it cannot always tell apart from a field you keep in the sidebar (alt text
+and css classes are strings too). Fields you don't render inline simply don't
+appear — the editor fills those from the sidebar as usual.
+
 ## Allowed Navigation (data-linkable-allow)
 
 Add `data-linkable-allow` to elements that should navigate during edit mode (paging links, facet controls, etc.):

--- a/docs/visual-editing.md
+++ b/docs/visual-editing.md
@@ -78,6 +78,12 @@ which it cannot always tell apart from a field you keep in the sidebar (alt text
 and css classes are strings too). Fields you don't render inline simply don't
 appear — the editor fills those from the sidebar as usual.
 
+Reveal replaces a per-block boolean only where "has data" and "should render"
+are the same thing. When they genuinely differ — the author has content but
+wants it hidden, or a field should appear only in certain configurations — add
+your own field and drive it with
+[`fieldRules`](custom-blocks.md#schema-enhancers).
+
 ## Allowed Navigation (data-linkable-allow)
 
 Add `data-linkable-allow` to elements that should navigate during edit mode (paging links, facet controls, etc.):

--- a/examples/nuxt-blog-starter/components/block.vue
+++ b/examples/nuxt-blog-starter/components/block.vue
@@ -56,19 +56,23 @@
   <!-- hydra edit-text=heading(.hero-heading) edit-text=subheading(.hero-subheading) edit-media=image(.hero-image) edit-text=buttonText(.hero-button) edit-link=buttonLink(.hero-button) -->
   <div :data-block-uid="block_uid"
        class="hero-block p-5 bg-gray-100 rounded-lg">
-    <!-- Image - uses class for selector, no data-edit-media -->
+    <!-- Image - uses class for selector, no data-edit-media.
+         Data-driven (issue #296): no data ⇒ no element. The `v-else` grey box that
+         used to sit here was the "always-render" hack — an inline target for an
+         empty field, at the cost of an empty div in view markup. -->
     <img v-if="block.image" class="hero-image w-full h-auto max-h-64 object-cover mb-4 rounded"
          :src="getImageUrl(block.image)"
          alt="Hero image" />
-    <div v-else class="hero-image w-full h-40 bg-gray-200 mb-4 rounded cursor-pointer">
+    <h1 v-if="block.heading" class="hero-heading text-3xl font-bold mb-2">{{ block.heading }}</h1>
+    <p v-if="block.subheading" class="hero-subheading text-xl text-gray-600 mb-4">{{ block.subheading }}</p>
+    <div v-if="block.description" class="hero-description mb-4" data-edit-text="description">
+      <RichText v-for="node in block.description" :key="node" :node="node" />
     </div>
-    <h1 class="hero-heading text-3xl font-bold mb-2">{{ block.heading }}</h1>
-    <p class="hero-subheading text-xl text-gray-600 mb-4">{{ block.subheading }}</p>
-    <div class="hero-description mb-4" data-edit-text="description">
-      <RichText v-for="node in (block.description || [])" :key="node" :node="node" />
-    </div>
-    <!-- Button - uses class for selectors -->
-    <a class="hero-button inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 no-underline"
+    <!-- Button - uses class for selectors. One element hosts TWO fields
+         (buttonText + buttonLink), so it exists when the button exists: it has a
+         label or a target. This is the case a per-block `hideButton` papers over. -->
+    <a v-if="block.buttonText || block.buttonLink"
+       class="hero-button inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 no-underline"
        :href="getUrl(block.buttonLink)">
       {{ block.buttonText }}
     </a>

--- a/packages/hydra-js/hydra.src.js
+++ b/packages/hydra-js/hydra.src.js
@@ -10317,8 +10317,22 @@ export class Bridge {
    * affordance that the frontend is currently rendering no element for.
    *
    * Purely observational — no schema annotation, no dependence on `required`
-   * (most block schemas here don't declare it). The renderer's own omission is
-   * the signal, which makes this correct by construction.
+   * (most block schemas here don't declare it).
+   *
+   * DELIBERATELY OVER-INCLUSIVE, don't "fix" this. The widget/type only says a
+   * field COULD be edited inline, not that this frontend renders it: alt text, a
+   * css class, a free-text style value are all plain strings that live in the
+   * sidebar. Telling them apart from an empty heading is impossible without data,
+   * since "renders nothing because it's empty" and "never renders inline" look
+   * identical — it would need a schema annotation or a frontend-side declaration,
+   * i.e. exactly the per-field bookkeeping #296 exists to remove.
+   *
+   * So reveal is BEST-EFFORT: it seeds every candidate, the ones the frontend
+   * renders appear, and the rest are a no-op. A sentinel for a field nobody
+   * renders is harmless — it lives only in the render projection, never in state
+   * and never in saved content — and the editor fills those from the sidebar as
+   * before. No warning is raised for them: a frontend that legitimately keeps a
+   * field sidebar-only is not misconfigured.
    */
   revealableFields(blockUid) {
     const schema = this.getBlockSchema(blockUid);

--- a/packages/hydra-js/hydra.src.js
+++ b/packages/hydra-js/hydra.src.js
@@ -3339,19 +3339,6 @@ export class Bridge {
       }
     }
 
-    // Keep whatever the editor is editing revealed, so emptying it doesn't delete
-    // the element out from under them (clearing an image via the overlay X, or
-    // deleting the last character of a heading).
-    //
-    // Safe to do on every BLOCK_SELECTED, including plain selection: a focused
-    // field is derived from an element that EXISTS, and an element exists only
-    // when the field has content or is already revealed. So this can make an
-    // existing element sticky but can never materialise a new one — reveal stays
-    // explicit.
-    this.keepFieldRevealed(blockUid, focusedFieldName);
-    this.keepFieldRevealed(blockUid, focusedLinkableField);
-    this.keepFieldRevealed(blockUid, focusedMediaField);
-
     const message = {
       type: 'BLOCK_SELECTED',
       src,
@@ -3369,7 +3356,7 @@ export class Bridge {
       // currently are. Rides BLOCK_SELECTED exactly like mediaFields, so the
       // quanta toolbar can show/hide the toggle with no extra round-trip.
       revealableFields: this.revealableFields(blockUid),
-      revealed: this.revealedEmptyFields(blockUid).length > 0,
+      revealed: !!this._revealedBlocks?.has(blockUid),
       focusedFieldName,
       focusedFieldRect,
       focusedLinkableField,
@@ -10362,84 +10349,33 @@ export class Bridge {
   }
 
   /**
-   * Fields currently revealed, as blockUid -> Set(fieldName).
+   * Blocks currently in reveal mode, as a Set of blockUid.
    *
-   * Per FIELD, not per block, because the two things that reveal a field are
-   * different in scope: the toolbar toggle reveals all of a block's empty optional
-   * fields at once, while editing reveals exactly the one field being edited
-   * (see keepFieldRevealed). Revealing a block's whole set because the editor
-   * cleared its image would pop in heading, subheading and button unasked.
+   * Per BLOCK, not per field: reveal is one mode ("show me this block's empty
+   * optional fields"), so whatever is empty at render time shows. That keeps it
+   * consistent while revealed — empty a field and its element stays, because the
+   * block is still in reveal mode — without any second, invisible way for a field
+   * to become revealed.
+   *
+   * Deliberately NOT sticky per field on edit. Emptying a field has to mean the
+   * field is gone, or there is no single action for "I want no image": the editor
+   * would delete, then have to dismiss the leftover placeholder through a
+   * block-level control. Swapping an image costs nothing either way — the quanta
+   * toolbar's image button (SyncedSlateToolbar.jsx, gated on focusedMediaField)
+   * replaces it in one click without deleting first.
    */
-  get revealedFields() {
-    if (!this._revealedFields) this._revealedFields = new Map();
-    return this._revealedFields;
-  }
-
-  isFieldRevealed(blockUid, fieldName) {
-    return !!this._revealedFields?.get(blockUid)?.has(fieldName);
-  }
-
-  /**
-   * Keep a field revealed for as long as the editor is working in it.
-   *
-   * Without this, "no data ⇒ no element" turns every field into a trapdoor: clear
-   * a hero image and the X button deletes its own overlay target, so there is
-   * nowhere to upload the replacement; delete the last character of a heading and
-   * the <h1> vanishes from under the caret. Marking the field on INTERACTION (not
-   * on emptiness) means the element survives whatever the value does next.
-   *
-   * Still explicit — clicking into a field or opening its media/link overlay is an
-   * editor action on that field. Nothing here fires on selection or on insert.
-   *
-   * @returns {boolean} true if this newly revealed the field (caller may re-render)
-   */
-  keepFieldRevealed(blockUid, fieldName) {
-    if (!blockUid || !fieldName) return false;
-    if (this.isFieldRevealed(blockUid, fieldName)) return false;
-    if (!this.revealedFields.has(blockUid)) {
-      this.revealedFields.set(blockUid, new Set());
-    }
-    this.revealedFields.get(blockUid).add(fieldName);
-    return true;
-  }
-
-  /**
-   * The revealed fields that are actually SHOWING because of reveal — i.e. still
-   * empty, so their element exists only thanks to a seeded sentinel.
-   *
-   * The rest of the set is bookkeeping: a field the editor clicked into that has
-   * real content renders on its own, and pressing the toggle should not treat it
-   * as something to hide.
-   */
-  revealedEmptyFields(blockUid) {
-    const set = this._revealedFields?.get(blockUid);
-    if (!set?.size) return [];
-    return this.revealableFields(blockUid).filter((f) => set.has(f));
+  get revealedBlocks() {
+    if (!this._revealedBlocks) this._revealedBlocks = new Set();
+    return this._revealedBlocks;
   }
 
   /**
    * Toggle reveal for a block. Reveal is ALWAYS EXPLICIT — nothing here runs on
-   * selection or on insert.
-   *
-   * The revealed SET is the source of truth, deliberately not re-derived per
-   * render: once a field is revealed its element exists, so revealableFields()
-   * stops matching it and the field would flicker straight back out.
+   * selection, on insert, or on a field becoming empty.
    */
   toggleOptionalFields(blockUid) {
-    const showing = this.revealedEmptyFields(blockUid);
-    if (showing.length) {
-      const set = this.revealedFields.get(blockUid);
-      // Only un-reveal what reveal is showing; entries for fields the editor is
-      // editing stay, so hiding can't strand a caret.
-      showing.forEach((f) => set.delete(f));
-      if (!set.size) this.revealedFields.delete(blockUid);
-    } else {
-      if (!this.revealedFields.has(blockUid)) {
-        this.revealedFields.set(blockUid, new Set());
-      }
-      const set = this.revealedFields.get(blockUid);
-      this.revealableFields(blockUid).forEach((f) => set.add(f));
-    }
+    if (this.revealedBlocks.has(blockUid)) this.revealedBlocks.delete(blockUid);
+    else this.revealedBlocks.add(blockUid);
     if (this.onContentChangeCallback) this._executeRender(this.onContentChangeCallback);
   }
 
@@ -10482,14 +10418,11 @@ export class Bridge {
       // the answer doesn't change once revealed. (The old DOM-based rule asked "is
       // there no element?" — a question revealing itself falsified, so the field
       // flickered back out on the next render.)
-      const revealed = this._revealedFields?.get(blockUid);
-      if (!revealed?.size) continue;
-      // Intersect with what's still EMPTY: a revealed field the editor has since
-      // filled needs no sentinel, and seeding one over real content would clobber
-      // it. The set is not pruned — the field stays revealed so emptying it again
-      // doesn't make the element vanish mid-edit.
+      if (!this._revealedBlocks?.has(blockUid)) continue;
+      // revealableFields is already "empty AND has an inline affordance", so a
+      // field the editor has since filled drops out on its own and no sentinel is
+      // written over real content.
       for (const fieldName of this.revealableFields(blockUid)) {
-        if (!revealed.has(fieldName)) continue;
         const fieldDef = properties[fieldName];
         const sentinel = this._revealSentinelFor(
           fieldDef,

--- a/packages/hydra-js/hydra.src.js
+++ b/packages/hydra-js/hydra.src.js
@@ -531,11 +531,69 @@ export class Bridge {
         continue;
       }
 
+      // Which block this comment belongs to. Both declaration styles are legal and
+      // in use: the mock frontend names the uid in the comment, while the Nuxt
+      // example omits it because the central <Block> wrapper already carries
+      // data-block-uid. Needed only to judge the selector warning below.
+      const blockUid =
+        parsed.attrs['block-uid']?.[0]?.value ??
+        nextElement.closest('[data-block-uid]')?.getAttribute('data-block-uid');
+
       // Apply attributes to the element
-      this.applyHydraAttributes(nextElement, parsed.attrs);
+      this.applyHydraAttributes(nextElement, parsed.attrs, this.getRenderedBlockData(blockUid));
     }
 
     log('materializeHydraComments: completed');
+  }
+
+  /**
+   * The block's data AS RENDERED — i.e. after _projectForRender, so a revealed
+   * field carries its sentinel here even though state has it empty.
+   *
+   * @param {string} blockUid
+   * @returns {Object|undefined}
+   */
+  getRenderedBlockData(blockUid) {
+    if (!blockUid || !this._lastRenderedData) return undefined;
+    const pathInfo = this.blockPathMap?.[blockUid];
+    if (!pathInfo?.path) return undefined;
+    let current = this._lastRenderedData;
+    for (const key of pathInfo.path) {
+      if (!current || typeof current !== 'object') return undefined;
+      current = current[key];
+    }
+    return current;
+  }
+
+  /**
+   * Is a comment selector matching nothing the CORRECT outcome?
+   *
+   * Yes exactly when the field it names has no data: "no data ⇒ no element" is the
+   * contract (issue #296), so a data-driven renderer is right to emit nothing and
+   * shouting about it would train devs to ignore the console. Everything else stays
+   * an error — a field WITH content and no element is a renderer bug, and that
+   * includes a revealed sentinel, where it means the reveal silently did nothing.
+   *
+   * Only edit-* attributes name a field. block-uid, block-add, linkable-* and the
+   * rest are structural, so a missing target is always wrong.
+   */
+  isFieldAbsentFromRender(name, fieldName, renderedBlock) {
+    if (name !== 'edit-text' && name !== 'edit-link' && name !== 'edit-media') {
+      return false;
+    }
+    // A leading slash means a PAGE field (/title, /description), which lives on the
+    // form root rather than the block.
+    const source = fieldName.startsWith('/')
+      ? this._lastRenderedData
+      : renderedBlock;
+    if (!source) return false;
+    const value = source[fieldName.replace(/^\//, '')];
+    return (
+      value === undefined ||
+      value === null ||
+      value === '' ||
+      (Array.isArray(value) && value.length === 0)
+    );
   }
 
   /**
@@ -543,8 +601,10 @@ export class Bridge {
    *
    * @param {HTMLElement} element - The root element
    * @param {Object} attrs - Parsed attributes { name: [{ value, selector }, ...] }
+   * @param {Object} [renderedBlock] - The block data the renderer was handed, used
+   *   to judge whether a selector matching nothing is correct or a bug.
    */
-  applyHydraAttributes(element, attrs) {
+  applyHydraAttributes(element, attrs, renderedBlock) {
     const attrMap = {
       'block-uid': 'data-block-uid',
       'block-readonly': 'data-block-readonly',
@@ -576,7 +636,7 @@ export class Bridge {
           ? element.querySelectorAll(selector)
           : [element];
 
-        if (selector && targets.length === 0) {
+        if (selector && targets.length === 0 && !this.isFieldAbsentFromRender(name, value, renderedBlock)) {
           console.error(`[hydra] Comment selector "${selector}" for ${name}=${value} matched no elements in`, element.tagName, element.className);
         }
 
@@ -3279,6 +3339,19 @@ export class Bridge {
       }
     }
 
+    // Keep whatever the editor is editing revealed, so emptying it doesn't delete
+    // the element out from under them (clearing an image via the overlay X, or
+    // deleting the last character of a heading).
+    //
+    // Safe to do on every BLOCK_SELECTED, including plain selection: a focused
+    // field is derived from an element that EXISTS, and an element exists only
+    // when the field has content or is already revealed. So this can make an
+    // existing element sticky but can never materialise a new one — reveal stays
+    // explicit.
+    this.keepFieldRevealed(blockUid, focusedFieldName);
+    this.keepFieldRevealed(blockUid, focusedLinkableField);
+    this.keepFieldRevealed(blockUid, focusedMediaField);
+
     const message = {
       type: 'BLOCK_SELECTED',
       src,
@@ -3292,6 +3365,11 @@ export class Bridge {
       editableFields,
       linkableFields,
       mediaFields,
+      // Reveal (#296): which optional fields COULD be revealed, and whether they
+      // currently are. Rides BLOCK_SELECTED exactly like mediaFields, so the
+      // quanta toolbar can show/hide the toggle with no extra round-trip.
+      revealableFields: this.revealableFields(blockUid),
+      revealed: this.revealedEmptyFields(blockUid).length > 0,
       focusedFieldName,
       focusedFieldRect,
       focusedLinkableField,
@@ -4123,6 +4201,10 @@ export class Bridge {
             log('Clearing processing state due to SLATE_ERROR');
             this.setBlockProcessing(blockId, false);
           }
+        } else if (event.data.type === 'TOGGLE_OPTIONAL_FIELDS') {
+          // Editor pressed the reveal toggle on the quanta toolbar.
+          log('Received TOGGLE_OPTIONAL_FIELDS:', event.data.blockUid);
+          this.toggleOptionalFields(event.data.blockUid);
         } else if (event.data.type === 'FOCUS_FIELD') {
           // Restore focus to a specific field (e.g., after LinkEditor closes)
           const { blockId, fieldName } = event.data;
@@ -10150,6 +10232,284 @@ export class Bridge {
    * naturally skipped because isInlineEditing is false and pendingTransform
    * / _reRenderBlocking are unset.
    */
+  /**
+   * Build the copy of formData the RENDERER sees. `this.formData` is never
+   * mutated — it stays exactly what the admin sent, so echo detection and the
+   * data that goes back up stay truthful.
+   *
+   * Today this does one job: make "cleared" read as "absent".
+   *
+   * A frontend's natural rule for an optional field is plain truthiness —
+   * `{block.heading && …}`, `v-if="block.buttonLink"`. That's the rule we want
+   * developers to write without thinking about edit mode. It works for every
+   * state except one: a field the editor CLEARED. Volto's ObjectBrowserWidget
+   * writes `[]` on remove (removeItem, ObjectBrowserWidget.jsx:163), not
+   * undefined — and `[]` is truthy in JS, so the natural rule would render an
+   * element for a field that has nothing in it. Making every renderer write
+   * `.length` to dodge that is exactly the per-block complexity issue #296 is
+   * removing, so the bridge collapses it here instead.
+   *
+   * Safe because `undefined` is ALREADY a legal state for every one of these
+   * fields (a never-set field arrives that way), so this introduces no state a
+   * renderer isn't already handling.
+   *
+   * Scoped by schema, deliberately: a blind recursive sweep would also strip
+   * `blocks_layout.items: []` on an empty container and break renderers that
+   * map over it. Only declared, non-container schema fields are touched.
+   */
+  /**
+   * Zero-width space. The reveal sentinel for every text-ish shape.
+   * Not a new convention — the bridge already inserts ZWS into empty inline
+   * elements for cursor positioning (_ensureZeroWidthSpaces) and already ignores
+   * it when deciding emptiness (updateFieldEmptyState), and the admin plants it
+   * so empty inline slate nodes survive withEmptyInlineRemoval.
+   */
+  static get REVEAL_ZWS() { return '\u200B'; }
+
+  /**
+   * The reveal sentinel for a string-URL image field: a fully transparent SVG
+   * with REAL intrinsic dimensions.
+   *
+   * Not a 1x1. The size matters — the frontend styles this exactly as it styles
+   * any other image, so the editor gets a correctly-shaped click target and
+   * hydra's zero-dimension media guard is satisfied naturally. The alternative
+   * (a 1x1 plus injected min-width/min-height CSS) would have been the one
+   * injection that reshapes the host page's layout, which the existing injected
+   * rules deliberately avoid — they use `outline` precisely so "the host element
+   * position is NOT mutated".
+   *
+   * Transparent, so nothing of ours is ever painted into the frontend.
+   */
+  static get REVEAL_PIXEL() {
+    return "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='300'/%3E";
+  }
+
+  /**
+   * The sentinel for a field, chosen by WIDGET — never by inspecting the current
+   * value, which is absent precisely when a sentinel is needed.
+   *
+   * Shape-preserving is the whole point: a renderer reading an object_browser
+   * field does `block.href?.[0]?.['@id']` or maps over it, so handing it a bare
+   * string would make it iterate characters.
+   *
+   * Returns undefined for a field that has no inline affordance (select, boolean,
+   * number …) — those are sidebar-only and nothing can be revealed for them.
+   */
+  _revealSentinelFor(fieldDef, fieldType) {
+    const Z = Bridge.REVEAL_ZWS;
+    // The admin DECORATES field defs — a copyFromTargetField wrapper keeps the real
+    // one under `baseWidget`. Read the wrapper and every media/link field looks like
+    // an unknown widget and silently yields no sentinel, so it never reveals.
+    let def = fieldDef;
+    while (def?.baseWidget) def = def.baseWidget;
+    const widget = def?.widget;
+    fieldDef = def;
+
+    if (widget === 'object_browser') return [{ '@id': Z, title: Z }];
+    if (widget === 'image' || fieldDef?.type === 'image') return Bridge.REVEAL_PIXEL;
+    if (widget === 'url' || fieldDef?.type === 'url') return Z;
+    if (isSlateFieldType(fieldType)) return [{ type: 'p', children: [{ text: Z }] }];
+    if (isTextEditableFieldType(fieldType)) return Z;
+    return undefined;
+  }
+
+  /** True when a value is (or contains) a reveal sentinel rather than real content. */
+  _isRevealSentinel(value) {
+    const Z = Bridge.REVEAL_ZWS;
+    if (value === Z || value === Bridge.REVEAL_PIXEL) return true;
+    if (Array.isArray(value) && value.length === 1) {
+      const only = value[0];
+      if (only && only['@id'] === Z) return true;
+      if (only?.children?.length === 1 && only.children[0]?.text === Z) return true;
+    }
+    return false;
+  }
+
+  /**
+   * The block's schema fields that COULD be revealed: ones with an inline
+   * affordance that the frontend is currently rendering no element for.
+   *
+   * Purely observational — no schema annotation, no dependence on `required`
+   * (most block schemas here don't declare it). The renderer's own omission is
+   * the signal, which makes this correct by construction.
+   */
+  revealableFields(blockUid) {
+    const schema = this.getBlockSchema(blockUid);
+    const properties = schema?.properties;
+    const block = this.getBlockData(blockUid);
+    if (!properties || !block) return [];
+
+    const isEmpty = (v) =>
+      v === undefined || v === null || v === '' || (Array.isArray(v) && v.length === 0);
+
+    return Object.entries(properties)
+      .filter(([fieldName, fieldDef]) => {
+        // Has an inline affordance at all. Returns undefined for select /
+        // boolean / number, so sidebar-only fields drop out for free.
+        if (!this._revealSentinelFor(fieldDef, this.getFieldType(blockUid, fieldName))) {
+          return false;
+        }
+        // A REQUIRED field is rendered unconditionally by the frontend (a value
+        // is guaranteed, so no `{field && …}` guard), which means its element
+        // always exists and there is nothing to reveal. Excluding it keeps the
+        // button's "N empty optional fields" count honest. If a required field
+        // ever IS missing an element, that's a renderer bug for the dev-warning
+        // to shout about — not something reveal should paper over.
+        if (schema.required?.includes(fieldName)) return false;
+        return isEmpty(block[fieldName]);
+      })
+      .map(([fieldName]) => fieldName);
+  }
+
+  /**
+   * Fields currently revealed, as blockUid -> Set(fieldName).
+   *
+   * Per FIELD, not per block, because the two things that reveal a field are
+   * different in scope: the toolbar toggle reveals all of a block's empty optional
+   * fields at once, while editing reveals exactly the one field being edited
+   * (see keepFieldRevealed). Revealing a block's whole set because the editor
+   * cleared its image would pop in heading, subheading and button unasked.
+   */
+  get revealedFields() {
+    if (!this._revealedFields) this._revealedFields = new Map();
+    return this._revealedFields;
+  }
+
+  isFieldRevealed(blockUid, fieldName) {
+    return !!this._revealedFields?.get(blockUid)?.has(fieldName);
+  }
+
+  /**
+   * Keep a field revealed for as long as the editor is working in it.
+   *
+   * Without this, "no data ⇒ no element" turns every field into a trapdoor: clear
+   * a hero image and the X button deletes its own overlay target, so there is
+   * nowhere to upload the replacement; delete the last character of a heading and
+   * the <h1> vanishes from under the caret. Marking the field on INTERACTION (not
+   * on emptiness) means the element survives whatever the value does next.
+   *
+   * Still explicit — clicking into a field or opening its media/link overlay is an
+   * editor action on that field. Nothing here fires on selection or on insert.
+   *
+   * @returns {boolean} true if this newly revealed the field (caller may re-render)
+   */
+  keepFieldRevealed(blockUid, fieldName) {
+    if (!blockUid || !fieldName) return false;
+    if (this.isFieldRevealed(blockUid, fieldName)) return false;
+    if (!this.revealedFields.has(blockUid)) {
+      this.revealedFields.set(blockUid, new Set());
+    }
+    this.revealedFields.get(blockUid).add(fieldName);
+    return true;
+  }
+
+  /**
+   * The revealed fields that are actually SHOWING because of reveal — i.e. still
+   * empty, so their element exists only thanks to a seeded sentinel.
+   *
+   * The rest of the set is bookkeeping: a field the editor clicked into that has
+   * real content renders on its own, and pressing the toggle should not treat it
+   * as something to hide.
+   */
+  revealedEmptyFields(blockUid) {
+    const set = this._revealedFields?.get(blockUid);
+    if (!set?.size) return [];
+    return this.revealableFields(blockUid).filter((f) => set.has(f));
+  }
+
+  /**
+   * Toggle reveal for a block. Reveal is ALWAYS EXPLICIT — nothing here runs on
+   * selection or on insert.
+   *
+   * The revealed SET is the source of truth, deliberately not re-derived per
+   * render: once a field is revealed its element exists, so revealableFields()
+   * stops matching it and the field would flicker straight back out.
+   */
+  toggleOptionalFields(blockUid) {
+    const showing = this.revealedEmptyFields(blockUid);
+    if (showing.length) {
+      const set = this.revealedFields.get(blockUid);
+      // Only un-reveal what reveal is showing; entries for fields the editor is
+      // editing stay, so hiding can't strand a caret.
+      showing.forEach((f) => set.delete(f));
+      if (!set.size) this.revealedFields.delete(blockUid);
+    } else {
+      if (!this.revealedFields.has(blockUid)) {
+        this.revealedFields.set(blockUid, new Set());
+      }
+      const set = this.revealedFields.get(blockUid);
+      this.revealableFields(blockUid).forEach((f) => set.add(f));
+    }
+    if (this.onContentChangeCallback) this._executeRender(this.onContentChangeCallback);
+  }
+
+  _projectForRender(formData) {
+    if (!formData || !this.blockPathMap) return formData;
+
+    // Container fields hold structure, not content — an empty one still has to
+    // arrive as an array for the renderer to map over.
+    const CONTAINER_WIDGETS = new Set(['blocks_layout', 'object_list']);
+
+    let projected = null; // cloned lazily; most renders change nothing
+    for (const blockUid of Object.keys(this.blockPathMap)) {
+      if (blockUid === '_schemas' || blockUid === '_page') continue;
+      const schema = this.getBlockSchema(blockUid);
+      const properties = schema?.properties;
+      if (!properties) continue;
+
+      const pathInfo = this.blockPathMap[blockUid];
+      const source = this.getBlockData(blockUid);
+      if (!source || !pathInfo?.path) continue;
+
+      for (const [fieldName, fieldDef] of Object.entries(properties)) {
+        if (CONTAINER_WIDGETS.has(fieldDef?.widget)) continue;
+        const value = source[fieldName];
+        if (!Array.isArray(value) || value.length > 0) continue;
+
+        // First actual change on this render — clone before touching anything.
+        if (!projected) projected = JSON.parse(JSON.stringify(formData));
+        let target = projected;
+        for (const key of pathInfo.path) target = target?.[key];
+        if (target) delete target[fieldName];
+      }
+
+      // Reveal: seed a sentinel into each empty inline field of a revealed
+      // block, so the renderer's own `{field && …}` rule fires and produces an
+      // element to click. Nothing here is persisted — the sentinel exists only
+      // in this projection and in the DOM.
+      // Re-derived every render, and stable BECAUSE sentinels never enter state:
+      // the projection reads this.formData, which stays empty for these fields, so
+      // the answer doesn't change once revealed. (The old DOM-based rule asked "is
+      // there no element?" — a question revealing itself falsified, so the field
+      // flickered back out on the next render.)
+      const revealed = this._revealedFields?.get(blockUid);
+      if (!revealed?.size) continue;
+      // Intersect with what's still EMPTY: a revealed field the editor has since
+      // filled needs no sentinel, and seeding one over real content would clobber
+      // it. The set is not pruned — the field stays revealed so emptying it again
+      // doesn't make the element vanish mid-edit.
+      for (const fieldName of this.revealableFields(blockUid)) {
+        if (!revealed.has(fieldName)) continue;
+        const fieldDef = properties[fieldName];
+        const sentinel = this._revealSentinelFor(
+          fieldDef,
+          this.getFieldType(blockUid, fieldName),
+        );
+        if (sentinel === undefined) continue;
+        if (!projected) projected = JSON.parse(JSON.stringify(formData));
+        let target = projected;
+        for (const key of pathInfo.path) target = target?.[key];
+        if (target) target[fieldName] = sentinel;
+      }
+    }
+    // What the renderer was actually handed. materializeHydraComments needs this
+    // (not this.formData) to tell "field is empty, so no element is CORRECT" from
+    // "field has content but the renderer produced no element" — including a
+    // revealed sentinel, whose element failing to appear means reveal did nothing.
+    this._lastRenderedData = projected || formData;
+    return this._lastRenderedData;
+  }
+
   _executeRender(callbackFn, afterRenderOptions = {}) {
     this._renderInProgress = true;
     this._renderStartTime = performance.now();
@@ -10193,8 +10553,9 @@ export class Bridge {
       this.blockTextMutationObserver.disconnect();
     }
 
-    // Call the callback to trigger the render
-    callbackFn(this.formData);
+    // Call the callback to trigger the render. The renderer never sees
+    // this.formData directly — it gets a projection (see _projectForRender).
+    callbackFn(this._projectForRender(this.formData));
 
     const afterRender = () => {
       this.afterContentRender(afterRenderOptions);

--- a/packages/volto-hydra/src/components/Iframe/View.jsx
+++ b/packages/volto-hydra/src/components/Iframe/View.jsx
@@ -3199,6 +3199,8 @@ const Iframe = (props) => {
                 prevBlockUI.focusedLinkableField === event.data.focusedLinkableField &&
                 prevBlockUI.focusedMediaField === event.data.focusedMediaField &&
                 prevBlockUI.addDirection === event.data.addDirection &&
+                prevBlockUI.revealed === event.data.revealed &&
+                JSON.stringify(prevBlockUI.revealableFields) === JSON.stringify(event.data.revealableFields) &&
                 prevBlockUI.rect?.top === event.data.rect?.top &&
                 prevBlockUI.rect?.left === event.data.rect?.left &&
                 prevBlockUI.rect?.width === event.data.rect?.width &&
@@ -3233,6 +3235,10 @@ const Iframe = (props) => {
               editableFields: event.data.editableFields, // Map of fieldName -> fieldType from iframe
               linkableFields: event.data.linkableFields, // Map of fieldName -> true for link fields
               mediaFields: event.data.mediaFields, // Map of fieldName -> true for image/media fields
+              // Reveal (#296): empty inline-editable fields the quanta toolbar can
+              // offer to reveal, and whether they currently are.
+              revealableFields: event.data.revealableFields, // string[] of field names
+              revealed: event.data.revealed, // are they currently revealed
               addDirection: event.data.addDirection, // Direction for add button positioning
               isMultiElement: event.data.isMultiElement, // True if block renders as multiple DOM elements
               canResize: event.data.canResize || null, // {top,bottom,left,right} booleans for edge-drag chrome

--- a/packages/volto-hydra/src/components/Toolbar/OptionalFieldsToggle.jsx
+++ b/packages/volto-hydra/src/components/Toolbar/OptionalFieldsToggle.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Icon } from '@plone/volto/components';
+import addSVG from '@plone/volto/icons/add.svg';
+
+/**
+ * Reveal the selected block's empty optional fields so they can be filled from
+ * the canvas (issue #296).
+ *
+ * Replaces two per-block hacks: rendering an element even when empty (which leaks
+ * an empty element into VIEW markup), and per-field `showButton`/`hideButton`
+ * booleans whose only job is to expose another field.
+ *
+ * ONE toggle for the whole block, not a per-field menu. Per-field targeting buys
+ * little, because reveal already collapses on deselect — fields the editor ignores
+ * disappear on their own.
+ *
+ * Reveal is ALWAYS EXPLICIT: nothing is revealed on selection or on insert. The
+ * button is rendered only when the block actually has something to reveal, so a
+ * fully populated block shows no control at all.
+ *
+ * @param {string} blockUid - block whose optional fields this toggles
+ * @param {string[]} revealableFields - empty inline-editable fields (from BLOCK_SELECTED)
+ * @param {boolean} revealed - are they currently revealed
+ * @param {(blockUid: string) => void} onToggle
+ */
+export default function OptionalFieldsToggle({
+  blockUid,
+  revealableFields,
+  revealed,
+  onToggle,
+}) {
+  if (!revealableFields?.length && !revealed) return null;
+
+  const title = revealed
+    ? 'Hide empty optional fields'
+    : `Show ${revealableFields.length} empty optional field${
+        revealableFields.length === 1 ? '' : 's'
+      }`;
+
+  return (
+    <button
+      type="button"
+      className={`optional-fields-toggle${revealed ? ' revealed' : ''}`}
+      title={title}
+      aria-label={title}
+      aria-pressed={revealed}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onToggle(blockUid);
+      }}
+    >
+      <Icon name={addSVG} size="18px" title={title} />
+    </button>
+  );
+}

--- a/packages/volto-hydra/src/components/Toolbar/SyncedSlateToolbar.jsx
+++ b/packages/volto-hydra/src/components/Toolbar/SyncedSlateToolbar.jsx
@@ -15,6 +15,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import FormatDropdown from './FormatDropdown';
 import DropdownMenu from './DropdownMenu';
 import TemplateLockToggle from './TemplateLockToggle';
+import OptionalFieldsToggle from './OptionalFieldsToggle';
 import linkSVG from '@plone/volto/icons/link.svg';
 import imageSVG from '@plone/volto/icons/image.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
@@ -1297,6 +1298,23 @@ const SyncedSlateToolbar = ({
   // Block action buttons (e.g., add row/column for tables) also need slots
   const blockActionToolbarItems = blockActions?.toolbar || [];
 
+  // Reveal empty optional fields on the selected block (#296). Hydra owns the
+  // revealed set — it's ephemeral edit state that must never reach the admin's
+  // formData, so the admin only sends the intent and reads the result back off
+  // BLOCK_SELECTED (blockUI.revealableFields / blockUI.revealed).
+  // NOT a hook: this sits below the component's early returns, so a useCallback
+  // here would change hook order between renders ("Rendered more hooks than
+  // during the previous render"). It needs no memoisation anyway.
+  const toggleOptionalFields = (blockUid) => {
+    const iframe = document.getElementById('previewIframe');
+    if (iframe?.contentWindow) {
+      iframe.contentWindow.postMessage(
+        { type: 'TOGGLE_OPTIONAL_FIELDS', blockUid },
+        '*',
+      );
+    }
+  };
+
   // Slate buttons come first in toolbar, so they get priority for slots
   // Calculate slots for Slate (format dropdown + inline buttons) first
   const slotsAfterFormatDropdown = Math.max(0, availableSlots - formatDropdownSlots);
@@ -1465,6 +1483,22 @@ const SyncedSlateToolbar = ({
         }
         return dragHandle;
       })()}
+
+      {/* Reveal empty optional fields (#296). Rendered only when the selected block
+          actually has some — a fully populated block shows no control. pointerEvents
+          must be re-enabled: the toolbar itself sets 'none' so drag events reach the
+          iframe's invisible drag button underneath. */}
+      {selectedBlock && selectedBlock !== PAGE_BLOCK_UID &&
+        !isBlockReadonly(getBlock(selectedBlock), templateEditMode) && (
+          <div style={{ pointerEvents: 'auto', display: 'flex', alignItems: 'center' }}>
+            <OptionalFieldsToggle
+              blockUid={selectedBlock}
+              revealableFields={blockUI?.revealableFields}
+              revealed={blockUI?.revealed}
+              onToggle={toggleOptionalFields}
+            />
+          </div>
+        )}
 
       {/* Real Slate buttons - only show if we have a valid slate field value */}
       {/* IMPORTANT: Wrap in div with pointerEvents: 'auto' to make buttons clickable

--- a/tests-playwright/fixtures/content/copy-target-page/data.json
+++ b/tests-playwright/fixtures/content/copy-target-page/data.json
@@ -30,7 +30,22 @@
       "heading": "Author Heading",
       "subheading": "",
       "buttonText": "Go",
-      "buttonLink": [{ "@id": "/news/big" }],
+      "buttonLink": [
+        {
+          "@id": "/news/big",
+          "image_field": "preview_image",
+          "image_scales": {
+            "preview_image": [
+              {
+                "content-type": "image/svg+xml",
+                "download": "@@images/preview_image/preview",
+                "width": 400,
+                "height": 300
+              }
+            ]
+          }
+        }
+      ],
       "description": [{ "type": "p", "children": [{ "text": "" }] }]
     },
     "btn-pick": {

--- a/tests-playwright/fixtures/content/optional-fields-page/data.json
+++ b/tests-playwright/fixtures/content/optional-fields-page/data.json
@@ -1,0 +1,73 @@
+{
+  "@id": "/optional-fields-page",
+  "@type": "Document",
+  "id": "optional-fields-page",
+  "title": "Optional Fields Page",
+  "description": "Hero blocks with optional fields empty vs populated, for the reveal-optional-fields feature (issue #296). `hero` is the only block that exercises all four sentinel types at once: heading (plain string), subheading (textarea), description (slate), buttonLink (link), image (media). `anchor-slate` is here only so the page has a block-uid in VIEW mode: hero declares its uid in a hydra comment (renderer.js renderBlock), and comments are materialised by the bridge in edit mode only, so an all-hero page renders zero [data-block-uid] after save and AdminUIHelper.waitForIframeReady never settles.",
+  "blocks": {
+    "hero-empty": {
+      "@type": "hero"
+    },
+    "hero-cleared": {
+      "@type": "hero",
+      "heading": "",
+      "subheading": "",
+      "buttonText": "",
+      "buttonLink": [],
+      "description": []
+    },
+    "hero-full": {
+      "@type": "hero",
+      "heading": "Populated Hero",
+      "subheading": "Populated subheading",
+      "buttonText": "Populated Button",
+      "buttonLink": [
+        {
+          "@id": "/target-page",
+          "title": "Target Page"
+        }
+      ],
+      "image": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='100%25' height='100%25' fill='%234a90d9'/%3E%3C/svg%3E",
+      "description": [
+        {
+          "type": "p",
+          "children": [{ "text": "Populated description" }]
+        }
+      ]
+    },
+    "anchor-slate": {
+      "@type": "slate",
+      "value": [
+        {
+          "type": "p",
+          "children": [{ "text": "Anchor block" }]
+        }
+      ]
+    }
+  },
+  "blocks_layout": {
+    "items": ["hero-empty", "hero-cleared", "hero-full", "anchor-slate"]
+  },
+  "@components": {
+    "actions": {
+      "@id": "/optional-fields-page/@actions",
+      "object": [
+        {
+          "@id": "/optional-fields-page/edit",
+          "id": "edit",
+          "title": "Edit"
+        }
+      ],
+      "object_buttons": []
+    },
+    "breadcrumbs": {
+      "@id": "/optional-fields-page/@breadcrumbs",
+      "items": [
+        {
+          "@id": "/optional-fields-page",
+          "title": "Optional Fields Page"
+        }
+      ]
+    }
+  }
+}

--- a/tests-playwright/fixtures/content/optional-fields-page/data.json
+++ b/tests-playwright/fixtures/content/optional-fields-page/data.json
@@ -3,6 +3,7 @@
   "@type": "Document",
   "id": "optional-fields-page",
   "title": "Optional Fields Page",
+  "exclude_from_nav": true,
   "description": "Hero blocks with optional fields empty vs populated, for the reveal-optional-fields feature (issue #296). `hero` is the only block that exercises all four sentinel types at once: heading (plain string), subheading (textarea), description (slate), buttonLink (link), image (media). `anchor-slate` is here only so the page has a block-uid in VIEW mode: hero declares its uid in a hydra comment (renderer.js renderBlock), and comments are materialised by the bridge in edit mode only, so an all-hero page renders zero [data-block-uid] after save and AdminUIHelper.waitForIframeReady never settles.",
   "blocks": {
     "hero-empty": {

--- a/tests-playwright/fixtures/content/optional-fields-page/data.json
+++ b/tests-playwright/fixtures/content/optional-fields-page/data.json
@@ -3,7 +3,6 @@
   "@type": "Document",
   "id": "optional-fields-page",
   "title": "Optional Fields Page",
-  "exclude_from_nav": true,
   "description": "Hero blocks with optional fields empty vs populated, for the reveal-optional-fields feature (issue #296). `hero` is the only block that exercises all four sentinel types at once: heading (plain string), subheading (textarea), description (slate), buttonLink (link), image (media). `anchor-slate` is here only so the page has a block-uid in VIEW mode: hero declares its uid in a hydra comment (renderer.js renderBlock), and comments are materialised by the bridge in edit mode only, so an all-hero page renders zero [data-block-uid] after save and AdminUIHelper.waitForIframeReady never settles.",
   "blocks": {
     "hero-empty": {

--- a/tests-playwright/fixtures/test-frontend/renderer.js
+++ b/tests-playwright/fixtures/test-frontend/renderer.js
@@ -669,7 +669,10 @@ function renderHeroBlock(block) {
     const buttonText = block.buttonText || '';
     const buttonLink = getLinkUrl(block.buttonLink);
     const imageSrc = getImageUrl(block.image);
-    const description = block.description || [{ type: 'p', children: [{ text: '' }] }];
+    // Data-driven: no data ⇒ no element (issue #296). Do NOT substitute an empty
+    // paragraph — that renders an editable element for a field with no content and
+    // leaks an empty <p> into view markup.
+    const description = block.description || [];
 
     // Render subheading as textarea (preserve newlines)
     const subheadingHtml = subheading.replace(/\n/g, '<br>');
@@ -692,18 +695,27 @@ function renderHeroBlock(block) {
         }
     });
 
-    // Image with data-edit-media for inline image selection
+    // Data-driven (issue #296): no image ⇒ no element. The grey stand-in that used
+    // to render here was the "always-render" hack — it gave an inline target for an
+    // empty field at the cost of an empty div in view markup.
     const imageHtml = imageSrc
         ? `<img data-edit-media="image" src="${imageSrc}" alt="Hero image" style="max-width: 100%; height: auto; margin-bottom: 10px;" />`
-        : `<div data-edit-media="image" style="width: 100%; height: 150px; background: #e5e5e5; margin-bottom: 10px; border-radius: 4px;"></div>`;
+        : '';
+
+    // The <a> hosts TWO fields (buttonText + buttonLink), so it exists when the
+    // button exists — i.e. when it has a label or a target. This is the case the
+    // per-block `hideButton` flag was papering over.
+    const buttonHtml = (block.buttonText || block.buttonLink)
+        ? `<a data-edit-text="buttonText" data-edit-link="buttonLink" href="${buttonLink}" style="display: inline-block; padding: 10px 20px; background: #007eb1; color: white; text-decoration: none; border-radius: 4px; cursor: pointer;">${buttonText}</a>`
+        : '';
 
     return `
         <div class="hero-block" style="padding: 20px; background: #f0f0f0; border-radius: 8px;">
             ${imageHtml}
-            <h1 data-edit-text="heading">${heading}</h1>
-            <p data-edit-text="subheading" style="font-size: 1.2em; color: #666;">${subheadingHtml}</p>
-            <div class="hero-description" style="margin: 10px 0;">${descriptionHtml}</div>
-            <a data-edit-text="buttonText" data-edit-link="buttonLink" href="${buttonLink}" style="display: inline-block; padding: 10px 20px; background: #007eb1; color: white; text-decoration: none; border-radius: 4px; cursor: pointer;">${buttonText}</a>
+            ${heading ? `<h1 data-edit-text="heading">${heading}</h1>` : ''}
+            ${subheading ? `<p data-edit-text="subheading" style="font-size: 1.2em; color: #666;">${subheadingHtml}</p>` : ''}
+            ${descriptionHtml ? `<div class="hero-description" style="margin: 10px 0;">${descriptionHtml}</div>` : ''}
+            ${buttonHtml}
         </div>
     `;
 }
@@ -721,7 +733,8 @@ function renderHeroBlockClean(block) {
     const buttonText = block.buttonText || '';
     const buttonLink = getLinkUrl(block.buttonLink);
     const imageSrc = getImageUrl(block.image);
-    const description = block.description || [{ type: 'p', children: [{ text: '' }] }];
+    // Data-driven: no data ⇒ no element (issue #296).
+    const description = block.description || [];
 
     // Render subheading as textarea (preserve newlines)
     const subheadingHtml = subheading.replace(/\n/g, '<br>');
@@ -744,19 +757,25 @@ function renderHeroBlockClean(block) {
         }
     });
 
-    // Image - uses class instead of data-edit-media
+    // Image - uses class instead of data-edit-media. Data-driven (issue #296):
+    // no image ⇒ no element, so the comment selector simply matches nothing.
     const imageHtml = imageSrc
         ? `<img class="hero-image" src="${imageSrc}" alt="Hero image" style="max-width: 100%; height: auto; margin-bottom: 10px;" />`
-        : `<div class="hero-image" style="width: 100%; height: 150px; background: #e5e5e5; margin-bottom: 10px; border-radius: 4px;"></div>`;
+        : '';
+
+    // One element, two fields (buttonText + buttonLink) — see renderHeroBlock.
+    const buttonHtml = (block.buttonText || block.buttonLink)
+        ? `<a class="hero-button" href="${buttonLink}" style="display: inline-block; padding: 10px 20px; background: #007eb1; color: white; text-decoration: none; border-radius: 4px; cursor: pointer;">${buttonText}</a>`
+        : '';
 
     // No data-* attributes on fields - comment syntax will add them via selectors
     return `
         <div class="hero-block" style="padding: 20px; background: #f0f0f0; border-radius: 8px;">
             ${imageHtml}
-            <h1 class="hero-heading">${heading}</h1>
-            <p class="hero-subheading" style="font-size: 1.2em; color: #666;">${subheadingHtml}</p>
-            <div class="hero-description" style="margin: 10px 0;">${descriptionHtml}</div>
-            <a class="hero-button" href="${buttonLink}" style="display: inline-block; padding: 10px 20px; background: #007eb1; color: white; text-decoration: none; border-radius: 4px; cursor: pointer;">${buttonText}</a>
+            ${heading ? `<h1 class="hero-heading">${heading}</h1>` : ''}
+            ${subheading ? `<p class="hero-subheading" style="font-size: 1.2em; color: #666;">${subheadingHtml}</p>` : ''}
+            ${descriptionHtml ? `<div class="hero-description" style="margin: 10px 0;">${descriptionHtml}</div>` : ''}
+            ${buttonHtml}
         </div>
     `;
 }

--- a/tests-playwright/helpers/AdminUIHelper.ts
+++ b/tests-playwright/helpers/AdminUIHelper.ts
@@ -2442,6 +2442,21 @@ export class AdminUIHelper {
    * Save the current content being edited.
    * Clicks Save, waits for navigation out of /edit, and waits for iframe to render.
    */
+  /**
+   * Press the quanta toolbar's "reveal optional fields" toggle for the selected
+   * block (issue #296).
+   *
+   * Needed after emptying a field inline: "no data ⇒ no element" means clearing a
+   * media or link field removes its element, so getting an inline target back is
+   * an explicit ask. (Replacing an image doesn't need this — the toolbar's image
+   * button swaps it in one click without clearing first.)
+   */
+  async revealOptionalFields(): Promise<void> {
+    const toggle = this.page.locator('.optional-fields-toggle');
+    await expect(toggle).toBeVisible({ timeout: 5000 });
+    await toggle.click();
+  }
+
   async saveContent(): Promise<void> {
     const saveButton = this.page.locator('#toolbar-save, button:has-text("Save")');
     await saveButton.click();

--- a/tests-playwright/integration/container-edge-drag.spec.ts
+++ b/tests-playwright/integration/container-edge-drag.spec.ts
@@ -325,13 +325,40 @@ test.describe('Container UX: Edge-drag', () => {
     );
     expect(initialParent).toBe('section-1');
 
-    // Drag the bottom handle UPWARD into the container, past the child's midpoint.
+    // Centre the section first. The bottom handle must not START inside hydra's
+    // 80px auto-scroll band (_createAutoScroller): there, the drag holds the cursor
+    // still while the page scrolls underneath, so a target computed from pre-scroll
+    // geometry is never reached and the expel legitimately doesn't fire. Centring
+    // makes this independent of page height — otherwise anything that changes the
+    // page (an extra nav line, a longer title) silently breaks the test.
     const bottomHandle = iframe.locator('.volto-hydra-edge-handle[data-edge="bottom"]');
     await expect(bottomHandle).toBeVisible({ timeout: 3000 });
+    await iframe.locator('[data-block-uid="section-1"]').first().evaluate((el) =>
+      el.scrollIntoView({ block: 'center', behavior: 'instant' }),
+    );
+    // Let the handle follow the scroll before measuring.
+    let settled = '';
+    await expect(async () => {
+      const box = await bottomHandle.boundingBox();
+      const key = JSON.stringify(box);
+      const same = key === settled;
+      settled = key;
+      expect(same).toBe(true);
+    }).toPass({ timeout: 5000 });
+
+    // Drag the bottom handle UPWARD into the container, past the child's midpoint.
     const childRect = await iframe.locator('[data-block-uid="section-child-1"]').boundingBox();
     const handleBox = await bottomHandle.boundingBox();
     expect(childRect).not.toBeNull();
     expect(handleBox).not.toBeNull();
+
+    // Make the precondition explicit, so a regression fails loudly here rather
+    // than showing up as an unexplained "expel didn't happen".
+    const viewportH = await iframe.locator('body').evaluate(() => window.innerHeight);
+    expect(
+      viewportH - (handleBox!.y + handleBox!.height),
+      'bottom handle must start clear of the 80px auto-scroll band',
+    ).toBeGreaterThan(80);
     const startX = handleBox!.x + handleBox!.width / 2;
     const startY = handleBox!.y + handleBox!.height / 2;
     const endY = childRect!.y + childRect!.height / 2 - 5; // upward past child midpoint

--- a/tests-playwright/integration/inline-media-link-editing.spec.ts
+++ b/tests-playwright/integration/inline-media-link-editing.spec.ts
@@ -138,8 +138,18 @@ test.describe('Inline image editing', () => {
     await expect(clearButton).toBeVisible({ timeout: 5000 });
     await clearButton.click();
 
-    // Wait for the image URL to disappear from the rendered block
+    // Clearing REMOVES the element — "no data ⇒ no element" (#296). Deleting an
+    // image has to mean the image is gone, otherwise there's no single action for
+    // "I want no image" and the editor has to dismiss a leftover placeholder.
     const heroMediaEl = iframe.locator('[data-block-uid="block-4-hero"] [data-edit-media="image"]');
+    await expect(heroMediaEl, 'cleared image should render no element').toHaveCount(0, {
+      timeout: 5000,
+    });
+
+    // Getting an inline target back is an explicit ask. (Swapping an image never
+    // needs this — the toolbar image button replaces it without clearing first.)
+    await helper.revealOptionalFields();
+    await expect(heroMediaEl).toHaveCount(1);
     await expect(async () => {
       const src = await heroMediaEl.getAttribute('src');
       expect(src).not.toBe(initialSrc);
@@ -432,7 +442,9 @@ test.describe('Image upload and drag-drop', () => {
     const initialSrc = await heroImage.getAttribute('src');
     await clearButton.click();
 
-    // Wait for image to be cleared
+    // Clearing removes the element (#296) — re-editing it inline is an explicit ask.
+    await expect(heroImage, 'cleared image should render no element').toHaveCount(0);
+    await helper.revealOptionalFields();
     if (initialSrc) {
       await expect(heroImage).not.toHaveAttribute('src', initialSrc, { timeout: 5000 });
     }
@@ -501,7 +513,9 @@ test.describe('Image upload and drag-drop', () => {
     // Click the clear button
     await clearButton.click();
 
-    // Wait for image src to change (cleared) before checking overlay
+    // Clearing removes the element (#296) — re-editing it inline is an explicit ask.
+    await expect(heroImage, 'cleared image should render no element').toHaveCount(0);
+    await helper.revealOptionalFields();
     if (initialSrc) {
       await expect(heroImage).not.toHaveAttribute('src', initialSrc, { timeout: 5000 });
     }
@@ -564,6 +578,10 @@ test.describe('Image upload and drag-drop', () => {
     const clearButton = page.locator('button[aria-label="Clear image"]');
     await expect(clearButton).toBeVisible({ timeout: 5000 });
     await clearButton.click({ force: true });
+
+    // Clearing removes the element (#296) — re-editing it inline is an explicit ask.
+    await expect(heroImage, 'cleared image should render no element').toHaveCount(0);
+    await helper.revealOptionalFields();
 
     // Wait for empty overlay to appear (this is the drop zone)
     const emptyOverlay = page.locator('.empty-image-overlay');
@@ -651,7 +669,9 @@ test.describe('Image upload and drag-drop', () => {
 
     await clearButton.click();
 
-    // Wait for image src to change (cleared) before checking overlay
+    // Clearing removes the element (#296) — re-editing it inline is an explicit ask.
+    await expect(heroImage, 'cleared image should render no element').toHaveCount(0);
+    await helper.revealOptionalFields();
     if (initialSrc) {
       await expect(heroImage).not.toHaveAttribute('src', initialSrc, { timeout: 5000 });
     }

--- a/tests-playwright/integration/optional-fields.spec.ts
+++ b/tests-playwright/integration/optional-fields.spec.ts
@@ -211,13 +211,15 @@ test.describe('Optional fields — reveal toggle (#296)', () => {
     // "No data ⇒ no element" would otherwise make a field a trapdoor: delete the
     // last character and the element the caret sits in stops existing.
     //
-    // For TEXT this already holds without the reveal machinery — hydra suppresses
-    // the re-render for the field being typed in — so this test passes with
-    // keepFieldRevealed disabled. It's kept because the property only started
-    // being AT RISK once renderers went data-driven. The variant that genuinely
-    // depends on keepFieldRevealed is media (clear an image, upload a replacement
-    // into the same overlay); inline-media-link-editing.spec.ts:116/413/475/546/629
-    // cover it and fail outright without it.
+    // It holds without any reveal machinery, because hydra suppresses the
+    // re-render for the field being typed in. Worth pinning even so: the property
+    // only started being AT RISK once renderers went data-driven.
+    //
+    // Note this is text-specific. Emptying a MEDIA field does remove its element,
+    // deliberately — deleting an image has to mean the image is gone, or there's no
+    // single action for "I want no image". Re-adding one inline is an explicit
+    // reveal, and swapping never needs either (the toolbar image button replaces it
+    // in one click). See inline-media-link-editing.spec.ts.
     //
     // hero-full's SUBHEADING is used because it starts POPULATED and owns its
     // element outright, unlike buttonText, whose <a> would survive on buttonLink

--- a/tests-playwright/integration/optional-fields.spec.ts
+++ b/tests-playwright/integration/optional-fields.spec.ts
@@ -1,0 +1,311 @@
+import { test, expect } from '../fixtures';
+import { AdminUIHelper } from '../helpers/AdminUIHelper';
+
+/**
+ * Issue #296 — "empty means absent" for optional block fields.
+ *
+ * The feature (reveal an empty optional field inline, from a toolbar toggle)
+ * rests on renderers being DATA-DRIVEN: a field with no data renders no element.
+ * Today they aren't — both the mock test frontend and the Nuxt example render the
+ * element unconditionally so there's always an inline-edit target:
+ *
+ *   renderer.js:698-705   `<h1 data-edit-text="heading">${heading}</h1>` with `heading || ''`
+ *                         and a grey `<div data-edit-media="image">` stand-in when there's no image
+ *   block.vue:60-71       `<h1 class="hero-heading">`, `<p class="hero-subheading">`, `<a class="hero-button">`
+ *                         unconditional, plus a `v-else` grey `.hero-image` div
+ *
+ * That's hack #1 from the issue ("per-block always-render"), and it leaks empty
+ * elements into VIEW markup. These tests pin the contract that replaces it.
+ *
+ * `hero` is used because it is the only block exercising all four sentinel types
+ * at once — plain string, textarea, slate, link and media.
+ *
+ * EXPECTED TO FAIL until the example renderers are made data-driven.
+ */
+
+/** field name → the attribute the bridge marks it with, and what kind of data it holds. */
+const FIELDS = [
+  { field: 'heading', kind: 'plain string', attr: 'data-edit-text' },
+  { field: 'subheading', kind: 'textarea', attr: 'data-edit-text' },
+  { field: 'description', kind: 'slate', attr: 'data-edit-text' },
+  { field: 'buttonText', kind: 'plain string (in link)', attr: 'data-edit-text' },
+  { field: 'buttonLink', kind: 'link', attr: 'data-edit-link' },
+  { field: 'image', kind: 'media', attr: 'data-edit-media' },
+] as const;
+
+test.describe('Optional fields — empty means absent (#296)', () => {
+  for (const { field, kind, attr } of FIELDS) {
+    test(`empty ${kind} field "${field}" renders no element`, async ({ page }) => {
+      const helper = new AdminUIHelper(page);
+      await helper.login();
+      await helper.navigateToEdit('/optional-fields-page');
+
+      const iframe = helper.getIframe();
+      const selector = `[${attr}="${field}"]`;
+
+      // Control first: the POPULATED hero must render the element. Without this the
+      // test would pass vacuously on a typo'd selector or a block that never rendered.
+      await expect(
+        iframe.locator(`[data-block-uid="hero-full"] ${selector}`),
+        `populated hero should render ${selector} — if this fails the selector or fixture is wrong, not the feature`,
+      ).toHaveCount(1);
+
+      // The actual contract: no data ⇒ no element.
+      await expect(
+        iframe.locator(`[data-block-uid="hero-empty"] ${selector}`),
+        `empty hero must not render ${selector} (${kind}); an always-rendered element leaks into view markup`,
+      ).toHaveCount(0);
+    });
+
+    test(`cleared ${kind} field "${field}" renders no element`, async ({ page }) => {
+      const helper = new AdminUIHelper(page);
+      await helper.login();
+      await helper.navigateToEdit('/optional-fields-page');
+
+      const iframe = helper.getIframe();
+      const selector = `[${attr}="${field}"]`;
+
+      // "Cleared" is a DIFFERENT state from "never set", and it's the one the widgets
+      // actually produce: ObjectBrowserWidget.removeItem writes `[]`, not undefined.
+      // `[]` is truthy in JS, so the natural `if (block.field)` rule a renderer writes
+      // would render an element for a field the editor just emptied. The bridge has to
+      // normalise these away — a renderer must never need `.length` to get this right.
+      await expect(
+        iframe.locator(`[data-block-uid="hero-cleared"] ${selector}`),
+        `cleared hero must not render ${selector} (${kind}); '' / [] must read as absent`,
+      ).toHaveCount(0);
+    });
+  }
+});
+
+/**
+ * The reveal affordance itself. Reveal is ALWAYS EXPLICIT — no auto-reveal on
+ * selection or on insert — so an all-empty block stays an empty box until the
+ * editor presses the toggle.
+ */
+test.describe('Optional fields — reveal toggle (#296)', () => {
+  test('toggle reveals every empty inline-editable field on the selected block', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/optional-fields-page');
+
+    const iframe = helper.getIframe();
+    await helper.clickBlockInIframe('hero-empty');
+
+    // Nothing is revealed until asked — this is the explicit-only contract.
+    for (const { field, attr } of FIELDS) {
+      await expect(
+        iframe.locator(`[data-block-uid="hero-empty"] [${attr}="${field}"]`),
+        `${field} must stay hidden before the toggle is pressed`,
+      ).toHaveCount(0);
+    }
+
+    const toggle = page.locator('.optional-fields-toggle');
+    await expect(toggle, 'quanta toolbar should offer the reveal toggle').toBeVisible({
+      timeout: 5000,
+    });
+    await toggle.click();
+
+    // Every empty inline-editable field now has an element to click.
+    for (const { field, kind, attr } of FIELDS) {
+      await expect(
+        iframe.locator(`[data-block-uid="hero-empty"] [${attr}="${field}"]`),
+        `${field} (${kind}) should be revealed after pressing the toggle`,
+      ).toHaveCount(1);
+    }
+  });
+
+  test('revealed but unfilled fields leave no trace in saved content', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+
+    await helper.login();
+    await helper.navigateToEdit('/optional-fields-page');
+
+    const iframe = helper.getIframe();
+    await helper.clickBlockInIframe('hero-empty');
+    await page.locator('.optional-fields-toggle').click();
+
+    const heading = iframe.locator('[data-block-uid="hero-empty"] [data-edit-text="heading"]');
+    await expect(heading).toHaveCount(1);
+
+    // Step-by-step checks — assert the value is what we think at each stage rather
+    // than only at the end, so a divergence is located instead of inferred.
+
+    // 1. Revealed but unfilled: the seed must read as EMPTY (hydra strips zero-width
+    //    when deciding emptiness), and carry the schema placeholder.
+    await expect(heading).toHaveAttribute('data-empty', '');
+    expect(
+      (await heading.textContent())?.replace(/[​﻿]/g, ''),
+      'revealed-but-unfilled heading should have no visible text',
+    ).toBe('');
+
+    // 2. Let the reveal SETTLE before touching anything. Revealing adds several
+    //    elements at once, so the block grows and the admin mounts chrome over the
+    //    newly-existing fields (a media overlay for the revealed image, repositioned
+    //    outline/toolbar). Clicking into a still-resizing block races that, and the
+    //    caret gets taken away mid-type. Wait for the condition — every revealable
+    //    field present AND the block's geometry unchanged between polls — never a
+    //    fixed sleep.
+    for (const { field, attr } of FIELDS) {
+      await expect(
+        iframe.locator(`[data-block-uid="hero-empty"] [${attr}="${field}"]`),
+        `${field} should be revealed before we start typing`,
+      ).toHaveCount(1);
+    }
+    const blockBox = iframe.locator('[data-block-uid="hero-empty"]');
+    let lastRect = '';
+    await expect(async () => {
+      const box = await blockBox.boundingBox();
+      const rect = JSON.stringify(box);
+      const settled = rect === lastRect;
+      lastRect = rect;
+      expect(settled, 'block geometry should stop changing after reveal').toBe(true);
+    }).toPass({ timeout: 10000 });
+
+    // 3. Clicking it must actually focus it (contenteditable, and the caret is in it).
+    await heading.click();
+    const focused = await iframe.locator('body').evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      return {
+        editField: el?.closest?.('[data-edit-text]')?.getAttribute('data-edit-text') ?? null,
+        editable: el?.isContentEditable ?? false,
+      };
+    });
+    expect(focused, 'click on a revealed field should focus it for editing').toEqual({
+      editField: 'heading',
+      editable: true,
+    });
+
+    // 3. First keystroke: this is where the seeded value stops being empty, so it's
+    //    the moment a re-render would steal focus. Assert BOTH the text and that we
+    //    are still in the field.
+    await page.keyboard.type('F');
+    await expect(heading).toHaveText(/F/, { timeout: 5000 });
+    const stillFocused = await iframe.locator('body').evaluate(
+      () => document.activeElement?.closest?.('[data-edit-text]')?.getAttribute('data-edit-text') ?? null,
+    );
+    expect(stillFocused, 'focus must survive the first keystroke on a revealed field').toBe('heading');
+
+    // 4. The rest of the word.
+    await page.keyboard.type('illed in');
+    await expect(heading).toHaveText(/Filled in/, { timeout: 5000 });
+
+    await helper.saveContent();
+
+    // Check what VIEW actually renders — that's the acceptance criterion
+    // ("revealed-but-unfilled fields render nothing in view"), and it's stronger
+    // than inspecting saved data: it proves no empty element leaked into the page.
+    const savedBlock = iframe.locator('.hero-block').first();
+    await expect(savedBlock).toContainText('Filled in', { timeout: 10000 });
+
+    // Every field left unfilled must have produced NO element at all.
+    await expect(savedBlock.locator('img'), 'unfilled image must not render').toHaveCount(0);
+    await expect(savedBlock.locator('a'), 'unfilled button must not render').toHaveCount(0);
+    await expect(
+      savedBlock.locator('.hero-subheading, .hero-description'),
+      'unfilled subheading/description must not render',
+    ).toHaveCount(0);
+  });
+
+  test('a populated field emptied while editing keeps its element', async ({ page }) => {
+    // "No data ⇒ no element" would otherwise make a field a trapdoor: delete the
+    // last character and the element the caret sits in stops existing.
+    //
+    // For TEXT this already holds without the reveal machinery — hydra suppresses
+    // the re-render for the field being typed in — so this test passes with
+    // keepFieldRevealed disabled. It's kept because the property only started
+    // being AT RISK once renderers went data-driven. The variant that genuinely
+    // depends on keepFieldRevealed is media (clear an image, upload a replacement
+    // into the same overlay); inline-media-link-editing.spec.ts:116/413/475/546/629
+    // cover it and fail outright without it.
+    //
+    // hero-full's SUBHEADING is used because it starts POPULATED and owns its
+    // element outright, unlike buttonText, whose <a> would survive on buttonLink
+    // alone. (Not `heading`: that's a copy-from-target destination, so it displays
+    // the link target's title rather than its stored value.)
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/optional-fields-page');
+
+    const iframe = helper.getIframe();
+    const heading = iframe.locator('[data-block-uid="hero-full"] [data-edit-text="subheading"]');
+    await expect(heading).toHaveText('Populated subheading');
+
+    await heading.click();
+    await expect(async () => {
+      const field = await iframe
+        .locator('body')
+        .evaluate(
+          () =>
+            document.activeElement?.closest?.('[data-edit-text]')?.getAttribute('data-edit-text') ??
+            null,
+        );
+      expect(field).toBe('subheading');
+    }).toPass({ timeout: 5000 });
+
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.press('Backspace');
+
+    // The element must survive being emptied, still editable, with the caret in it.
+    await expect(
+      heading,
+      'the field being edited must not disappear when it becomes empty',
+    ).toHaveCount(1);
+    expect((await heading.textContent())?.replace(/[​﻿]/g, '')).toBe('');
+    const stillFocused = await iframe
+      .locator('body')
+      .evaluate(
+        () =>
+          document.activeElement?.closest?.('[data-edit-text]')?.getAttribute('data-edit-text') ??
+          null,
+      );
+    expect(stillFocused, 'caret must stay in the emptied field').toBe('subheading');
+
+    // And typing continues in place.
+    await page.keyboard.type('Refilled');
+    await expect(heading).toHaveText(/Refilled/, { timeout: 5000 });
+  });
+
+  test('an empty optional field is not reported as a renderer error', async ({ page }) => {
+    // Comment-syntax renderers name each field by CSS selector. Before "no data ⇒
+    // no element", a selector matching nothing always WAS a renderer bug, so hydra
+    // logged console.error. Now it's the correct outcome for an empty field, and
+    // erroring on it would train devs to ignore the console — which is where the
+    // genuine version of this warning has to land (content, or a revealed sentinel,
+    // with no element).
+    const selectorErrors: string[] = [];
+    page.on('console', (m) => {
+      if (m.type() === 'error' && m.text().includes('Comment selector')) {
+        selectorErrors.push(m.text());
+      }
+    });
+
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/optional-fields-page');
+
+    // The populated hero proves the comment path ran at all, so an empty error list
+    // can't just mean "nothing was materialised".
+    await expect(
+      helper.getIframe().locator('[data-block-uid="hero-full"] [data-edit-text="heading"]'),
+    ).toHaveCount(1);
+
+    expect(
+      selectorErrors,
+      'empty optional fields render no element by design — that must not be logged as an error',
+    ).toEqual([]);
+  });
+
+  test('toggle does not appear on a block with nothing to reveal', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit('/optional-fields-page');
+
+    await helper.clickBlockInIframe('hero-full');
+
+    await expect(
+      page.locator('.optional-fields-toggle'),
+      'a fully populated block has no empty optional fields, so no toggle',
+    ).toHaveCount(0);
+  });
+});

--- a/tests-playwright/integration/slash-menu.spec.ts
+++ b/tests-playwright/integration/slash-menu.spec.ts
@@ -73,9 +73,14 @@ test.describe('Slash Menu', () => {
     // Slash menu should close
     await expect(slashMenu).not.toBeVisible({ timeout: 5000 });
 
-    // Block should now be a hero block (hero-heading appears inside the block)
-    const heroHeading = iframe.locator(`[data-block-uid="${blockId}"] .hero-heading`);
-    await expect(heroHeading).toBeVisible({ timeout: 5000 });
+    // Block should now be a hero block. Assert the block's OWN class, not a child
+    // field element: a freshly converted hero has no field data, and fields are
+    // data-driven (issue #296), so `.hero-heading` no longer renders. The wrapper
+    // is the direct signal for "this block is a hero" anyway.
+    await expect(
+      iframe.locator(`[data-block-uid="${blockId}"]`),
+      'block should have been converted to a hero',
+    ).toHaveClass(/hero-block/, { timeout: 5000 });
   });
 
   test('Escape dismisses slash menu', async ({ page }) => {
@@ -213,8 +218,11 @@ test.describe('Slash Menu', () => {
     // Slash menu should close
     await expect(slashMenu).not.toBeVisible({ timeout: 5000 });
 
-    // Block should now be a hero block (hero-heading appears inside the block)
-    const heroHeading = iframe.locator(`[data-block-uid="${blockId}"] .hero-heading`);
-    await expect(heroHeading).toBeVisible({ timeout: 5000 });
+    // Block should now be a hero block. Assert the block's OWN class, not a child
+    // field element — see the Enter-selects test above for why.
+    await expect(
+      iframe.locator(`[data-block-uid="${blockId}"]`),
+      'block should have been converted to a hero',
+    ).toHaveClass(/hero-block/, { timeout: 5000 });
   });
 });


### PR DESCRIPTION
Closes #296.

## What

Optional block fields are data-driven in view — blank means absent — but that leaves no inline target when the field is empty. We worked around it two ways, both per-block: always-render the element (leaking empty markup into view), or add a boolean field whose only job is to reveal another field.

This adds a generic **reveal toggle** to the quanta toolbar. **Renderers change nothing**: the bridge seeds a shape-preserving sentinel into a *projection* of the form data, so the renderer's own `{field && …}` rule produces the element.

## How

- **`_projectForRender`** at the single `_executeRender` handoff. Sentinels never enter `this.formData`, so echo detection stays truthful and the save path needs no strip step. The same projection collapses a widget-cleared `[]` to absent — `ObjectBrowserWidget.removeItem` writes `[]`, which is truthy, so without this every renderer would need `.length` to tell cleared from set.
- **Sentinels keyed by widget**, unwrapping the admin's `copyFromTargetField` decoration first: `object_browser` gets an array of refs, media a sized transparent SVG, text/url a ZWS, slate a one-paragraph doc. A bare string in an `object_browser` field would make renderers iterate characters.
- **Discovery is pure schema + data.** A DOM query ("is there no element?") is a question reveal itself falsifies, so the field flickers straight back out.
- **Reveal state is per field.** The toggle reveals all of a block's empty optional fields; editing reveals exactly the one in play. `keepFieldRevealed` keeps the edited field alive so emptying it can't delete its own element — without it, the X on an image overlay removes the target you'd upload the replacement into. Safe because a focused field implies an element that already exists, so it can never materialise a new one.
- **Comment-selector warnings corrected** to fire only when the field *has* content in what was rendered. "No data ⇒ no element" made the old unconditional `console.error` a false alarm; the new rule also covers reveal, since a seeded sentinel counts as content.

Hero is made data-driven across the mock frontend, the Nuxt example and the react/vue/svelte doc examples, guarded on raw field truthiness only — no `.length`, no `getUrl()`.

## Tests

| Suite | Result |
|---|---|
| `optional-fields.spec.ts` (new, 17) | green on **admin-mock** and **admin-nuxt** |
| `inline-media-link-editing.spec.ts` (46) | green — the 5 clear-then-reupload tests pass **unmodified** |
| `inline-editing-fields` + `inline-editing-placeholders` (15) | green |

Those 5 media tests are the honest proof of `keepFieldRevealed`: they pass on `main`, fail once hero goes data-driven, and pass again with it. No assertion was weakened. The one changed existing spec is `slash-menu.spec.ts`, where two assertions moved from a `.hero-heading` descendant to the block itself, since an empty hero no longer renders a heading.

## Not in this PR

- The general `#hydra-dev-warning` guard for "sentinel seeded but no element materialised" — only the comment-syntax path warns today.
- Coverage for `slide` / `highlight` / `objectBlocks` (nested + container cases), and removing `slide.hideButton`.

## Review notes

Locally I ran only the four suites above. The hero change touches every frontend, so the doc-example bridge projects (react/svelte/vue) and the container suites are unverified here — if CI reds, that's where to look first.

Two traps worth knowing, both of which cost a debugging round:

- **hero's `heading` is a copy-from-target destination** (hero → heading/subheading/image, on by default for any block with a link field), so a populated hero renders the *link target's* title, not its stored value. Use `subheading` for "populated field" assertions.
- **A fixture page of only comment-syntax blocks has no `[data-block-uid]` in view mode** — the uid is declared in a hydra comment and comments are materialised in edit mode only, so `waitForIframeReady` never settles and `saveContent()` hangs. `optional-fields-page` carries one plain `slate` block as an anchor for this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTYzaaivqmGsem6U49yatY
