### PR TITLE
Make the sidebar helpers say what went wrong, and drive the widgets they claim to

### DIFF
--- a/tests-playwright/helpers/AdminUIHelper.ts
+++ b/tests-playwright/helpers/AdminUIHelper.ts
@@ -3321,7 +3321,11 @@ export class AdminUIHelper {
    * Set the value of a text field in the sidebar.
    * Matches Cypress pattern: #sidebar-properties #field-{fieldname}
    */
-  async setSidebarFieldValue(fieldName: string, value: string, options: { container?: string } = {}): Promise<void> {
+  async setSidebarFieldValue(
+    fieldName: string,
+    value: string | boolean,
+    options: { container?: string } = {},
+  ): Promise<void> {
     const container = options.container || '#sidebar-properties';
     const fieldWrapper = this.page.locator(`${container} .field-wrapper-${fieldName}`);
 
@@ -3335,6 +3339,92 @@ export class AdminUIHelper {
       .first()
       .waitFor({ state: 'visible', timeout: 5000 })
       .catch(() => {});
+
+    // A BOOLEAN field is a checkbox, which fill() cannot drive — it needs
+    // check/uncheck. Callers already pass booleans (the columns clip sets
+    // `gap`), and before this they fell through every branch below and returned
+    // silently, so the field simply never changed.
+    if (typeof value === 'boolean') {
+      const checkbox = fieldWrapper.locator('input[type="checkbox"]').first();
+      await checkbox.waitFor({ state: 'attached', timeout: 5000 });
+      // Click the LABEL, which is what a user clicks: Volto styles the checkbox
+      // by covering the real input, so check()/uncheck() report the input as
+      // visible and then time out because the label intercepts the pointer.
+      // Only click when the state actually needs to change — clicking a checkbox
+      // already in the wanted state would toggle it away.
+      if ((await checkbox.isChecked()) !== value) {
+        const label = fieldWrapper.locator('label').first();
+        if (await label.count()) {
+          await label.click();
+        } else {
+          await checkbox.click({ force: true });
+        }
+      }
+      await expect(checkbox).toBeChecked({ checked: value, timeout: 5000 });
+      return;
+    }
+
+    // A CHOICE field. Three shapes appear in this admin and none of them is a
+    // text input, so without this they fell through to the throw below (or,
+    // before that, to a silent return): a native <select>, a Volto/Semantic
+    // dropdown, and a react-select. Try them in that order.
+    const nativeSelect = fieldWrapper.locator('select').first();
+    if (await nativeSelect.count()) {
+      await nativeSelect.selectOption(value);
+      return;
+    }
+    const dropdown = fieldWrapper
+      .locator('.ui.dropdown, [class*="react-select"], [role="combobox"]')
+      .first();
+    if (await dropdown.count()) {
+      await dropdown.click();
+      // The menu portals out of the field wrapper, so look for the option on the
+      // page, matched on its visible text OR its value.
+      // Match on the option's VALUE first, then its visible text. Callers pass
+      // the stored value (a block id like `listItem`), while the menu shows a
+      // human label ("List item"), so a text-only match silently finds nothing
+      // and the field never changes.
+      const byValue = this.page
+        .locator(
+          `[role="option"][data-value="${value}"], .menu .item[data-value="${value}"]`,
+        )
+        .first();
+      const byText = this.page
+        .locator('[role="option"], .menu .item')
+        .filter({ hasText: new RegExp(`^\\s*${value}\\s*$`, 'i') })
+        .first();
+      const option = (await byValue.count()) ? byValue : byText;
+      if (await option.count()) {
+        await option.click();
+        // VERIFY: a dropdown that closes without applying the choice looks
+        // exactly like success from here, and the caller only finds out when an
+        // assertion about the rendered page fails much later. Name the options
+        // that were on offer so a wrong value is obvious.
+        const applied = await dropdown
+          .textContent()
+          .then((t) => (t || '').toLowerCase())
+          .catch(() => '');
+        if (applied && !applied.includes(String(value).toLowerCase())) {
+          const labels = await this.page
+            .locator('[role="option"], .menu .item')
+            .evaluateAll((els) =>
+              els.map((e) => `${e.getAttribute('data-value') ?? ''}=${(e.textContent || '').trim()}`),
+            );
+          if (labels.length) {
+            throw new Error(
+              `setSidebarFieldValue('${fieldName}'): clicked an option for ` +
+                `'${value}' but the control still reads '${applied.trim()}'. ` +
+                `Options offered: [${labels.join(', ')}]`,
+            );
+          }
+        }
+      } else {
+        // Keyboard-driven react-select: type to filter, then commit.
+        await this.page.keyboard.type(String(value), { delay: 20 });
+        await this.page.keyboard.press('Enter');
+      }
+      return;
+    }
 
     // Try text input
     const input = fieldWrapper.locator('input[type="text"], input[type="url"], textarea');

--- a/tests-playwright/helpers/AdminUIHelper.ts
+++ b/tests-playwright/helpers/AdminUIHelper.ts
@@ -1273,9 +1273,22 @@ export class AdminUIHelper {
 
   /**
    * Get the type of block currently being edited in the sidebar.
+   *
+   * Reads the block-editor's own type class FIRST (`block-editor-<type>`, which
+   * Volto renders for every block), so this answers for any type. The
+   * hand-listed slate/image checks below only ever covered those two, and
+   * returned null for everything else — indistinguishable from "the sidebar is
+   * showing nothing", which is the state a caller usually wants to rule out.
    */
   async getSidebarBlockType(): Promise<string | null> {
     const sidebar = this.page.locator('#sidebar-properties');
+
+    const typed = sidebar.locator('[class*="block-editor-"]').first();
+    if (await typed.isVisible().catch(() => false)) {
+      const cls = (await typed.getAttribute('class')) || '';
+      const match = cls.match(/block-editor-([\w-]+)/);
+      if (match) return match[1];
+    }
 
     // Check for common block type indicators
     const selectors = [
@@ -3312,6 +3325,17 @@ export class AdminUIHelper {
     const container = options.container || '#sidebar-properties';
     const fieldWrapper = this.page.locator(`${container} .field-wrapper-${fieldName}`);
 
+    // WAIT for the field, don't probe once. The sidebar form re-renders when the
+    // selection changes, so a caller that selects a block and immediately sets a
+    // field races that render — and the single isVisible() check below would
+    // answer "no" for a field that appears a moment later, then fall through to
+    // a silent return (now a throw). Waiting here is not a blind sleep: it is
+    // the app's own signal that the form for this block is up.
+    await fieldWrapper
+      .first()
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => {});
+
     // Try text input
     const input = fieldWrapper.locator('input[type="text"], input[type="url"], textarea');
     if (await input.isVisible()) {
@@ -3347,6 +3371,25 @@ export class AdminUIHelper {
       await contentEditable.blur(); // Trigger blur to commit the value
       return;
     }
+
+    // Nothing matched. Failing here rather than returning quietly: a silent
+    // no-op surfaces much later as "the block didn't render" or "the value
+    // didn't stick", and the real cause — a wrong field name, a sidebar that
+    // isn't showing this block, a widget shape this helper doesn't drive — is
+    // invisible by then. Name what IS on offer so the caller can see which.
+    const available = await this.page
+      .locator(`${container} [class*="field-wrapper-"]`)
+      .evaluateAll((els) =>
+        els
+          .map((e) => (e.className.match(/field-wrapper-([\w-]+)/) || [])[1])
+          .filter(Boolean),
+      );
+    throw new Error(
+      `setSidebarFieldValue('${fieldName}'): no input, textarea or contenteditable ` +
+        `found in ${container}. Fields present: [${available.join(', ') || 'none'}]. ` +
+        `If that list is empty the sidebar is not showing a block form at all ` +
+        `(open it, or select the block first).`,
+    );
   }
 
   /**


### PR DESCRIPTION
`setSidebarFieldValue` returned **quietly** when it found no widget to drive, and
`getSidebarBlockType` answered `null` for every type it didn't hand-list. Both
turn a wrong call into a mystery much later — I lost an afternoon to the first
one, chasing "this block type isn't registered" when the real answer was "the
sidebar wasn't showing that block's form at all".

## setSidebarFieldValue

- **Fails loudly.** If nothing matched, it throws naming the fields that ARE
  present — which distinguishes a wrong field name from a sidebar showing no
  block form (the list comes back empty).
- **Waits for the field.** The form re-renders when the selection changes, so a
  caller that selects a block and immediately sets a field raced that render and
  the single `isVisible()` probe answered "no".
- **Drives booleans.** Callers already pass them (the columns clip sets `gap`)
  and they fell through every branch. Clicks the LABEL, which is what a user
  clicks: Volto styles the checkbox by covering the real input, so
  `check()`/`uncheck()` see it as visible and then time out on the intercepting
  label. Only clicks when the state must change.
- **Drives choices.** Native `<select>`, Volto dropdown and react-select, matching
  an option by VALUE first and visible text second — callers pass the stored
  value (`listItem`) while the menu shows a label ("List item"). The click is
  then verified, since a dropdown that closes without applying looks exactly like
  success.

## getSidebarBlockType

Recognised slate and image; everything else answered `null`, indistinguishable
from "the sidebar is showing nothing" — the state callers most want to rule out.
It now reads the block-editor's own `block-editor-<type>` class first, so it
answers for any block.

## How this was found

Writing doc-video recorders that drive the real editor. Each failure above was a
silent no-op that surfaced as a wrong conclusion about the product rather than
about the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDwgYNLC3CarxqZJXfvAsr
