### PR TITLE
docs: clarify that only `fieldMapping` (singular, on the block) is read at render

### DIFF
--- a/docs/content/content/content/docs/listings/data.json
+++ b/docs/content/content/content/docs/listings/data.json
@@ -2013,7 +2013,7 @@
     },
     "p-33": {
       "@type": "slate",
-      "plaintext": "`filterConvertibleFrom: '@default'` restricts the dropdown to types that have a `fieldMappings['@default']` entry — i.e. types that can be populated from the canonical content fields (`@id`, `title`, `description`, `image`) that listing queries return. Each item type's `fieldMappings['@default']` (on its own block config) defines how those source fields land on its schema; that static mapping is enough to render listings. Adding `mappingField` to the enhancer exposes the `FieldMappingWidget` so the editor can override the mapping per listing instance.",
+      "plaintext": "`filterConvertibleFrom: '@default'` restricts the dropdown to types that have a `fieldMappings['@default']` entry — i.e. types that can be populated from the canonical content fields (`@id`, `title`, `description`, `image`) that listing queries return. Each item type's `fieldMappings['@default']` (on its own block config) defines how those source fields land on its schema. Adding `mappingField` to the enhancer exposes the `FieldMappingWidget` so the editor can override the mapping per listing instance.",
       "value": [
         {
           "type": "p",
@@ -2093,7 +2093,7 @@
               ]
             },
             {
-              "text": " (on its own block config) defines how those source fields land on its schema; that static mapping is enough to render listings. Adding "
+              "text": " (on its own block config) defines how those source fields land on its schema. Adding "
             },
             {
               "type": "code",
@@ -2121,15 +2121,48 @@
         }
       ]
     },
-    "p-34": {
+    "h-34": {
       "@type": "slate",
-      "plaintext": "The widget saves its output as `fieldMapping` (singular) on the block data. `expandListingBlocks` reads that at render time to translate each query result into an item block.",
+      "plaintext": "Where the mapping lives",
+      "value": [
+        {
+          "type": "h3",
+          "children": [
+            {
+              "text": "Where the mapping lives"
+            }
+          ]
+        }
+      ]
+    },
+    "p-35": {
+      "@type": "slate",
+      "plaintext": "`fieldMappings` (plural, on a **block config**) and `fieldMapping` (singular, on **block data**) are different things, and only the singular one is read at render:",
       "value": [
         {
           "type": "p",
           "children": [
             {
-              "text": "The widget saves its output as "
+              "type": "code",
+              "children": [
+                {
+                  "text": "fieldMappings"
+                }
+              ]
+            },
+            {
+              "text": " (plural, on a "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "block config"
+                }
+              ]
+            },
+            {
+              "text": ") and "
             },
             {
               "type": "code",
@@ -2140,7 +2173,297 @@
               ]
             },
             {
-              "text": " (singular) on the block data. "
+              "text": " (singular, on "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "text": "block data"
+                }
+              ]
+            },
+            {
+              "text": ") are different things, and only the singular one is read at render:"
+            }
+          ]
+        }
+      ]
+    },
+    "tbl-36": {
+      "@type": "slateTable",
+      "table": {
+        "fixed": true,
+        "compact": false,
+        "basic": false,
+        "celled": true,
+        "inverted": false,
+        "striped": false,
+        "rows": [
+          {
+            "key": "tbl-36-r0",
+            "cells": [
+              {
+                "key": "tbl-36-r0c0",
+                "type": "header",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": ""
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-36-r0c1",
+                "type": "header",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "fieldMappings['@default']"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-36-r0c2",
+                "type": "header",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "fieldMapping"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "key": "tbl-36-r1",
+            "cells": [
+              {
+                "key": "tbl-36-r1c0",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "Lives on"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-36-r1c1",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "the item type's block config"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-36-r1c2",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "the listing block's saved data"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "key": "tbl-36-r2",
+            "cells": [
+              {
+                "key": "tbl-36-r2c0",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "Used by"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-36-r2c1",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "FieldMappingWidget"
+                          }
+                        ]
+                      },
+                      {
+                        "text": ", while "
+                      },
+                      {
+                        "type": "strong",
+                        "children": [
+                          {
+                            "text": "editing"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-36-r2c2",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "type": "code",
+                        "children": [
+                          {
+                            "text": "expandListingBlocks"
+                          }
+                        ]
+                      },
+                      {
+                        "text": ", at "
+                      },
+                      {
+                        "type": "strong",
+                        "children": [
+                          {
+                            "text": "render"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "key": "tbl-36-r3",
+            "cells": [
+              {
+                "key": "tbl-36-r3c0",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "Role"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-36-r3c1",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "seeds the widget's smart defaults for the chosen item type"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "tbl-36-r3c2",
+                "type": "data",
+                "value": [
+                  {
+                    "type": "p",
+                    "children": [
+                      {
+                        "text": "the mapping actually applied to query results"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "p-37": {
+      "@type": "slate",
+      "plaintext": "The registry mapping is an *editing-time* input: it decides what the widget proposes for the selected `variation`. `expandListingBlocks` never reads a block config — it reads `block.fieldMapping`, and when that is absent falls back to its own default, `{ @id → href, title, description, image }`.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "The registry mapping is an "
+            },
+            {
+              "type": "em",
+              "children": [
+                {
+                  "text": "editing-time"
+                }
+              ]
+            },
+            {
+              "text": " input: it decides what the widget proposes for the selected "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "variation"
+                }
+              ]
+            },
+            {
+              "text": ". "
             },
             {
               "type": "code",
@@ -2151,13 +2474,241 @@
               ]
             },
             {
-              "text": " reads that at render time to translate each query result into an item block."
+              "text": " never reads a block config — it reads "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "block.fieldMapping"
+                }
+              ]
+            },
+            {
+              "text": ", and when that is absent falls back to its own default, "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "{ @id → href, title, description, image }"
+                }
+              ]
+            },
+            {
+              "text": "."
             }
           ]
         }
       ]
     },
-    "h-35": {
+    "p-38": {
+      "@type": "slate",
+      "plaintext": "That fallback targets `href`, which suits `link`-shaped item types and not others. A `card`, for example, renders its link from `url`, so a listing of cards with no saved `fieldMapping` produces cards with no link at all.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "That fallback targets "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "href"
+                }
+              ]
+            },
+            {
+              "text": ", which suits "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "link"
+                }
+              ]
+            },
+            {
+              "text": "-shaped item types and not others. A "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "card"
+                }
+              ]
+            },
+            {
+              "text": ", for example, renders its link from "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "url"
+                }
+              ]
+            },
+            {
+              "text": ", so a listing of cards with no saved "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "fieldMapping"
+                }
+              ]
+            },
+            {
+              "text": " produces cards with no link at all."
+            }
+          ]
+        }
+      ]
+    },
+    "p-39": {
+      "@type": "slate",
+      "plaintext": "Two ways to end up with no saved mapping:",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Two ways to end up with no saved mapping:"
+            }
+          ]
+        }
+      ]
+    },
+    "ul-40": {
+      "@type": "slate",
+      "plaintext": "Hand-authored content. A listing block written directly into a distribution or fixture JSON never passes through the widget, so nothing is saved. Author fieldMapping explicitly. An untouched widget. FieldMappingWidget displays { ...smartDefaults, ...saved }, but only persists rows the editor actually changes. Accepting every proposed default without touching a row leaves fieldMapping empty — the sidebar shows one mapping while the page renders with another.",
+      "value": [
+        {
+          "type": "ul",
+          "children": [
+            {
+              "type": "li",
+              "children": [
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "text": "Hand-authored content."
+                    }
+                  ]
+                },
+                {
+                  "text": " A listing block written directly into a distribution or fixture JSON never passes through the widget, so nothing is saved. Author "
+                },
+                {
+                  "type": "code",
+                  "children": [
+                    {
+                      "text": "fieldMapping"
+                    }
+                  ]
+                },
+                {
+                  "text": " explicitly."
+                }
+              ]
+            },
+            {
+              "type": "li",
+              "children": [
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "text": "An untouched widget."
+                    }
+                  ]
+                },
+                {
+                  "text": " "
+                },
+                {
+                  "type": "code",
+                  "children": [
+                    {
+                      "text": "FieldMappingWidget"
+                    }
+                  ]
+                },
+                {
+                  "text": " "
+                },
+                {
+                  "type": "em",
+                  "children": [
+                    {
+                      "text": "displays"
+                    }
+                  ]
+                },
+                {
+                  "text": " "
+                },
+                {
+                  "type": "code",
+                  "children": [
+                    {
+                      "text": "{ ...smartDefaults, ...saved }"
+                    }
+                  ]
+                },
+                {
+                  "text": ", but only persists rows the editor actually changes. Accepting every proposed default without touching a row leaves "
+                },
+                {
+                  "type": "code",
+                  "children": [
+                    {
+                      "text": "fieldMapping"
+                    }
+                  ]
+                },
+                {
+                  "text": " empty — the sidebar shows one mapping while the page renders with another."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "p-41": {
+      "@type": "slate",
+      "plaintext": "If the item type's fields don't match the render-time fallback, set `fieldMapping` on the block rather than relying on the defaults shown in the sidebar.",
+      "value": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "If the item type's fields don't match the render-time fallback, set "
+            },
+            {
+              "type": "code",
+              "children": [
+                {
+                  "text": "fieldMapping"
+                }
+              ]
+            },
+            {
+              "text": " on the block rather than relying on the defaults shown in the sidebar."
+            }
+          ]
+        }
+      ]
+    },
+    "h-42": {
       "@type": "slate",
       "plaintext": "Combining Listings with Container Syncing",
       "value": [
@@ -2171,7 +2722,7 @@
         }
       ]
     },
-    "p-36": {
+    "p-43": {
       "@type": "slate",
       "plaintext": "A container (e.g. `gridBlock`) can mix **manual children** AND **a listing** as children. Add `'listing'` to the blocks field's `allowedBlocks`, and the parent's typeField propagates everywhere:",
       "value": [
@@ -2240,18 +2791,18 @@
         }
       ]
     },
-    "ce-37": {
+    "ce-44": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-37-javascript-2ec596",
+          "@id": "ce-44-javascript-82ad8e",
           "label": "Javascript",
           "language": "javascript",
           "code": "gridBlock: {\n    blockSchema: {\n        properties: {\n            slides: {\n                widget: 'blocks_layout',\n                itemTypeField: 'variation',\n                allowedBlocks: ['teaser', 'image', 'listing'],  // manual items + listing\n            },\n            variation: {\n                widget: 'blockTypeSelect',\n                filterConvertibleFrom: '@default',  // keeps 'listing' out of the dropdown\n            },\n        },\n    },\n    schemaEnhancer: { inheritSchemaFrom: {} },\n}"
         }
       ]
     },
-    "p-38": {
+    "p-45": {
       "@type": "slate",
       "plaintext": "`filterConvertibleFrom: '@default'` keeps `'listing'` out of the dropdown (it's a structural container, not an item type, so it has no `fieldMappings['@default']`) but it stays in `allowedBlocks` so a listing block can still exist as a structural child. The editor sees \"Teaser / Image / Summary\" in the picker; the listing is a structural choice they don't have to think about.",
       "value": [
@@ -2306,7 +2857,7 @@
         }
       ]
     },
-    "p-39": {
+    "p-46": {
       "@type": "slate",
       "plaintext": "When the editor changes `gridBlock.variation` to e.g. `'summary'`:",
       "value": [
@@ -2342,7 +2893,7 @@
         }
       ]
     },
-    "ul-40": {
+    "ul-47": {
       "@type": "slate",
       "plaintext": "Manual children (a teaser, an image) get their @type converted via the destination type's fieldMappings — teaser becomes summary. Listing child keeps @type: 'listing' but its own variation field is set to 'summary', so the listing now renders summary items.",
       "value": [
@@ -2440,7 +2991,7 @@
         }
       ]
     },
-    "p-41": {
+    "p-48": {
       "@type": "slate",
       "plaintext": "The sync walks recursively — if the listing held nested containers with their own typeFields, those would update too. Net effect: ONE picker on the parent controls the rendered type for every descendant, regardless of whether descendants are authored manually or expanded from a query.",
       "value": [
@@ -2454,7 +3005,7 @@
         }
       ]
     },
-    "h-42": {
+    "h-49": {
       "@type": "slate",
       "plaintext": "Path Transformation (pathToApiPath)",
       "value": [
@@ -2468,7 +3019,7 @@
         }
       ]
     },
-    "p-43": {
+    "p-50": {
       "@type": "slate",
       "plaintext": "If your frontend embeds state in the URL path (like pagination), you need to tell hydra.js how to transform the frontend path to the API/admin path. Otherwise, the admin will try to navigate to URLs that don't exist in the CMS.",
       "value": [
@@ -2482,18 +3033,18 @@
         }
       ]
     },
-    "ce-44": {
+    "ce-51": {
       "@type": "codeExample",
       "tabs": [
         {
-          "@id": "ce-44-javascript-82ad8e",
+          "@id": "ce-51-javascript-71a711",
           "label": "Javascript",
           "language": "javascript",
           "code": "const bridge = initBridge({\n    page: { ... },\n    // Transform frontend path to API path by stripping paging segments\n    // e.g., /test-page/@pg_block-8-grid_1 -> /test-page\n    pathToApiPath: (path) => path.replace(/\\/@pg_[^/]+_\\d+/, ''),\n});"
         }
       ]
     },
-    "p-45": {
+    "p-52": {
       "@type": "slate",
       "plaintext": "The `pathToApiPath` function is called whenever hydra.js sends a `PATH_CHANGE` message to the admin, allowing your frontend to strip or transform URL segments that are frontend-specific (like pagination, filters, or other client-side state).",
       "value": [
@@ -2529,7 +3080,7 @@
         }
       ]
     },
-    "h-46": {
+    "h-53": {
       "@type": "slate",
       "plaintext": "Paging Values",
       "value": [
@@ -2543,7 +3094,7 @@
         }
       ]
     },
-    "p-47": {
+    "p-54": {
       "@type": "slate",
       "plaintext": "Both `expandListingBlocks` and `staticBlocks` return `{ items, paging }`. You pass `{ start, size }` as input (not mutated) and get back computed paging values:",
       "value": [
@@ -2601,7 +3152,7 @@
         }
       ]
     },
-    "ul-48": {
+    "ul-55": {
       "@type": "slate",
       "plaintext": "currentPage (number) — Zero-based current page index totalPages (number) — Total number of pages totalItems (number) — Total item count across all blocks prev (number | null) — Previous page index, or null on first page next (number | null) — Next page index, or null on last page pages (array) — Window of ~5 page objects: { start, page } where page is 1-based seen (number) — Running item count — pass to the next call's seen option for position tracking in grids",
       "value": [
@@ -2746,7 +3297,7 @@
         }
       ]
     },
-    "p-49": {
+    "p-56": {
       "@type": "slate",
       "plaintext": "Neither function mutates the input `paging` object — calling again with the same `{ start, size }` is safe.",
       "value": [
@@ -2782,7 +3333,7 @@
         }
       ]
     },
-    "p-50": {
+    "p-57": {
       "@type": "slate",
       "plaintext": "When multiple listings share a pager (e.g. a grid with several listings), `expandListingBlocks` walks them sequentially. Each fetch returns `{ items, total }`, so the total is learned from the response and used to compute where the next listing starts. One request per listing. Listings outside the page window are fetched with `size: 0` (total only, no items).",
       "value": [
@@ -2829,7 +3380,7 @@
         }
       ]
     },
-    "p-51": {
+    "p-58": {
       "@type": "slate",
       "plaintext": "When mixing listings with static blocks in a shared pager, use `staticBlocks(ids, { blocks, paging, seen })` for the non-listing blocks — it tracks their position in the paging window. Chain the returned `paging.seen` to the next call so each block knows its offset (see the React example above).",
       "value": [
@@ -2865,7 +3416,7 @@
         }
       ]
     },
-    "h-52": {
+    "h-59": {
       "@type": "slate",
       "plaintext": "Notes",
       "value": [
@@ -2879,7 +3430,7 @@
         }
       ]
     },
-    "p-53": {
+    "p-60": {
       "@type": "slate",
       "plaintext": "Expanded listing items share the listing block's `@uid`. Selecting any expanded item selects the parent listing block.",
       "value": [
@@ -2941,10 +3492,10 @@
       "p-31",
       "ce-32",
       "p-33",
-      "p-34",
-      "h-35",
-      "p-36",
-      "ce-37",
+      "h-34",
+      "p-35",
+      "tbl-36",
+      "p-37",
       "p-38",
       "p-39",
       "ul-40",
@@ -2953,14 +3504,21 @@
       "p-43",
       "ce-44",
       "p-45",
-      "h-46",
-      "p-47",
-      "ul-48",
-      "p-49",
+      "p-46",
+      "ul-47",
+      "p-48",
+      "h-49",
       "p-50",
-      "p-51",
-      "h-52",
-      "p-53"
+      "ce-51",
+      "p-52",
+      "h-53",
+      "p-54",
+      "ul-55",
+      "p-56",
+      "p-57",
+      "p-58",
+      "h-59",
+      "p-60"
     ]
   }
 }

--- a/docs/listings.md
+++ b/docs/listings.md
@@ -195,9 +195,28 @@ listing: {
 }
 ```
 
-`filterConvertibleFrom: '@default'` restricts the dropdown to types that have a `fieldMappings['@default']` entry — i.e. types that can be populated from the canonical content fields (`@id`, `title`, `description`, `image`) that listing queries return. Each item type's `fieldMappings['@default']` (on its own block config) defines how those source fields land on its schema; that static mapping is enough to render listings. Adding `mappingField` to the enhancer exposes the `FieldMappingWidget` so the editor can override the mapping per listing instance.
+`filterConvertibleFrom: '@default'` restricts the dropdown to types that have a `fieldMappings['@default']` entry — i.e. types that can be populated from the canonical content fields (`@id`, `title`, `description`, `image`) that listing queries return. Each item type's `fieldMappings['@default']` (on its own block config) defines how those source fields land on its schema. Adding `mappingField` to the enhancer exposes the `FieldMappingWidget` so the editor can override the mapping per listing instance.
 
-The widget saves its output as `fieldMapping` (singular) on the block data. `expandListingBlocks` reads that at render time to translate each query result into an item block.
+### Where the mapping lives
+
+`fieldMappings` (plural, on a **block config**) and `fieldMapping` (singular, on **block data**) are different things, and only the singular one is read at render:
+
+| | `fieldMappings['@default']` | `fieldMapping` |
+|---|---|---|
+| Lives on | the item type's block config | the listing block's saved data |
+| Used by | `FieldMappingWidget`, while **editing** | `expandListingBlocks`, at **render** |
+| Role | seeds the widget's smart defaults for the chosen item type | the mapping actually applied to query results |
+
+The registry mapping is an *editing-time* input: it decides what the widget proposes for the selected `variation`. `expandListingBlocks` never reads a block config — it reads `block.fieldMapping`, and when that is absent falls back to its own default, `{ @id → href, title, description, image }`.
+
+That fallback targets `href`, which suits `link`-shaped item types and not others. A `card`, for example, renders its link from `url`, so a listing of cards with no saved `fieldMapping` produces cards with no link at all.
+
+Two ways to end up with no saved mapping:
+
+- **Hand-authored content.** A listing block written directly into a distribution or fixture JSON never passes through the widget, so nothing is saved. Author `fieldMapping` explicitly.
+- **An untouched widget.** `FieldMappingWidget` *displays* `{ ...smartDefaults, ...saved }`, but only persists rows the editor actually changes. Accepting every proposed default without touching a row leaves `fieldMapping` empty — the sidebar shows one mapping while the page renders with another.
+
+If the item type's fields don't match the render-time fallback, set `fieldMapping` on the block rather than relying on the defaults shown in the sidebar.
 
 ## Combining Listings with Container Syncing
 


### PR DESCRIPTION
listings.md said an item type's `fieldMappings['@default']` "is enough to render
listings". It isn't, on its own: `expandListingBlocks` never reads a block config.
It reads `block.fieldMapping` and otherwise falls back to its own
`{ @id -> href, ... }` default.

The registry mapping is an editing-time input — `FieldMappingWidget` feeds it to
computeSmartDefaults to propose a mapping for the chosen `variation`. What renders
is whatever ends up saved on the block.

Two ways a listing ends up with nothing saved, both of which then render through a
default that may not suit the item type:

- Hand-authored content (a distribution or fixture JSON) never passes through the
  widget.
- The widget displays `{ ...smartDefaults, ...saved }` but `handleChange` only
  persists rows the editor actually changes, so accepting every proposal without
  touching a row saves nothing. The sidebar then shows one mapping while the page
  renders with another.

Found the hard way: a grid of `card` items rendered every card with `href="#"`,
because the fallback maps `@id` to `href` while `card` renders its link from `url`.

Adds a "Where the mapping lives" section contrasting the two, and drops the
"enough to render listings" claim.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr