### PR TITLE
test-frontend: honour HYDRA_<NAME>_PORT; un-quarantine the placeholder height test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,7 @@ jobs:
   # ── Build Volto and upload artifact ──────────────────────────────────────
   build:
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,10 +102,30 @@ jobs:
           key: ${{ runner.os }}-playwright-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install --with-deps chromium firefox
       - name: Install Playwright deps only
+        # This step sat for 3h38m on one run. The log shows apt-get update stalling
+        # mid-fetch of the Ubuntu package indexes — silent after
+        # "Get:5 …noble-security InRelease", no output until the run was cancelled.
+        # A stalled fetch, not a dpkg lock or a prompt. Retry and time-limit the
+        # acquire so it fails fast, and bound the step as a backstop.
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install-deps chromium firefox
       - name: Start servers
         run: |
           node tests-playwright/fixtures/mock-api-server.cjs &
@@ -145,6 +166,7 @@ jobs:
   test-admin-mock:
     needs: build
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -189,10 +211,30 @@ jobs:
           key: ${{ runner.os }}-playwright-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install --with-deps chromium firefox
       - name: Install Playwright deps only
+        # This step sat for 3h38m on one run. The log shows apt-get update stalling
+        # mid-fetch of the Ubuntu package indexes — silent after
+        # "Get:5 …noble-security InRelease", no output until the run was cancelled.
+        # A stalled fetch, not a dpkg lock or a prompt. Retry and time-limit the
+        # acquire so it fails fast, and bound the step as a backstop.
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install-deps chromium firefox
       - name: Start servers
         run: |
           node tests-playwright/fixtures/mock-api-server.cjs &
@@ -228,6 +270,7 @@ jobs:
   # ── Nuxt bridge tests (no Volto needed) ─────────────────────────────────
   test-nuxt-bridge:
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -265,10 +308,30 @@ jobs:
           key: ${{ runner.os }}-playwright-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install --with-deps chromium firefox
       - name: Install Playwright deps only
+        # This step sat for 3h38m on one run. The log shows apt-get update stalling
+        # mid-fetch of the Ubuntu package indexes — silent after
+        # "Get:5 …noble-security InRelease", no output until the run was cancelled.
+        # A stalled fetch, not a dpkg lock or a prompt. Retry and time-limit the
+        # acquire so it fails fast, and bound the step as a backstop.
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install-deps chromium firefox
       - name: Start servers
         run: |
           node tests-playwright/fixtures/mock-api-server.cjs &
@@ -304,6 +367,7 @@ jobs:
   test-nuxt-admin:
     needs: build
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -350,10 +414,30 @@ jobs:
           key: ${{ runner.os }}-playwright-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install --with-deps chromium firefox
       - name: Install Playwright deps only
+        # This step sat for 3h38m on one run. The log shows apt-get update stalling
+        # mid-fetch of the Ubuntu package indexes — silent after
+        # "Get:5 …noble-security InRelease", no output until the run was cancelled.
+        # A stalled fetch, not a dpkg lock or a prompt. Retry and time-limit the
+        # acquire so it fails fast, and bound the step as a backstop.
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install-deps chromium firefox
       - name: Start servers
         run: |
           node tests-playwright/fixtures/mock-api-server.cjs &
@@ -390,6 +474,7 @@ jobs:
   # ── Next.js + F7 bridge tests (no Volto needed) ─────────────────────────
   test-nextjs-f7:
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -431,10 +516,30 @@ jobs:
           key: ${{ runner.os }}-playwright-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install --with-deps chromium firefox
       - name: Install Playwright deps only
+        # This step sat for 3h38m on one run. The log shows apt-get update stalling
+        # mid-fetch of the Ubuntu package indexes — silent after
+        # "Get:5 …noble-security InRelease", no output until the run was cancelled.
+        # A stalled fetch, not a dpkg lock or a prompt. Retry and time-limit the
+        # acquire so it fails fast, and bound the step as a backstop.
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium firefox
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-hydra-acquire >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          APTCONF
+          pnpm exec playwright install-deps chromium firefox
       - name: Start servers
         run: |
           node tests-playwright/fixtures/mock-api-server.cjs &

--- a/tests-playwright/fixtures/test-frontend/index.html
+++ b/tests-playwright/fixtures/test-frontend/index.html
@@ -179,8 +179,13 @@
             return criteria;
         }
 
-        // API origin — the mock Plone API always runs on port 8888
-        window._apiOrigin = 'http://localhost:8888';
+        // window._apiOrigin is injected by vite from HYDRA_MOCK_API_PORT (see
+        // vite.config.js). Never hardcode it here: the mock API moves whenever
+        // the ports are overridden, and a stale constant silently fetches
+        // whatever else happens to be on that port.
+        if (!window._apiOrigin) {
+            throw new Error('window._apiOrigin was not injected — check vite.config.js');
+        }
 
         // Make search criteria available globally for form handlers
         window._searchCriteria = {};

--- a/tests-playwright/fixtures/test-frontend/vite.config.js
+++ b/tests-playwright/fixtures/test-frontend/vite.config.js
@@ -1,13 +1,57 @@
 import { defineConfig } from 'vite';
 import path from 'path';
 
+// Ports come from the same HYDRA_<NAME>_PORT overrides as tests-playwright/ports.ts.
+// Resolving them HERE means every launcher inherits them — playwright's webServer,
+// `pnpm start:test-frontend`, and any parent project running this checkout — rather
+// than each having to remember a flag.
+//
+// The API origin is handed to index.html through `define` (its inline script is a
+// module, so vite substitutes there). The fixture used to hardcode
+// `window._apiOrigin = 'http://localhost:8888'` with a comment claiming the mock
+// API "always" runs on 8888. It doesn't: ports.ts made every port overridable,
+// and an override moved the server while the browser kept fetching 8888 —
+// ERR_CONNECTION_REFUSED on every test. A fixture should be told which API it is
+// talking to, not assert one.
+const envPort = (name, fallback) => {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid ${name}: ${raw} (must be a positive integer)`);
+  }
+  return n;
+};
+const TEST_FRONTEND_PORT = envPort('HYDRA_TEST_FRONTEND_PORT', 8889);
+const MOCK_API_ORIGIN = `http://localhost:${envPort('HYDRA_MOCK_API_PORT', 8888)}`;
+
 export default defineConfig({
   root: __dirname,
+  plugins: [
+    {
+      // Tell the fixture which API it is talking to. Injected as a tag rather
+      // than substituted into the page: `define` never reaches index.html's
+      // inline module (vite extracts it to an html-proxy first), and a
+      // transformIndexHtml string replace loses the same race in dev. An
+      // injected head script runs before the deferred module, so _apiOrigin is
+      // set by the time the fixture boots.
+      name: 'inject-mock-api-origin',
+      transformIndexHtml() {
+        return [
+          {
+            tag: 'script',
+            injectTo: 'head-prepend',
+            children: `window._apiOrigin = ${JSON.stringify(MOCK_API_ORIGIN)};`,
+          },
+        ];
+      },
+    },
+  ],
   server: {
-    port: 8889,
+    port: TEST_FRONTEND_PORT,
     strictPort: true,
     // Bind on all interfaces so tests can reach the same server via both
-    // http://localhost:8889 and http://127.0.0.1:8889 — different origins
+    // http://localhost:<port> and http://127.0.0.1:<port> — different origins
     // to the browser, used by the publicURL-flatten test to simulate
     // switching between two frontends without standing up a second Vite
     // process.

--- a/tests-playwright/integration/inline-editing-placeholders.spec.ts
+++ b/tests-playwright/integration/inline-editing-placeholders.spec.ts
@@ -199,22 +199,6 @@ test.describe('Inline Editing - Placeholders', () => {
     await expect(buttonField).toHaveAttribute('data-placeholder', 'Click to edit');
   });
 
-  test.describe('flake-quarantined on admin-nuxt — height across focus states', () => {
-    // Chronically flaky on admin-nuxt: this branch's CI history shows
-    // ~33% fail-rate on this specific test (5/15 recent runs failing all
-    // retries). Root cause is admin-nuxt's slower iframe round-trip:
-    // clicking back into the field after a blur triggers a selection-
-    // change FORM_DATA echo that drives an `onEditChange` Vue update of
-    // the Nuxt hero block, which can race with `keyboard.type('x')` —
-    // the typing lands on the OLD contenteditable just before Vue
-    // replaces it, so the typed 'x' is lost and `data-empty=""` stays
-    // set on the freshly-rendered (empty) div. Fix belongs in the bridge
-    // (capture-in-flight-typing during a swap) or in the Nuxt example
-    // component, not in PR #229 (Astro example). Bumped retries to 5
-    // until the underlying race is fixed separately.
-    // TODO(follow-up): track typing-during-swap race as its own issue.
-    test.describe.configure({ retries: process.env.CI ? 5 : 0 });
-
     test('field height stays constant across unfocused-empty, focused-empty, and one-line typed states', async ({ page }) => {
     // The whole point of switching the placeholder ::before to
     // `:focus::before { visibility: hidden }` (instead of display:none)
@@ -254,10 +238,17 @@ test.describe('Inline Editing - Placeholders', () => {
     expect(unfocusedEmptyBox).not.toBeNull();
     expect(unfocusedEmptyBox!.height).toBeGreaterThan(10);
 
-    // (b) Empty + focused. Click back into the field. data-empty stays
-    // set (we no longer toggle it on focus); :focus::before hides the
-    // placeholder TEXT via visibility:hidden but the layout space stays.
-    await editField.click();
+    // (b) Empty + focused. Re-enter through enterEditMode rather than a bare
+    // click: clicking back in triggers a selection-change FORM_DATA echo that
+    // re-renders the block, and enterEditMode is the path that waits for
+    // contenteditable + focus to settle afterwards ("polling instead of a
+    // single check to handle race conditions with FORM_DATA re-renders").
+    // Hand-rolling click-then-type here is what made this chronically flaky on
+    // admin-nuxt: the keystroke landed on the contenteditable that was about to
+    // be replaced. data-empty stays set (we no longer toggle it on focus);
+    // :focus::before hides the placeholder TEXT via visibility:hidden but the
+    // layout space stays.
+    const editor = await helper.enterEditMode(blockId);
     const focusedEmptyBox = await editField.boundingBox();
     expect(focusedEmptyBox).not.toBeNull();
     expect(focusedEmptyBox!.height).toBeGreaterThan(10);
@@ -267,14 +258,14 @@ test.describe('Inline Editing - Placeholders', () => {
     // (c) After the first keystroke. data-empty toggles off, ::before
     // disappears, content provides the height. Single-line typed text
     // sits at the same line-height as the placeholder did.
-    await page.keyboard.type('x');
+    await editor.pressSequentially('x', { delay: 10 });
+    await helper.waitForEditorText(editor, /x/);
     await expect(editField).not.toHaveAttribute('data-empty', '', { timeout: 3000 });
     const typedBox = await editField.boundingBox();
     expect(typedBox).not.toBeNull();
     expect(typedBox!.height).toBeGreaterThan(10);
     // Height must NOT jump from focused-empty to one-line typed.
     expect(Math.abs(typedBox!.height - focusedEmptyBox!.height)).toBeLessThan(2);
-    });
   });
 
 


### PR DESCRIPTION
ports.ts promises "an env-var override so parallel test runs, different CI shards,
or local dev environments with port conflicts can rebind without code changes".
The test frontend didn't honour it, in two places:

- vite.config.js hardcoded `port: 8889`, while playwright's webServer health URL
  used URLS.testFrontend. Override the port and playwright waits on the new port
  while vite still binds 8889 — startup times out after 30s.
- index.html hardcoded `window._apiOrigin = 'http://localhost:8888'`, with a
  comment stating the mock API "always runs on port 8888". Override the port and
  the server moves but the browser keeps fetching 8888 — every test fails with
  ERR_CONNECTION_REFUSED.

The hardcode predates the contract: it arrived in #199 (a text-editing fix, March)
and ports.ts landed in #224 (June), which parameterised the servers but never
reached the fixtures. Invisible while the defaults agree; the only way to see it
is to actually override.

Resolve both in vite.config.js, from the same env vars ports.ts reads, so every
launcher inherits them — playwright's webServer, `pnpm start:test-frontend`, and
any parent project driving this checkout — instead of each needing a flag.

The origin reaches the page as an injected head script, not `define` and not a
transformIndexHtml replace: vite extracts index.html's inline module to an
html-proxy before either applies, so both leave the token verbatim in the browser
(verified by curling the served proxy module). An injected head script runs before
the deferred module. index.html now throws if it is missing rather than falling
back to a port that may belong to another checkout.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr

---

**Second commit — un-quarantine `inline-editing-placeholders`**

The height-across-focus-states test was quarantined as "flake-quarantined on
admin-nuxt" with retries bumped to 5, attributed to a bridge race that loses
typing during a re-render.

The bridge already handles that: keydowns are buffered in eventBuffer and replayed
after the DOM settles (pendingBufferReplay / replayBufferAndUnblock). What this
test did differently from every other editing spec was bypass the helper that
engages with it — `editField.click()` then `page.keyboard.type('x')`, with nothing
waiting for the click's FORM_DATA echo to finish re-rendering. The keystroke landed
on the contenteditable that was about to be replaced.

enterEditMode is the standard path (:993, :1046, block-add-remove:886 all use it):
it waits for contenteditable=true and then polls for focus, "instead of a single
check to handle race conditions with FORM_DATA re-renders". Typing goes through the
locator and is confirmed with waitForEditorText, as elsewhere.

Drops the quarantine describe and the retries override — with the standard path
there is nothing to retry past.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr