### PR TITLE
Content validator: derive parent hierarchy from @id, not the directory path

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
-    "test:api": "node --test tests-playwright/fixtures/mock-api-server.test.cjs",
+    "test:api": "node --test tests-playwright/fixtures/*.test.cjs",
     "check:docs": "node docs/examples/check-examples.mjs",
     "sync:docs": "node docs/sync.mjs",
     "sync:docs:check": "node docs/sync.mjs --check",

--- a/tests-playwright/fixtures/plone-content-validator.cjs
+++ b/tests-playwright/fixtures/plone-content-validator.cjs
@@ -17,6 +17,25 @@
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * Content ids that break their PARENT, not themselves.
+ *
+ * `BTreeFolder2Base.__getattr__` resolves an attribute miss out of `self._tree`,
+ * so a child whose id matches a name Plone reads off the container with
+ * `getattr(aq_base(container), name)` is returned instead of that attribute.
+ * Plone content is callable, so code like CMFDynamicViewFTI's
+ * `if safe_callable(layout): layout = layout()` then invokes the child on an
+ * acquisition-stripped object and dies in `aq_acquire(self, 'REQUEST')` —
+ * surfacing as a 500 on the container, with nothing wrong in the child.
+ *
+ * Only names that Dexterity does NOT keep as instance attributes are listed:
+ * an attribute that already exists never reaches `__getattr__`. `layout` is the
+ * one confirmed against a live site (it 500'd /components and is covered by
+ * tests/test_reserved_content_ids.py); the others are the same read pattern in
+ * CMFPlone/CMFDynamicViewFTI and are reserved to prevent a repeat.
+ */
+const RESERVED_CONTENT_IDS = new Set(['layout', 'default_page', 'index_html']);
+
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
@@ -153,6 +172,12 @@ function validate(contentDir) {
       errors.push(`  ${entry} has empty id`);
     } else if (/^_/.test(data.id)) {
       errors.push(`  ${entry} id "${data.id}" starts with underscore (Plone OFS rejects this at import)`);
+    } else if (RESERVED_CONTENT_IDS.has(data.id)) {
+      errors.push(
+        `  ${entry} id "${data.id}" is reserved — it shadows an attribute Plone ` +
+        `reads off the container, which makes the PARENT return 500 ` +
+        `(AttributeError). Rename it (e.g. "page-${data.id}").`,
+      );
     }
     if (data.UID) allUids.add(data.UID);
 
@@ -176,30 +201,51 @@ function validate(contentDir) {
     }
   }
 
-  // Every non-root listing should have its parent container also listed
-  for (const entry of listed) {
-    const parts = entry.split('/');
-    if (parts.length > 2 && parts[0] !== 'plone_site_root') {
-      const parentEntry = parts.slice(0, -2).join('/') + '/data.json';
-      if (!listed.has(parentEntry)) {
-        errors.push(`  ${entry} parent container missing: ${parentEntry}`);
-      }
-    }
-  }
-
-  // Ordering: parents must appear before their children in _data_files_
+  // Parent containers must be listed, and must be listed BEFORE their children.
+  //
+  // plone.exportimport walks _data_files_ in order and skips any object whose
+  // container does not exist yet — logging a WARNING, not an error, while
+  // create-site still exits 0. A mis-ordered manifest therefore ships a partial
+  // site with every gate green (this cost us 90 of 150 objects once).
+  //
+  // Derive the hierarchy from each item's `@id`, NOT from its directory path.
+  // Real distributions are UID-keyed and flat (`<uid>/data.json`), so the path
+  // carries no hierarchy at all and a path-derived parent silently no-ops —
+  // which is exactly why the check above it never fired. `@id` works for both
+  // the flat and the path-shaped layout.
   const listedList = meta._data_files_ || [];
-  const seenParents = new Set();
+  const entryId = new Map();
   for (const entry of listedList) {
-    const parts = entry.split('/');
-    if (parts.length > 2 && parts[0] !== 'plone_site_root') {
-      const parentEntry = parts.slice(0, -2).join('/') + '/data.json';
-      if (listed.has(parentEntry) && !seenParents.has(parentEntry)) {
-        errors.push(`  ${entry} appears before its parent ${parentEntry} in _data_files_`);
-      }
+    const entryPath = path.join(contentDir, entry);
+    if (!fs.existsSync(entryPath)) continue;  // reported by the on-disk check below
+    const atId = readJson(entryPath)['@id'];
+    if (typeof atId !== 'string' || !atId) {
+      errors.push(`  ${entry} has no @id — hierarchy cannot be determined`);
+      continue;
     }
-    seenParents.add(entry);
+    entryId.set(entry, atId);
   }
+  const idPosition = new Map();
+  listedList.forEach((entry, index) => {
+    const atId = entryId.get(entry);
+    if (atId !== undefined && !idPosition.has(atId)) idPosition.set(atId, index);
+  });
+  listedList.forEach((entry, index) => {
+    const atId = entryId.get(entry);
+    if (atId === undefined) return;
+    // A top-level item's parent is the site root, which always exists before
+    // content import begins.
+    const parentAtId = atId.slice(0, atId.lastIndexOf('/'));
+    if (!parentAtId) return;
+    const parentPosition = idPosition.get(parentAtId);
+    if (parentPosition === undefined) {
+      errors.push(`  ${entry} (${atId}) parent container missing: ${parentAtId}`);
+    } else if (parentPosition > index) {
+      errors.push(
+        `  ${entry} (${atId}) appears before its parent ${parentAtId} in _data_files_`,
+      );
+    }
+  });
 
   // Listed entries must exist on disk
   for (const entry of listed) {
@@ -448,18 +494,21 @@ function checkIntegrity(contentDir) {
     }
   }
 
-  // Parent containers (metadata cross-check for completeness)
+  // Parent containers (metadata cross-check for completeness). Uses the `@id`
+  // hierarchy via pathMap, not the directory path — see validate()'s note: our
+  // content is UID-keyed and flat, so a path-derived parent never resolves.
   const metaPath = path.join(contentDir, '__metadata__.json');
   if (fs.existsSync(metaPath)) {
     const meta = readJson(metaPath);
-    const listed = new Set(meta._data_files_ || []);
-    for (const entry of listed) {
-      const parts = entry.split('/');
-      if (parts.length > 2 && parts[0] !== 'plone_site_root') {
-        const parentEntry = parts.slice(0, -2).join('/') + '/data.json';
-        if (!listed.has(parentEntry)) {
-          errors.push(`  ${entry}: parent container missing (${parentEntry})`);
-        }
+    for (const entry of meta._data_files_ || []) {
+      const entryPath = path.join(contentDir, entry);
+      if (!fs.existsSync(entryPath)) continue;
+      const atId = readJson(entryPath)['@id'];
+      if (typeof atId !== 'string' || !atId) continue;  // validate() reports this
+      const parentAtId = atId.slice(0, atId.lastIndexOf('/'));
+      if (!parentAtId) continue;  // top-level: parent is the site root
+      if (!pathMap.has(parentAtId)) {
+        errors.push(`  ${entry}: parent container missing (${parentAtId})`);
       }
     }
   }

--- a/tests-playwright/fixtures/plone-content-validator.test.cjs
+++ b/tests-playwright/fixtures/plone-content-validator.test.cjs
@@ -144,6 +144,109 @@ describe('plone-content-validator validate()', () => {
     );
   });
 
+  // The two tests above use path-shaped directories (section/child/data.json).
+  // Real distributions are UID-keyed and FLAT — every data.json sits in its own
+  // <uid>/ dir and the hierarchy lives ONLY in the `@id` field. Deriving the
+  // parent from the directory path silently no-ops on that layout, which is how
+  // 90 of 150 objects got dropped at import with nothing going red.
+  it('reports child before parent in a UID-keyed (flat) layout', () => {
+    const { root, contentDir } = buildFixture({
+      dataFiles: [
+        'plone_site_root/data.json',
+        'childuid12345678/data.json',   // /components/card — child first
+        'parentuid1234567/data.json',   // /components      — parent second
+      ],
+    });
+    const flat = {
+      childuid12345678: { '@id': '/components/card', id: 'card' },
+      parentuid1234567: { '@id': '/components', id: 'components' },
+    };
+    for (const [uid, item] of Object.entries(flat)) {
+      fs.mkdirSync(path.join(contentDir, uid), { recursive: true });
+      fs.writeFileSync(
+        path.join(contentDir, uid, 'data.json'),
+        JSON.stringify({ ...item, '@type': 'Document', UID: uid }),
+      );
+    }
+    const r = validate(contentDir);
+    cleanup(root);
+    assert.ok(
+      r.errors.some((e) => e.includes('appears before its parent')),
+      r.errors.join('\n'),
+    );
+  });
+
+  it('reports a missing parent container in a UID-keyed (flat) layout', () => {
+    const { root, contentDir } = buildFixture({
+      dataFiles: ['plone_site_root/data.json', 'orphanuid1234567/data.json'],
+    });
+    fs.mkdirSync(path.join(contentDir, 'orphanuid1234567'), { recursive: true });
+    fs.writeFileSync(
+      path.join(contentDir, 'orphanuid1234567', 'data.json'),
+      JSON.stringify({
+        '@id': '/editing/pages', '@type': 'Document', id: 'pages', UID: 'orphanuid1234567',
+      }),
+    );
+    const r = validate(contentDir);
+    cleanup(root);
+    assert.ok(
+      r.errors.some((e) => e.includes('parent container missing')),
+      r.errors.join('\n'),
+    );
+  });
+
+  it('accepts a correctly ordered UID-keyed (flat) layout', () => {
+    const { root, contentDir } = buildFixture({
+      dataFiles: [
+        'plone_site_root/data.json',
+        'parentuid1234567/data.json',   // parent first
+        'childuid12345678/data.json',   // child second
+      ],
+    });
+    const flat = {
+      parentuid1234567: { '@id': '/components', id: 'components' },
+      childuid12345678: { '@id': '/components/card', id: 'card' },
+    };
+    for (const [uid, item] of Object.entries(flat)) {
+      fs.mkdirSync(path.join(contentDir, uid), { recursive: true });
+      fs.writeFileSync(
+        path.join(contentDir, uid, 'data.json'),
+        JSON.stringify({ ...item, '@type': 'Document', UID: uid }),
+      );
+    }
+    const r = validate(contentDir);
+    cleanup(root);
+    assert.ok(
+      !r.errors.some((e) => e.includes('appears before its parent') || e.includes('parent container missing')),
+      r.errors.join('\n'),
+    );
+  });
+
+  // A child whose id shadows an attribute the FTI machinery reads makes its
+  // CONTAINER un-serializable: BTreeFolder2Base.__getattr__ resolves the name
+  // out of _tree, so getViewMethod's `getattr(aq_base(context), "layout")`
+  // returns the child object, calls it unwrapped, and plone.restapi 500s with
+  // `AttributeError: REQUEST`. /components died this way in production.
+  it('reports a content id that shadows the layout attribute', () => {
+    const { root, contentDir } = buildFixture({
+      dataFiles: ['plone_site_root/data.json', 'shadowuid1234567/data.json'],
+    });
+    fs.mkdirSync(path.join(contentDir, 'shadowuid1234567'), { recursive: true });
+    fs.writeFileSync(
+      path.join(contentDir, 'shadowuid1234567', 'data.json'),
+      JSON.stringify({
+        '@id': '/page-a/layout', '@type': 'Document', id: 'layout',
+        UID: 'shadowuid1234567',
+      }),
+    );
+    const r = validate(contentDir);
+    cleanup(root);
+    assert.ok(
+      r.errors.some((e) => e.includes('reserved')),
+      r.errors.join('\n'),
+    );
+  });
+
   it('reports id starting with underscore', () => {
     const { root, contentDir } = buildFixture({
       dataFiles: ['plone_site_root/data.json', '_underscore/data.json'],


### PR DESCRIPTION
## The bug

`validate()`'s parent-container and `_data_files_` ordering checks were both guarded on:

```js
const parts = entry.split('/');
if (parts.length > 2 && parts[0] !== 'plone_site_root') {
  const parentEntry = parts.slice(0, -2).join('/') + '/data.json';
  ...
```

That only holds for **path-shaped** entries like `section/child/data.json`. Real
distributions are **UID-keyed and flat** — `<uid>/data.json` — with the hierarchy
living only in each item's `@id`. So `parts.length` is always 2, the guard is never
true, and both checks were dead code. `checkIntegrity()` had a third copy of the
same dead guard.

The existing ordering test used a path-shaped fixture, so it passed while the
layout that actually ships went unchecked.

## Why it matters

`plone.exportimport` walks `_data_files_` **in list order** and skips any object
whose container does not exist yet — logging a `WARNING`, not an error, while
`create-site` still exits `0`:

```
WARNING:plone.exportimport:Container /components for /components/card not found
WARNING:plone.exportimport:Skipping /components/card creation
```

A manifest of ours had 68 entries listed before their parent. The result was a
deployed site missing **90 of 150 objects** — 20 documents and 70 images — with
every gate green and the frontend serving HTTP 200. `validate` exited 0 throughout.

With this change the same manifest exits 1 and names all 68.

## Changes

- Derive the parent from each item's `@id` instead of its directory path. Works
  for the flat *and* the path-shaped layout, so it subsumes the old checks rather
  than adding a second mechanism. Applied to `checkIntegrity()`'s copy too.
- Report a listed entry with no `@id`, since hierarchy can't be determined without it.
- Reject content ids that shadow an attribute Plone reads off the **container**:
  `layout`, `default_page`, `index_html`. `BTreeFolder2Base.__getattr__` resolves an
  attribute miss out of `self._tree`, so a child page id'd `layout` is returned
  instead of the layout name; Plone content is callable, so CMFDynamicViewFTI's
  `if safe_callable(layout): layout = layout()` invokes it acquisition-stripped and
  `unrestrictedTraverse` dies in `aq_acquire(self, 'REQUEST')`. The **parent** 500s
  with nothing wrong in the child — this took out a whole landing page in production
  (`plone.restapi.serializer.dxcontent` → `context.getLayout()`).
  Only `layout` is confirmed against a live site; the other two are the same read
  pattern and are reserved to prevent a repeat.

## Tests

Four new cases, each of which fails without the corresponding fix:

- child before parent in a UID-keyed (flat) layout
- missing parent container in a UID-keyed (flat) layout
- a correctly ordered flat layout is accepted (guards against over-firing)
- a content id that shadows `layout`

22/22 pass. The pre-existing path-shaped tests still pass unchanged, confirming the
`@id` approach covers both layouts.

## Also: these tests were never running in CI

While verifying the above, `test:api` turned out to name a single file:

```
node --test tests-playwright/fixtures/mock-api-server.test.cjs
```

`plone-content-validator.test.cjs` was executed by nothing — vitest doesn't collect
it either (`include` covers `packages/volto-hydra/**` and `packages/helpers/**`, not
`tests-playwright/**`). So the validator's 18 existing tests had never run in CI, and
the 4 added here would have gone green without executing.

`test:api` now points at the directory: **18 tests → 40**, and future fixtures tests
are picked up automatically.

Same failure as the one this PR fixes, one level up: a check that looks present,
reports success, and never runs.
