### PR TITLE
Advanced search query type

### DIFF
--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -188,9 +188,15 @@ export function buildQuerystringSearchBody(
 
   // Merge extraCriteria into query
   if (extraCriteria.SearchableText) {
+    // queryType (plone6): "search" = Advanced (word/phrase) → the ZCTextIndex
+    // `string.search` operation; anything else = Standard substring
+    // (`string.contains`, the default). Only "search" switches it.
     query.push({
       i: 'SearchableText',
-      o: 'plone.app.querystring.operation.string.contains',
+      o:
+        extraCriteria.queryType === 'search'
+          ? 'plone.app.querystring.operation.string.search'
+          : 'plone.app.querystring.operation.string.contains',
       v: extraCriteria.SearchableText,
     });
   }

--- a/packages/helpers/index.test.js
+++ b/packages/helpers/index.test.js
@@ -60,6 +60,45 @@ describe('buildQuerystringSearchBody — core body', () => {
   });
 });
 
+describe('buildQuerystringSearchBody — queryType (Standard vs Advanced)', () => {
+  test('queryType "search" → string.search (Advanced)', () => {
+    const body = buildQuerystringSearchBody({}, {}, {
+      SearchableText: 'dog park',
+      queryType: 'search',
+    });
+    expect(criterion(body, 'SearchableText')).toEqual({
+      i: 'SearchableText',
+      o: 'plone.app.querystring.operation.string.search',
+      v: 'dog park',
+    });
+  });
+
+  test('queryType "contains" → string.contains (Standard)', () => {
+    const body = buildQuerystringSearchBody({}, {}, {
+      SearchableText: 'dog',
+      queryType: 'contains',
+    });
+    expect(criterion(body, 'SearchableText').o).toBe(
+      'plone.app.querystring.operation.string.contains',
+    );
+  });
+
+  test('no queryType defaults to string.contains', () => {
+    const body = buildQuerystringSearchBody({}, {}, { SearchableText: 'dog' });
+    expect(criterion(body, 'SearchableText').o).toBe(
+      'plone.app.querystring.operation.string.contains',
+    );
+  });
+
+  test('queryType is never emitted as its own query criterion', () => {
+    const body = buildQuerystringSearchBody({}, {}, {
+      SearchableText: 'dog',
+      queryType: 'search',
+    });
+    expect(criterion(body, 'queryType')).toBeUndefined();
+  });
+});
+
 describe('buildQuerystringSearchBody — discrete (value) facets', () => {
   test('facet.<field> array → selection.any with the array', () => {
     const body = buildQuerystringSearchBody({}, {}, {

--- a/tests-playwright/fixtures/mock-plone-api.cjs
+++ b/tests-playwright/fixtures/mock-plone-api.cjs
@@ -2252,10 +2252,17 @@ app.post('*/@querystring-search', (req, res) => {
         });
       }
       allItems = allItems.filter((item) => new URL(item['@id']).pathname !== contextPath);
-    } else if (index === 'SearchableText' && operation.includes('string.contains')) {
+    } else if (
+      index === 'SearchableText' &&
+      (operation.includes('string.contains') ||
+        operation.includes('string.search'))
+    ) {
       // Full-text search across title/description/id. Mirrors Plone 6.2's
       // plone.app.querystring 3.0.0 wildcard-prefix behavior — each word in
       // the search term must prefix-match a word token in one of those fields.
+      // Both `string.contains` (Standard) and `string.search` (Advanced,
+      // queryType=search) resolve to a SearchableText full-text match; the
+      // block's queryType picks the operation, and both filter here.
       if (value) {
         allItems = allItems.filter((item) => matchSearchableText(value, item));
       }


### PR DESCRIPTION
Add an option to the search query builder which allows setting the SearchableText to use "string.search" or "string.contains" depending on the use-case.

This PR also updates the mock-API to handle this case.