### PR TITLE
Encode listing depth on the path criterion, not as a top-level field

### DIFF
--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -241,12 +241,21 @@ export function buildQuerystringSearchBody(
     metadata_fields: '_all',
   };
 
-  // Add depth if specified — Plone catalog supports a top-level depth
-  // field that limits results to N levels under each path criterion.
-  // Used by contextNavigation's listing config so a path+depth combo
-  // returns only the right tree slice.
+  // Depth belongs ON the path criterion, encoded in its VALUE as `path::depth`
+  // (`.::1`, `/docs::2`); a bare path is a recursive query. A top-level `depth`
+  // field on the request body is NOT honoured by @querystring-search — it is
+  // accepted and silently ignored, and inside the criterion as an object it
+  // errors with "index 'UID': option 'depth' is not valid".
+  //
+  // This used to set `body.depth` and so did nothing: a listing configured with
+  // depth 1 still matched the whole subtree, which put every nested Image into
+  // the /components index (`.` → 107 items, `.::1` → 33).
   if (queryConfig?.depth !== undefined) {
-    body.depth = queryConfig.depth;
+    for (const criterion of body.query) {
+      if (criterion.i !== 'path') continue;
+      if (typeof criterion.v !== 'string' || criterion.v.includes('::')) continue;
+      criterion.v = `${criterion.v}::${queryConfig.depth}`;
+    }
   }
 
   // Add limit if specified (0 or undefined means no limit)

--- a/packages/helpers/index.test.js
+++ b/packages/helpers/index.test.js
@@ -228,3 +228,86 @@ describe('buildQuerystringSearchBody — date-facet edge cases', () => {
     expect(criteria(body, 'created.after')).toHaveLength(0);
   });
 });
+
+describe('buildQuerystringSearchBody — depth', () => {
+  // Plone encodes path-criterion depth in the criterion VALUE as `path::depth`
+  // (`.::1`, `/docs::2`). A bare path is a recursive query. The top-level `depth`
+  // field on the request body is NOT honoured by @querystring-search — the mock
+  // API says so explicitly (verified against demo.plone.org) and the live backend
+  // agrees: `.` returns 107 items under /components, `.::1` returns 33.
+  //
+  // Sending the ignored top-level field is what put every nested Image into the
+  // /components index.
+  test('depth is encoded onto the path criterion, not sent as a top-level field', () => {
+    const body = buildQuerystringSearchBody(
+      {
+        depth: 1,
+        query: [
+          {
+            i: 'path',
+            o: 'plone.app.querystring.operation.string.relativePath',
+            v: '.',
+          },
+        ],
+      },
+      {},
+      {},
+    );
+    expect(criterion(body, 'path').v).toBe('.::1');
+    expect(body.depth).toBeUndefined();
+  });
+
+  test('an absolute path criterion gets the same encoding', () => {
+    const body = buildQuerystringSearchBody(
+      {
+        depth: 2,
+        query: [
+          {
+            i: 'path',
+            o: 'plone.app.querystring.operation.string.absolutePath',
+            v: '/docs',
+          },
+        ],
+      },
+      {},
+      {},
+    );
+    expect(criterion(body, 'path').v).toBe('/docs::2');
+  });
+
+  test('a depth already in the value is left alone', () => {
+    const body = buildQuerystringSearchBody(
+      {
+        depth: 5,
+        query: [
+          {
+            i: 'path',
+            o: 'plone.app.querystring.operation.string.relativePath',
+            v: '.::1',
+          },
+        ],
+      },
+      {},
+      {},
+    );
+    expect(criterion(body, 'path').v).toBe('.::1');
+  });
+
+  test('no depth leaves the path criterion recursive', () => {
+    const body = buildQuerystringSearchBody(
+      {
+        query: [
+          {
+            i: 'path',
+            o: 'plone.app.querystring.operation.string.relativePath',
+            v: '.',
+          },
+        ],
+      },
+      {},
+      {},
+    );
+    expect(criterion(body, 'path').v).toBe('.');
+    expect(body.depth).toBeUndefined();
+  });
+});


### PR DESCRIPTION
`buildQuerystringSearchBody` set `body.depth` from `queryConfig.depth`, with a
comment stating "Plone catalog supports a top-level depth field". It does not.
@querystring-search accepts the field and silently ignores it, so every listing
configured with a depth still matched its whole subtree.

The mock API already had this right, and said so:

    // The top-level `depth` field on the request body is NOT honoured by
    // Plone's @querystring-search — verified against demo.plone.org — so it
    // is deliberately ignored here.

It implements the real encoding — depth lives in the criterion VALUE as
`path::depth` (`.::1`, `/docs::2`), a bare path being recursive. The helper and
the mock therefore disagreed, and the helper was the one that was wrong.

Confirmed against a live Plone 6 backend, POSTing to
`/++api++/components/@querystring-search`:

    v: "."      → 107 items (34 Document, 72 Image, 1 File), 74 nested
    v: ".::1"   →  33 items (33 Document),                    0 nested
    top-level depth: 1        → 107, identical to no depth at all
    {query, depth: 1} in `v`  → 400, "index 'UID': option 'depth' is not valid"

Real impact: a docs site's /components index listed every nested Image under
/components/*/ ahead of the component pages, because they sort earlier by title.

Translate `queryConfig.depth` onto each path criterion instead. A value that
already carries `::` is left alone, so an explicitly-encoded depth wins.

Tests: four cases in packages/helpers/index.test.js (relative and absolute paths,
an already-encoded value, and no depth at all). The first two fail before this
change. 260 vitest tests and 40 mock-api tests pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr