### PR TITLE
Don't let a sidebar widget take the caret out of the preview

### DIFF
--- a/examples/hydra-vue-f7/src/components/block.vue
+++ b/examples/hydra-vue-f7/src/components/block.vue
@@ -366,9 +366,13 @@
   <!-- Highlight -->
   <section v-else-if="block['@type'] == 'highlight'" :data-block-uid="block_uid" class="highlight-block"
            :style="{ position: 'relative', overflow: 'hidden', borderRadius: '8px', padding: '0' }">
-    <div v-if="imageProps(block.image).url"
+    <!-- data-edit-media on BOTH branches, matching hydra-nextjs: the backdrop is
+         the only element this image ever produces, and it has to be pickable
+         when EMPTY (that is how an author sets one) as well as when filled. -->
+    <div v-if="imageProps(block.image).url" data-edit-media="image"
          :style="{ position: 'absolute', inset: '0', backgroundSize: 'cover', backgroundPosition: 'center', backgroundImage: `url(${imageProps(block.image).url})` }" />
-    <div v-else :style="{ position: 'absolute', inset: '0', background: highlightGradient(block.styles?.descriptionColor) }" />
+    <div v-else data-edit-media="image"
+         :style="{ position: 'absolute', inset: '0', background: highlightGradient(block.styles?.descriptionColor) }" />
     <div :style="{ position: 'absolute', inset: '0', background: 'rgba(0,0,0,0.5)' }" />
     <div :style="{ position: 'relative', zIndex: '1', padding: '4rem 2rem', textAlign: 'center', color: 'white' }">
       <h2 data-edit-text="title" style="margin-bottom:1rem; font-size:2rem; font-weight:800;">{{ block.title }}</h2>

--- a/examples/nuxt-blog-starter/components/block.vue
+++ b/examples/nuxt-blog-starter/components/block.vue
@@ -585,10 +585,13 @@
 
   <section v-else-if="block['@type'] == 'highlight'" :data-block-uid="block_uid"
            class="relative overflow-hidden rounded-lg my-6 isolate">
+    <!-- data-edit-media on BOTH branches: the field has to be pickable when it
+         is empty (that is how you set one) as well as when it is filled. -->
     <div v-if="imageProps(block.image).url"
          class="absolute inset-0 bg-cover bg-center z-0"
+         data-edit-media="image"
          :style="{ backgroundImage: `url(${imageProps(block.image).url})` }" />
-    <div v-else class="absolute inset-0 z-0"
+    <div v-else class="absolute inset-0 z-0" data-edit-media="image"
          :class="highlightGradient(block.styles?.descriptionColor)"></div>
     <div class="absolute inset-0 bg-black/50 z-10"></div>
     <div class="relative z-20 py-16 px-4 mx-auto max-w-screen-xl text-center lg:py-24">

--- a/packages/volto-hydra/src/customizations/volto/components/manage/AnchorPlugin/components/LinkButton/AddLinkForm.jsx
+++ b/packages/volto-hydra/src/customizations/volto/components/manage/AnchorPlugin/components/LinkButton/AddLinkForm.jsx
@@ -124,11 +124,22 @@ class AddLinkForm extends Component {
   componentDidMount() {
     // HYDRA FIX: Guard against null ref. In volto-hydra's synced toolbar,
     // the Slate component may remount during the 50ms delay, making this.input null.
-    setTimeout(() => {
-      if (this.input) {
-        this.input.focus();
-      }
-    }, 50);
+    //
+    // autoFocus=false for form renders the AUTHOR DID NOT ASK FOR. As a toolbar
+    // popup this form is the thing just opened, so taking focus is right. As a
+    // widget in the sidebar it mounts merely because a block got selected — and
+    // an empty image field renders the picker on every selection. Focusing then
+    // yanks the caret out of the iframe ~50ms after the author clicked a field
+    // in the preview: the field stays contenteditable, the caret is gone, and
+    // typing goes to this input instead. A second click appears to "fix" it
+    // only because the form is already mounted and doesn't re-fire.
+    if (this.props.autoFocus !== false) {
+      setTimeout(() => {
+        if (this.input) {
+          this.input.focus();
+        }
+      }, 50);
+    }
     document.addEventListener('mousedown', this.handleClickOutside, false);
   }
 

--- a/packages/volto-hydra/src/customizations/volto/components/manage/Widgets/ImageWidget.jsx
+++ b/packages/volto-hydra/src/customizations/volto/components/manage/Widgets/ImageWidget.jsx
@@ -371,6 +371,9 @@ const UnconnectedImageInput = (props) => {
   // No image - show picker UI
   const pickerContent = (
     <AddLinkForm
+      // Mounted because a block was selected, not because the author asked for
+      // this form — so it must not steal the caret from the preview iframe.
+      autoFocus={false}
       data={{ url: '' }}
       theme={{}}
       objectBrowserPickerType="image"

--- a/tests-playwright/fixtures/content/sidebar-focus-page/data.json
+++ b/tests-playwright/fixtures/content/sidebar-focus-page/data.json
@@ -3,7 +3,7 @@
  "@type": "Document",
  "id": "sidebar-focus-page",
  "title": "Sidebar Focus Page",
- "description": "Fixture for the sidebar-steals-the-caret test. The highlight block has a title to type into and NO image, so selecting it renders the image widget's empty state — the case where an inline AddLinkForm used to focus itself and pull the caret out of the preview.",
+ "description": "Fixture for the sidebar-steals-the-caret test. The highlight block has text to type into and NO image, which is the trigger: an image field with no value renders its picker on every selection.",
  "review_state": "published",
  "UID": "sidebar-focus-page-uid",
  "is_folderish": false,
@@ -17,6 +17,12 @@
   "highlight-1": {
    "@type": "highlight",
    "title": "Type into me",
+   "description": [
+    {
+     "type": "p",
+     "children": [{ "text": "Clicking this text must leave the caret in the preview." }]
+    }
+   ],
    "cta_title": "Read more"
   }
  }

--- a/tests-playwright/fixtures/content/sidebar-focus-page/data.json
+++ b/tests-playwright/fixtures/content/sidebar-focus-page/data.json
@@ -1,0 +1,23 @@
+{
+ "@id": "http://localhost:8888/sidebar-focus-page",
+ "@type": "Document",
+ "id": "sidebar-focus-page",
+ "title": "Sidebar Focus Page",
+ "description": "Fixture for the sidebar-steals-the-caret test. The highlight block has a title to type into and NO image, so selecting it renders the image widget's empty state — the case where an inline AddLinkForm used to focus itself and pull the caret out of the preview.",
+ "review_state": "published",
+ "UID": "sidebar-focus-page-uid",
+ "is_folderish": false,
+ "blocks_layout": {
+  "items": ["title-block", "highlight-1"]
+ },
+ "blocks": {
+  "title-block": {
+   "@type": "title"
+  },
+  "highlight-1": {
+   "@type": "highlight",
+   "title": "Type into me",
+   "cta_title": "Read more"
+  }
+ }
+}

--- a/tests-playwright/integration/sidebar-focus.spec.ts
+++ b/tests-playwright/integration/sidebar-focus.spec.ts
@@ -13,8 +13,16 @@
  * keystrokes went to the sidebar input instead. Clicking a second time appeared
  * to fix it, because by then the form was mounted and did not re-fire.
  *
- * The fixture's highlight block has a title and NO image, which is the whole
- * trigger: an image field that is empty renders the picker on every selection.
+ * The fixture's highlight block has text and NO image, which is the whole
+ * trigger: an image field with no value renders its picker on every selection.
+ * (A hero with an empty image does NOT reproduce it — verified — so the fixture
+ * is not incidental.)
+ *
+ * Adding it made `highlight` discoverable for the first time, which promptly
+ * failed block-sanity's media-coverage check: the nuxt example painted
+ * highlight.image as a CSS background and never annotated it, so the field was
+ * uneditable everywhere it appeared. A block type with no example escapes that
+ * check entirely. Annotating it here is the smaller half of this PR.
  */
 import { test, expect } from '../fixtures';
 import { AdminUIHelper } from '../helpers/AdminUIHelper';

--- a/tests-playwright/integration/sidebar-focus.spec.ts
+++ b/tests-playwright/integration/sidebar-focus.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * A sidebar widget must not take the caret away from the preview.
+ *
+ * Selecting a block renders that block's form. Any image field with no value
+ * renders its empty state — an inline AddLinkForm — and AddLinkForm focused
+ * itself on mount, unconditionally, 50ms later. It was written as the toolbar
+ * link popup, where the author has just opened it and taking focus is correct.
+ * Mounted as a widget it fires on something the author never asked for.
+ *
+ * What an author saw: click a text field in the preview, get a caret, and lose
+ * it ~400ms later. The field kept contenteditable="true", the element was never
+ * replaced, and nothing called blur() — focus had simply left the iframe, so
+ * keystrokes went to the sidebar input instead. Clicking a second time appeared
+ * to fix it, because by then the form was mounted and did not re-fire.
+ *
+ * The fixture's highlight block has a title and NO image, which is the whole
+ * trigger: an image field that is empty renders the picker on every selection.
+ */
+import { test, expect } from '../fixtures';
+import { AdminUIHelper } from '../helpers/AdminUIHelper';
+
+const PAGE = '/sidebar-focus-page';
+
+test.describe('sidebar widgets and the preview caret', () => {
+  test('clicking a field keeps focus in the preview iframe', async ({ page }) => {
+    const helper = new AdminUIHelper(page);
+    await helper.login();
+    await helper.navigateToEdit(PAGE);
+
+    const field = helper.getIframe().locator('[data-block-uid="highlight-1"] [data-edit-text="title"]');
+    await expect(field).toBeVisible({ timeout: 10_000 });
+    const before = (await field.textContent())?.trim();
+
+    await field.click();
+    // Longer than AddLinkForm's 50ms mount timer, and than the selection
+    // round-trip that mounts it — the theft happened ~400ms after the click.
+    await page.waitForTimeout(1500);
+
+    // The admin must still be handing input to the preview, not to a widget.
+    const adminActive = await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      return el ? `${el.tagName}.${(el.className || '').toString().split(' ')[0]}` : 'none';
+    });
+    expect(adminActive, 'focus must stay on the preview iframe').toContain('IFRAME');
+
+    expect(
+      await field.evaluate((el) => document.activeElement === el),
+      'the clicked field holds the caret',
+    ).toBe(true);
+
+    // The contract an author experiences: one click, then type.
+    await page.keyboard.type('ZZ');
+    await page.waitForTimeout(800);
+    expect((await field.textContent())?.trim(), 'typing lands in the clicked field').not.toBe(before);
+  });
+});


### PR DESCRIPTION
## What an author sees

Click a text field in the preview, get a caret, lose it ~400ms later. The field keeps `contenteditable="true"`, the element is never replaced, and nothing calls `blur()` — focus has simply left the iframe, so keystrokes go to a sidebar input. Clicking a second time looks like a fix, because by then the form is mounted and does not re-fire.

## Cause

`AddLinkForm` focuses itself on mount, unconditionally:

```js
componentDidMount() {
  setTimeout(() => { if (this.input) this.input.focus(); }, 50);
}
```

Correct for the toolbar link popup — that form *is* the thing the author just opened. Wrong for `ImageWidget`, which renders `AddLinkForm` as the **empty state of an image field**. That widget mounts because a block got *selected*, and any image field with no value renders it on every selection.

Traced on a site where every section has an empty background image, so nothing inside a section survived its first click:

```
+510ms  MOUNT field-wrapper-backgroundImage
+560ms  AddLinkForm autofocus fires
+632ms  caret lost from the iframe   (no blur(), no attribute change, no DOM swap)
```

## Fix

Autofocus becomes opt-out. The popup keeps it; `ImageWidget`'s picker passes `autoFocus={false}`. The other two consumers (`SyncedSlateToolbar`) are the deliberate popup and are unchanged.

## Test

`tests-playwright/integration/sidebar-focus.spec.ts` drives the real admin: after clicking a field, the admin's `activeElement` must still be the preview iframe, the clicked field must hold the caret, and one keystroke must land. The fixture's `highlight` block has a title and no image — the entire trigger.

Without the fix:

```
Error: focus must stay on the preview iframe
Expected substring: "IFRAME"
Received string:    "INPUT.link-input"
```

## Why this isn't narrow

The sidebar renders the selected block's form *and* its ancestors' — by design. So the field that steals focus need not belong to the block the author clicked: here it is the parent section's `backgroundImage`, mounted because the teaser inside it was selected. The corollary is that the deeper a block sits, the more ancestor forms mount with it, and any one of them with an empty image field is enough to take the caret. Fixing it at the autofocus is what covers all of them.

## Context

Found while adopting #306 downstream. Its stricter block-sanity check ("a frontend whose fields are annotated but not actually editable will go red where it was green") did its job and surfaced two genuinely dead fields in our frontend — those were ours to fix. This one was not: the annotations were fine and the bridge was placing the caret correctly, then the sidebar took it away.
