### PR TITLE
Don't count an object_list's display label as a block type

### DIFF
--- a/packages/hydra-js/buildBlockPathMap.js
+++ b/packages/hydra-js/buildBlockPathMap.js
@@ -837,6 +837,12 @@ export function buildBlockPathMap(formData, blocksConfig, intl = {}) {
         region: fieldName, // The container field (region) — same concept as blocks fields
         blockType: itemBlockType, // Real type (from typeField) or virtual type (from parent:field)
         isObjectListItem: true,
+        // `parent:field` is a SIDEBAR DISPLAY name, not a block type: nothing
+        // registers it in blocksConfig and nothing renders it. Flag it so
+        // consumers that treat `blockType` as a real `@type` (coverage
+        // discovery) can tell the two apart — an untyped object_list item
+        // (a table row/cell) only ever gets this label.
+        ...(itemBlockType === virtualType && { isVirtualBlockType: true }),
         idField,
         ...(typeField && { typeField }), // Only set if typed object_list
         // A region-level `@type` RULE: a `when`-based fieldRule whose `set` is a

--- a/packages/hydra-js/virtualBlockType.test.js
+++ b/packages/hydra-js/virtualBlockType.test.js
@@ -1,0 +1,71 @@
+import { buildBlockPathMap } from './buildBlockPathMap.js';
+
+/**
+ * An UNTYPED object_list (a table's `rows`, whose items are uniform and carry no
+ * `@type`) gets a virtual `parent:field` label as its pathMap blockType. That
+ * label is a SIDEBAR DISPLAY name — no blocksConfig registers it and nothing
+ * renders it — so it must be marked, or a consumer that reads `blockType` as a
+ * real `@type` reports every table as an unregistered `table:rows` block.
+ *
+ * A TYPED object_list (a form's `subblocks`, typed by `field_type`) is the case
+ * the fallback exists for: those items have a real type and must NOT be marked.
+ */
+const blocksConfig = {
+  table: {
+    id: 'table',
+    schema: {
+      properties: {
+        rows: {
+          widget: 'object_list',
+          idField: '@id',
+          schema: { properties: { cells: { widget: 'object_list', idField: '@id' } } },
+        },
+      },
+    },
+  },
+  form: {
+    id: 'form',
+    schema: {
+      properties: {
+        subblocks: {
+          widget: 'object_list',
+          idField: 'field_id',
+          typeField: 'field_type',
+          allowedBlocks: ['text', 'select'],
+        },
+      },
+    },
+  },
+};
+
+const pathMapFor = (blocks) =>
+  buildBlockPathMap(
+    { blocks, blocks_layout: { items: Object.keys(blocks) } },
+    blocksConfig,
+  );
+
+test('an untyped object_list item is flagged as carrying a virtual block type', () => {
+  const map = pathMapFor({
+    'tbl-1': {
+      '@type': 'table',
+      rows: [{ '@id': 'row-1', cells: [{ '@id': 'cell-1' }] }],
+    },
+  });
+
+  expect(map['row-1'].blockType).toBe('table:rows');
+  expect(map['row-1'].isVirtualBlockType).toBe(true);
+  // Nested one level down the label is built from the parent's virtual type.
+  expect(map['cell-1'].isVirtualBlockType).toBe(true);
+});
+
+test('a typed object_list item keeps its real type and is not flagged', () => {
+  const map = pathMapFor({
+    'form-1': {
+      '@type': 'form',
+      subblocks: [{ field_id: 'fld-1', field_type: 'text' }],
+    },
+  });
+
+  expect(map['fld-1'].blockType).toBe('text');
+  expect(map['fld-1'].isVirtualBlockType).toBeUndefined();
+});

--- a/tests-playwright/helpers/discover-blocks.cjs
+++ b/tests-playwright/helpers/discover-blocks.cjs
@@ -1123,7 +1123,16 @@ async function discoverBlocks(apiUrl, maxPages = Infinity, blocksConfig = {}, fr
         // already resolved from the container's `typeField`. Without this a form
         // field (text / select / single_choice …) is skipped from coverage
         // instead of being credited as its own registered block type.
-        const blockType = blockData['@type'] || entry.blockType;
+        // A TYPED object_list item (a form's `subblocks`, keyed by `field_id`
+        // and typed by `field_type`) has no `@type`, so fall back to the type
+        // buildBlockPathMap resolved from the container's `typeField` —
+        // otherwise a form field (text / select / single_choice …) is skipped
+        // from coverage instead of being credited as its own block type.
+        // UNTYPED items (table rows/cells) only get a virtual `parent:field`
+        // display label, which no blocksConfig can ever register; counting one
+        // as a block type reports every table as an unregistered `table:rows`.
+        const blockType =
+          blockData['@type'] || (entry.isVirtualBlockType ? undefined : entry.blockType);
         // Resolved schema for this entry — may be inline (object_list schema)
         // or come from blocksConfig[blockType].
         const schemaRef = entry._schemaRef;


### PR DESCRIPTION
#307 made coverage discovery fall back to the pathMap's `blockType` when an
object_list item has no `@type`, so a form's typed `subblocks` (`field_id` /
`field_type`) are credited as their own types instead of being skipped.

An **untyped** object_list is a different animal. A table's `rows` items are
uniform and carry no type, so `buildBlockPathMap` gives them a virtual
`parent:field` label — by its own comment, "used when no typeField/allowedBlocks".
That is a sidebar DISPLAY name: no `blocksConfig` registers it and nothing
renders it. Discovery now reads it as a real `@type` and reports every table as
an unregistered block:

```
Block @type "table:rows" is used in content (6 occurrence(s), e.g. /dev/blocks/table)
but is not registered in the frontend's blocksConfig, so it renders as
"Not implemented Block".
```

`buildBlockPathMap` now sets `isVirtualBlockType` where it mints the label, and
discovery ignores flagged entries. Flagging at the source also covers a *typed*
list whose item is missing its type and falls back to the same label — testing
for a colon at the consumer would not.

## Testing

- `packages/hydra-js/virtualBlockType.test.js` covers both directions: an
  untyped item is flagged, a typed one keeps its real type and is not. It fails
  without the fix (`Expected: true, Received: undefined`).
- hydra unit suite: 236/236.
- Downstream (nsw-dds-nextjs) block sanity returns to its pre-#307 baseline —
  28 failures, all unrelated form-field work; the `table:rows` failure is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr
