### PR TITLE
Import helpers by path, so a checkout works without an install

### DIFF
--- a/packages/hydra-js/buildBlockPathMap.js
+++ b/packages/hydra-js/buildBlockPathMap.js
@@ -10,9 +10,16 @@
  * to use it via the same import path as before.
  */
 
-// @volto-hydra/helpers is pure (no @plone/volto), so importing from it keeps this module
-// free of Volto deps — unlike @volto-hydra/hydra-js, which is why PAGE_BLOCK_UID is inlined.
-import { getBlockType } from '@volto-hydra/helpers';
+// The helpers package is pure (no @plone/volto), so importing from it keeps this
+// module free of Volto deps — unlike @volto-hydra/hydra-js, which is why
+// PAGE_BLOCK_UID is inlined below.
+//
+// Imported by RELATIVE path, not as '@volto-hydra/helpers'. Consumers import
+// this file directly out of a checkout — pretagov-site's content gate runs it
+// as plain node, with no install — and a bare specifier needs node_modules to
+// resolve, so it failed there with ERR_MODULE_NOT_FOUND while passing anywhere
+// the workspace happened to be linked. A relative path needs nothing installed.
+import { getBlockType } from '../helpers/index.js';
 
 // Same value as PAGE_BLOCK_UID in hydra.js — defined locally to avoid
 // importing from @volto-hydra/hydra-js (which would pull in Volto deps).


### PR DESCRIPTION
`buildBlockPathMap.js` imported `@volto-hydra/helpers` by package name. Consumers that import this file directly out of a checkout and run it as plain node — pretagov-site's content gate, which has no install step — hit:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@volto-hydra/helpers'
imported from .../hydra/packages/hydra-js/buildBlockPathMap.js
```

It resolved anywhere the pnpm workspace happened to be linked, so it was green on developer machines and red only in CI.

A relative import needs nothing installed, and keeps the original intent of that import — staying clear of Volto deps, not asserting a package boundary.

**Verified** by removing `hydra/node_modules/@volto-hydra/helpers` and running the site's gate: exits 0 where it previously failed. hydra unit suite 264/264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195WXX3ED1mn6qTzib3GZGH