### PR TITLE
No blind waits: wait for the condition, or for a frame

### DIFF
--- a/tests-playwright/bridge/deferred-selection.spec.ts
+++ b/tests-playwright/bridge/deferred-selection.spec.ts
@@ -43,7 +43,23 @@ test.describe('Deferred SELECT_BLOCK', () => {
       });
 
     // The author's selection stands.
-    await page.waitForTimeout(500);
+    //
+    // Asserting that something did NOT happen has no positive signal to wait
+    // for, so wait for the browser to reach a frame instead of sleeping: the
+    // MutationObserver callback that would steal the selection is delivered as
+    // a microtask, so if it were going to fire it has fired by then.
+    await helper
+      .getIframe()
+      .locator('body')
+      .evaluate(
+        (node: HTMLElement) =>
+          new Promise<void>((resolve) => {
+            const win = node.ownerDocument.defaultView as Window;
+            win.requestAnimationFrame(() =>
+              win.requestAnimationFrame(() => resolve()),
+            );
+          }),
+      );
     expect(await selectedUid(helper)).toBe('mock-hero-block');
   });
 });

--- a/tests-playwright/helpers/AdminUIHelper.ts
+++ b/tests-playwright/helpers/AdminUIHelper.ts
@@ -4635,23 +4635,28 @@ export class AdminUIHelper {
   }
 
   /**
-   * Wait for block count to stabilize and return it.
-   * Use this when the page may still be rendering (e.g., Nuxt async components).
-   * Returns after getting the same count on consecutive checks.
+   * Wait for the block count to stop changing, and return it.
+   *
+   * QUIESCENCE, NOT A CONDITION — and that distinction is the whole caveat.
+   * "Same count twice" cannot tell FINISHED from HASN'T STARTED: sample before
+   * an add lands and 1,1 reads as settled, so the caller proceeds too early.
+   * Whenever the expected end state is known, don't call this — assert it:
+   * `await expect(blocks).toHaveCount(n)` waits for the thing you actually mean
+   * and says what went wrong when it doesn't happen. This is for the case where
+   * no target exists (a frontend still hydrating async components).
+   *
+   * Fails rather than guesses: on timeout it throws with the counts it saw.
+   * (It used to sleep 100ms per turn and, on timeout, RETURN the last count —
+   * so a never-settling page silently handed the caller a number.)
    *
    * @param timeout - Maximum time to wait in milliseconds (default 5000)
    * @returns The stable block count
    */
   async getStableBlockCount(timeout: number = 5000): Promise<number> {
-    const startTime = Date.now();
-    let lastCount = -1;
-    let stableChecks = 0;
-    const requiredStableChecks = 2;
-
-    // Caller often triggers a navigation (e.g. search form submit) then
-    // immediately polls. evaluateAll throws "Execution context was
-    // destroyed" if the iframe navigates mid-call. Treat that as
-    // "iframe is still settling" and keep polling instead of failing.
+    // A caller often triggers a navigation (e.g. a search form submit) and then
+    // polls immediately; evaluateAll throws "Execution context was destroyed"
+    // if the iframe navigates mid-call. Treat that as "still settling" rather
+    // than an error, and keep polling.
     const safeCount = async (): Promise<number> => {
       try {
         return await this.getBlockCount();
@@ -4662,24 +4667,37 @@ export class AdminUIHelper {
       }
     };
 
-    while (Date.now() - startTime < timeout) {
-      const currentCount = await safeCount();
+    const seen: number[] = [];
+    let lastCount = -1;
+    let stableChecks = 0;
 
-      if (currentCount !== -1 && currentCount === lastCount) {
-        stableChecks++;
-        if (stableChecks >= requiredStableChecks) {
-          return currentCount;
-        }
-      } else {
-        lastCount = currentCount;
-        stableChecks = 1;
-      }
+    // expect.poll owns the interval and the failure — no sleep of our own, and
+    // a page that never settles fails loudly instead of returning a number.
+    await expect
+      .poll(
+        async () => {
+          const currentCount = await safeCount();
+          seen.push(currentCount);
+          if (currentCount !== -1 && currentCount === lastCount) {
+            stableChecks += 1;
+          } else {
+            lastCount = currentCount;
+            stableChecks = 1;
+          }
+          return stableChecks;
+        },
+        {
+          timeout,
+          message:
+            `Block count never settled within ${timeout}ms — counts seen: ` +
+            `[${seen.join(', ')}] (-1 = iframe was navigating). The page kept ` +
+            `re-rendering; if you know the count you expect, assert it with ` +
+            `toHaveCount instead of waiting for quiescence.`,
+        },
+      )
+      .toBeGreaterThanOrEqual(2);
 
-      await this.page.waitForTimeout(100);
-    }
-
-    // Return the last count if timeout reached
-    return await safeCount();
+    return lastCount;
   }
 
   /**

--- a/tests-playwright/helpers/BlockVerificationHelper.ts
+++ b/tests-playwright/helpers/BlockVerificationHelper.ts
@@ -38,6 +38,26 @@ export interface SubBlock {
  * never opens. Fields belonging to NESTED blocks are skipped — they are that
  * block's contract, checked when it is the subject.
  */
+/**
+ * Let the browser reach its next frame in the iframe.
+ *
+ * The bridge answers a click synchronously in the click handler, and a
+ * MutationObserver callback is delivered as a microtask — so both have run by
+ * the time a frame is painted. Waiting for that boundary is CAUSAL: it waits
+ * for the work to be possible, not for a guessed number of milliseconds. Use it
+ * before asserting that something did NOT happen, where there is no positive
+ * signal to await.
+ */
+async function nextFrame(iframe: FrameLocator): Promise<void> {
+  await iframe.locator('body').evaluate(
+    (node) =>
+      new Promise<void>((resolve) => {
+        const win = node.ownerDocument.defaultView as Window;
+        win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve()));
+      }),
+  );
+}
+
 export async function checkDataEditTextClicks(
   page: Page,
   iframe: FrameLocator,
@@ -90,7 +110,9 @@ export async function checkDataEditTextClicks(
     );
 
     await el.click();
-    await page.waitForTimeout(300);
+    // The warning below is asserted ABSENT, so give the bridge its frame to
+    // raise one — see nextFrame. (Was a 300ms sleep.)
+    await nextFrame(iframe);
 
     const warning = iframe.locator('#hydra-dev-warning');
     await expect(

--- a/tests-playwright/integration/block-sync.spec.ts
+++ b/tests-playwright/integration/block-sync.spec.ts
@@ -499,18 +499,23 @@ test.describe('Block Sync - Search Block with Listing Container', () => {
     const searchInputAfter = iframe.locator('[data-block-uid="search-block-1"] input[name="SearchableText"]');
     await expect(searchInputAfter).toHaveValue('accordion', { timeout: 10000 });
 
-    // Check filtered results — the assertion below waits for the re-fetch,
-    // which is the condition we mean (a settled count would not prove the
-    // filter had been applied).
     const filteredResults = iframe.locator('[data-block-uid="search-block-1"] .search-results [data-block-uid]');
 
-    // Should have at least one result (accordion-test-page matches "accordion")
-    await expect(filteredResults.first()).toBeVisible({ timeout: 10000 });
-    const filteredCount = await filteredResults.count();
-    expect(filteredCount).toBeGreaterThan(0);
+    // Wait for the RESULT of the re-fetch — fewer rows than before — not for
+    // the DOM to go quiet. `first()` being visible is satisfied by the OLD rows
+    // still on screen, which is how this read a stale 6-of-6 and failed on the
+    // comparison below; polling the count retries until the new rows land and
+    // reports what it saw if they never do.
+    await expect
+      .poll(() => filteredResults.count(), {
+        timeout: 10000,
+        message:
+          `search for "accordion" never narrowed the results (started at ${initialCount})`,
+      })
+      .toBeLessThan(initialCount);
 
-    // Should have fewer results than initial (search filtered them)
-    expect(filteredCount).toBeLessThan(initialCount);
+    // …and it filtered rather than emptied: accordion-test-page matches.
+    expect(await filteredResults.count()).toBeGreaterThan(0);
   });
 
   test('search block filters results when user clicks facet checkbox', async ({ page }) => {

--- a/tests-playwright/integration/block-sync.spec.ts
+++ b/tests-playwright/integration/block-sync.spec.ts
@@ -93,10 +93,8 @@ test.describe('Block Sync - Listing Block Item Type', () => {
     const imageDefaultsFieldset = page.locator('#blockform-fieldset-inherited_fields');
     await expect(imageDefaultsFieldset).toBeVisible({ timeout: 5000 });
 
-    // Wait for Nuxt async re-rendering to settle after variation change
-    await helper.getStableBlockCount();
-
-    // Wait for teasers to disappear first (confirms variation change is taking effect)
+    // The variation change is confirmed by the teasers going away — assert
+    // that directly rather than waiting for the count to stop moving.
     await expect(teaserItems).toHaveCount(0, { timeout: 5000 });
 
     // Then wait for image blocks to appear
@@ -501,10 +499,9 @@ test.describe('Block Sync - Search Block with Listing Container', () => {
     const searchInputAfter = iframe.locator('[data-block-uid="search-block-1"] input[name="SearchableText"]');
     await expect(searchInputAfter).toHaveValue('accordion', { timeout: 10000 });
 
-    // Wait for block count to stabilize after reactive re-fetch
-    await helper.getStableBlockCount();
-
-    // Check filtered results
+    // Check filtered results — the assertion below waits for the re-fetch,
+    // which is the condition we mean (a settled count would not prove the
+    // filter had been applied).
     const filteredResults = iframe.locator('[data-block-uid="search-block-1"] .search-results [data-block-uid]');
 
     // Should have at least one result (accordion-test-page matches "accordion")

--- a/tests-playwright/integration/navigation.spec.ts
+++ b/tests-playwright/integration/navigation.spec.ts
@@ -359,10 +359,9 @@ test.describe('Navigation and URL Handling', () => {
     // Go to view mode (not edit)
     await page.goto(helper.contentUrl('/test-page'));
 
-    // Wait for all blocks to render (Nuxt async components)
-    await helper.getStableBlockCount();
-
-    // Wait for iframe content to load
+    // No quiescence wait here: the assertion below IS the condition (the
+    // paragraph is visible once the blocks have rendered), and it fails with a
+    // useful message if they never do.
     const iframe = helper.getIframe();
     await expect(iframe.locator('text=This is a test paragraph')).toBeVisible({ timeout: 10000 });
 


### PR DESCRIPTION
`page.waitForTimeout` is a guess that a race has resolved. Three of them, replaced by what each was actually waiting for.

- **`deferred-selection.spec`** — a 500 ms sleep before asserting the selection did *not* move. Asserting a negative has no positive signal to await, so it now waits for the browser to reach a frame: the MutationObserver callback that would steal the selection is a microtask, so by that boundary it has fired or never will. Still catches the bug it was written for.
- **`BlockVerificationHelper`** — a 300 ms sleep after clicking a field, before asserting the dev-warning overlay is *absent*. Same shape, same fix (`nextFrame`).
- **`getStableBlockCount`** — slept 100 ms per poll turn and, on timeout, **returned the last count**, so a page that never settled handed the caller a number and the test carried on. It now polls via `expect.poll` (which owns the interval) and fails with the counts it saw.

Its doc now says what it is: **quiescence, not a condition**. "Same count twice" cannot tell FINISHED from HASN'T STARTED — sample before an add lands and 1,1 reads as settled. Three of its call sites were followed immediately by the assertion they actually wanted (`toHaveCount(0)`, a visible result, a visible paragraph), so they now just assert it; the rest use it as a "don't click while the DOM churns" guard, which is what it's for.

Verified: `deferred-selection` still green; `inline-editing-basic` 24 passed / 1 failed, and that one passes 3/3 on its own (load-sensitive, unrelated).
